### PR TITLE
Release Syncular 0.7.0

### DIFF
--- a/apps/docs/src/content/syql.md
+++ b/apps/docs/src/content/syql.md
@@ -154,6 +154,25 @@ sync query messages(roomId, left, right) by messages.thread_id {
 
 There are no `@scope` or `@cover` directives.
 
+## Reading the server version
+
+Syncular owns a local `_sync_version` column for every synced row. Project it
+with an explicit alias when a mutation needs optimistic-concurrency evidence:
+
+```syql
+query getTodo(listId, todoId) {
+  select id, title, _sync_version as server_version
+  from todos
+  where todos.list_id = :listId and todos.id = :todoId;
+}
+```
+
+Typegen emits `serverVersion` as an exact, non-null integer. The physical
+column remains query-only: it is excluded from schema and mutation types and
+from `select *`, so applications cannot accidentally write engine-owned state.
+Use a positive observed value as the mutation `baseVersion`; omit it for a
+local row that has not yet received a server version.
+
 ## Sort and limit
 
 Dynamic sorting is a closed enum, not arbitrary runtime SQL:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,33 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.6.0** (`v0.6.0`). All artifacts use Apache-2.0, except
+current release is **0.7.0** (`v0.7.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.7.0 release notes
+
+0.7.0 completes the breaking SQL-first SYQL cutover that landed after the
+0.6.0 tag. Prototype `.syql` files must be migrated before upgrading: queries
+now contain SQL directly, ordinary predicates replace `@cover(...)`,
+`sync query` explicitly claims synchronization coverage, and result identity
+is inferred instead of declared with `identity by`.
+
+The release includes:
+
+- the finalized revision-1 SYQL grammar, compiler, formatter, LSP, docs,
+  examples, and cross-language emitters built around one checked QueryIR;
+- inferred scope dependencies, explicit `sync query` coverage, conservative
+  table-wide fallback, inferred identity, finite sort profiles, and bounded
+  limit controls;
+- an opt-in, explicitly aliased `_sync_version` named-query projection with an
+  exact, non-null integer type, allowing applications to pass the observed
+  server version into optimistic-concurrency mutations without raw SQL or
+  handwritten result types;
+- root-authoritative release versioning that materializes package and crate
+  versions only in disposable release checkouts and validates packed internal
+  dependency pins before publication;
+- docs/demo builds on normal `main` changes while production deployment remains
+  attached to the trusted release workflow.
 
 ## 0.6.0 release notes
 
@@ -99,12 +124,15 @@ bash bindings/tauri/check.sh
 Run the binding-specific checks when their toolchains are available:
 
 ```sh
-bun run --cwd bindings/react-native typecheck
-bun test bindings/react-native/test
+bash bindings/react-native/check.sh
 bash bindings/swift/check.sh
 bash bindings/kotlin/check.sh
 bash bindings/flutter/check.sh
 ```
+
+Run the React Native gate through its package script so Bun loads the binding's
+local `bunfig.toml` preload. Running its test paths from the repository root
+resolves React Native's Flow source before the off-device mock is installed.
 
 For the release performance contract, run the worker and real native bridge
 lanes with strict thresholds:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/typegen/README.md
+++ b/packages/typegen/README.md
@@ -448,6 +448,27 @@ boundary):
 | **plain column ref** (`title`, `t.title`, `title AS x`) | resolved to the IR column (decltype confirms) — exact IR type, incl. `json`/`blob_ref`/`crdt` | the IR column's `NOT NULL` | **exact** |
 | **computed expression** (`count(*)`, `done + 1`, `:p AS l`) | decltype is null → documented fallback: aggregate/arithmetic → number, else string | always nullable (an expression's nullability is not knowable from decltype) | **fallback** |
 
+Every local synced table also has the protocol-owned `_sync_version` column.
+Named queries may project it with an explicit public alias when an application
+needs the observed server version for optimistic concurrency:
+
+```syql
+query getTodo(listId, todoId) {
+  select id, title, _sync_version as server_version
+  from todos
+  where todos.list_id = :listId and todos.id = :todoId;
+}
+```
+
+The generated `serverVersion` field is an exact, non-null `integer`. The
+physical name is intentionally not a public result name: project it with an
+alias such as `server_version`. `_sync_version` is query-only, is excluded from
+schema and mutation types, and is not added by `select *`; this prevents client
+code from writing engine-owned concurrency state. Pass a positive observed
+value as a mutation `baseVersion`. Locally-created or still-unacknowledged rows
+can carry a non-positive sentinel and should omit the base version until the
+server assigns one.
+
 `bun:sqlite` exposes `columnNames`, `declaredTypes` (once executed once — we
 run the statement against the empty DB), and `paramsCount`. It does **not**
 expose column origin (table/column), param **names**, or `NOT NULL` flags — so

--- a/packages/typegen/src/query.ts
+++ b/packages/typegen/src/query.ts
@@ -87,6 +87,9 @@ const DECLTYPE_MAP: Readonly<Record<string, IrColumnType>> = {
   CRDT: 'crdt',
 };
 
+/** Local client protocol column; query-only and never part of schema IR. */
+const SYNC_VERSION_COLUMN = '_sync_version';
+
 /** A param type is one of the §2.4 types (the columns params compare to). */
 export type QueryParamType = IrColumnType;
 
@@ -813,6 +816,20 @@ function resolveSource(
   return null;
 }
 
+/** Resolve the one supported query-only protocol column. SQLite still proves
+ * qualifier/ambiguity against the synthesized local tables. */
+function isSyncVersionSource(
+  item: SelectItem,
+  refs: readonly TableRef[],
+): boolean {
+  const match = PLAIN_REF_RE.exec(item.expr);
+  if (match === null || match[2] !== SYNC_VERSION_COLUMN) return false;
+  const qualifier = match[1];
+  return qualifier === undefined
+    ? refs.length === 1
+    : refs.some((ref) => ref.alias === qualifier);
+}
+
 // -- param type inference -----------------------------------------------------
 //
 // Infer a param's type from `col <op> :name` or `col IN (:name, …)` where `col`
@@ -1162,6 +1179,10 @@ export function synthesizeDdl(ir: IrDocument): string {
       const pk = c.name === table.primaryKey ? ' PRIMARY KEY' : '';
       return `  ${c.name} ${SQL_TYPE[c.type]}${pk}${notNull}`;
     });
+    // The materialized local client table always carries this hidden protocol
+    // token. It is absent from IR mutation types but may be explicitly aliased
+    // by a named read query for optimistic concurrency.
+    cols.push(`  ${SYNC_VERSION_COLUMN} INTEGER NOT NULL DEFAULT -1`);
     lines.push(`CREATE TABLE ${table.name} (\n${cols.join(',\n')}\n);`);
     // Create the declared indexes too — harmless for prepare()/decltype, and
     // keeps the type-check DB's shape honest with what the client materializes.
@@ -1285,6 +1306,21 @@ export function analyzeStatement(
     const source = item !== undefined ? resolveSource(item, refs, ir) : null;
     const sqlName = sqlNames[index] ?? colName;
     const langName = langNames[index] ?? colName;
+    if (item !== undefined && isSyncVersionSource(item, refs)) {
+      if (sqlName === SYNC_VERSION_COLUMN) {
+        throw new TypegenError(
+          file,
+          `${SYNC_VERSION_COLUMN} is stripped from app-facing query rows unless explicitly aliased (for example \`${SYNC_VERSION_COLUMN} AS server_version\`)`,
+        );
+      }
+      return {
+        name: sqlName,
+        langName,
+        type: 'integer',
+        nullable: false,
+        fidelity: 'exact',
+      };
+    }
     if (source !== null) {
       // Exact: IR column type + IR nullability. (decltype agrees; we prefer
       // the IR type so blob_ref/crdt/json semantic types survive.)

--- a/packages/typegen/test/query-errors.test.ts
+++ b/packages/typegen/test/query-errors.test.ts
@@ -243,6 +243,42 @@ describe('column fidelity', () => {
     const q = analyze('q.sql', 'SELECT done FROM todos');
     expect(q.columns[0]).toMatchObject({ type: 'boolean', fidelity: 'exact' });
   });
+  test('an explicitly aliased local server version is exact and non-null', () => {
+    const q = analyze(
+      'q.sql',
+      'SELECT id, _sync_version AS server_version FROM todos',
+    );
+    expect(q.columns[1]).toMatchObject({
+      name: 'server_version',
+      langName: 'serverVersion',
+      type: 'integer',
+      nullable: false,
+      fidelity: 'exact',
+    });
+    expect(q.sql).toContain('_sync_version AS serverVersion');
+  });
+  test('requires a public alias for the hidden physical name', () => {
+    expect(() =>
+      analyze('q.sql', 'SELECT id, _sync_version FROM todos'),
+    ).toThrow(/explicitly aliased/);
+  });
+  test('the hidden version remains absent from star projections', () => {
+    const q = analyze('q.sql', 'SELECT * FROM todos');
+    expect(q.columns.some((column) => column.name === '_sync_version')).toBe(
+      false,
+    );
+  });
+  test('the synthetic query database defaults direct fixture rows to optimistic', () => {
+    const sqlite = new Database(':memory:');
+    sqlite.run(synthesizeDdl(IR));
+    sqlite.run(
+      "INSERT INTO todos (id, list_id, title, done) VALUES ('t1', 'l1', 'Todo', 0)",
+    );
+    expect(
+      sqlite.query('SELECT _sync_version AS version FROM todos').get(),
+    ).toEqual({ version: -1 });
+    sqlite.close();
+  });
 });
 
 const analyzeFile = (file: string, sql: string) =>

--- a/packages/typegen/test/syql-validator.test.ts
+++ b/packages/typegen/test/syql-validator.test.ts
@@ -459,6 +459,19 @@ describe('SYQL schema/SQL validation', () => {
     expect(noPrimary?.identity).toBeUndefined();
   });
 
+  test('types an explicitly aliased local server version for concurrency', () => {
+    const query = validate(
+      'query q() { select id, _sync_version as server_version from todos; }',
+    ).queries[0];
+    expect(query?.analysis.columns[1]).toMatchObject({
+      name: 'server_version',
+      langName: 'serverVersion',
+      type: 'integer',
+      nullable: false,
+      fidelity: 'exact',
+    });
+  });
+
   test('wraps SQLite reference failures in stable SYQL diagnostics', () => {
     const error = frontendError(() =>
       validate('query q() {  select missing from todos ; }'),


### PR DESCRIPTION
## Summary

- finalize the post-0.6 SQL-first SYQL release boundary
- add exact typed named-query access to an explicitly aliased `_sync_version`
- document optimistic-concurrency usage and the root-authoritative release process
- correct the React Native release gate invocation

## Verification

- `bun run check` (1,085 pass, 7 environment-gated skips; isolated multi-tab 8 pass)
- package, docs, and demo builds
- Rust fmt, Clippy, workspace tests
- Tauri binding feature matrix and real native bridge
- React Native binding: 16 pass plus typecheck
- Swift binding: 10 pass plus example build
- strict worker/native performance lane: 14 pass
- Kotlin/Flutter generated outputs fresh; executable toolchain gates delegated to CI