### PR TITLE
feat: add durable commit outcomes

### DIFF
--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -93,11 +93,17 @@ const WORKLOAD = {
  * - `propagationP95CeilingMs` 20 ms: local in-process p95 is 0.2 ms. A
  *   100× allowance absorbs runner noise; breaching 20 ms in-process means
  *   a sleep/poll crept into the sync/realtime loop.
- * - `ownJsRawCeilingBytes` 88 KB: syncular's own JS (core + codec) is
- *   83.0 KB raw today. Bundle bytes are deterministic — no runner noise —
+ * - `ownJsRawCeilingBytes` 95 KB: syncular's own JS (core + codec) is
+ *   89.4 KB raw today. Bundle bytes are deterministic — no runner noise —
  *   so this stays tight (~6% headroom: enough that a one-KB innocent
  *   change doesn't trip, small enough to catch real bloat). RAISED from
- *   82 KB
+ *   88 KB
+ *   (2026-07-15, SPEC §7.2.1): durable final commit outcomes added 6,542
+ *   raw bytes (85,010 → 91,552) for the atomic local journal, exact
+ *   conflict/rejection evidence, restart restoration, protected retention,
+ *   and explicit one-way resolution. 95 KB restores the standing ~6%
+ *   headroom over the shipped feature; the total-gzip payload gate remains
+ *   unchanged. RAISED from 82 KB
  *   (2026-07-14, RFC 0003): revisioned reactive views added 5,677 raw
  *   bytes / 1,853 gzip bytes (79,333 → 85,010 raw) for the durable local
  *   revision, exact change batches, atomic query/status snapshots, and
@@ -137,7 +143,7 @@ const BUDGETS = {
   bootstrapRowsPerSecFloor: 90_000,
   imageBootstrapRowsPerSecFloor: 300_000,
   propagationP95CeilingMs: 20,
-  ownJsRawCeilingBytes: 88 * 1024,
+  ownJsRawCeilingBytes: 95 * 1024,
   totalGzipCeilingBytes: 600 * 1024,
 } as const;
 

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -82,6 +82,10 @@ shims marshal only strings. Lifecycle: `client.pause()` (stop the native event
 pump + disconnect realtime — call from `AppState` `'background'`) and
 `client.resume()`; `client.close()` releases the native core.
 
+Final commit outcomes use the same native SQLite journal as Tauri. Call
+`commitOutcome`, `commitOutcomes`, and `resolveCommitOutcome`; active
+conflicts/rejections and their losing operations survive app restarts.
+
 ## Verification bar
 
 `./check.sh` runs the automated gate:

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -26,6 +26,8 @@
 import type {
   ClientChangeBatch,
   ClientChangeListener,
+  CommitOutcome,
+  CommitOutcomeQuery,
   ConflictRecord,
   InvalidationEvent,
   InvalidationListener,
@@ -35,6 +37,7 @@ import type {
   QueryReadSpec,
   QuerySnapshot,
   RejectionRecord,
+  ResolveCommitOutcomeInput,
   SchemaFloor,
   SqlRow,
   SqlValue,
@@ -606,6 +609,33 @@ export class NativeSyncClient {
     return result.rejections;
   }
 
+  async commitOutcome(
+    clientCommitId: string,
+  ): Promise<CommitOutcome | undefined> {
+    const result = (await this.#command('commitOutcome', {
+      clientCommitId,
+    })) as { outcome?: CommitOutcome };
+    return result.outcome;
+  }
+
+  async commitOutcomes(
+    query: CommitOutcomeQuery = {},
+  ): Promise<readonly CommitOutcome[]> {
+    const result = (await this.#command('commitOutcomes', { query })) as {
+      outcomes: CommitOutcome[];
+    };
+    return result.outcomes;
+  }
+
+  async resolveCommitOutcome(
+    input: ResolveCommitOutcomeInput,
+  ): Promise<CommitOutcome> {
+    const result = (await this.#command('resolveCommitOutcome', {
+      input,
+    })) as { outcome: CommitOutcome };
+    return result.outcome;
+  }
+
   async schemaFloor(): Promise<SchemaFloor | undefined> {
     const result = (await this.#command('schemaFloor', {})) as {
       floor?: SchemaFloor;
@@ -771,6 +801,7 @@ function decodeChangeBatch(value: unknown): ClientChangeBatch | undefined {
       : {}),
     conflictsChanged: raw.conflictsChanged === true,
     rejectionsChanged: raw.rejectionsChanged === true,
+    outcomesChanged: raw.outcomesChanged === true,
   };
 }
 

--- a/bindings/react-native/test/bridge.test.ts
+++ b/bindings/react-native/test/bridge.test.ts
@@ -110,6 +110,31 @@ function defaultResponder(
       return OK({ conflicts: [] });
     case 'rejections':
       return OK({ rejections: [] });
+    case 'commitOutcome':
+      return OK({
+        outcome: {
+          sequence: 1,
+          clientCommitId: 'commit-1',
+          status: 'applied',
+          recordedAtMs: 1,
+          results: [{ status: 'applied', opIndex: 0 }],
+          resolution: 'active',
+        },
+      });
+    case 'commitOutcomes':
+      return OK({ outcomes: [] });
+    case 'resolveCommitOutcome':
+      return OK({
+        outcome: {
+          sequence: 1,
+          clientCommitId: 'commit-1',
+          status: 'applied',
+          recordedAtMs: 1,
+          results: [{ status: 'applied', opIndex: 0 }],
+          resolution: 'dismissed',
+          resolvedAtMs: 2,
+        },
+      });
     case 'schemaFloor':
       return OK({ floor: undefined });
     case 'leaseState':
@@ -346,6 +371,16 @@ describe('SyncClientLike parity', () => {
     expect((await normalized.statusSnapshot()).outbox).toBe(1);
     expect(await normalized.conflicts()).toEqual([]);
     expect(await normalized.rejections()).toEqual([]);
+    expect(await normalized.commitOutcome('commit-1')).toMatchObject({
+      status: 'applied',
+    });
+    expect(await normalized.commitOutcomes()).toEqual([]);
+    expect(
+      await normalized.resolveCommitOutcome({
+        clientCommitId: 'commit-1',
+        resolution: 'dismissed',
+      }),
+    ).toMatchObject({ resolution: 'dismissed' });
     expect(await normalized.schemaFloor()).toBeUndefined();
     expect(await normalized.leaseState()).toBeUndefined();
     expect(await normalized.upgrading()).toBe(false);

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,30 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.7.0** (`v0.7.0`). All artifacts use Apache-2.0, except
+current release is **0.8.0** (`v0.8.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.8.0 release notes
+
+0.8.0 makes final client commit outcomes durable. Applications no longer need
+to infer whether a missing outbox item applied or failed, or mirror conflict
+state into preferences to survive a restart.
+
+The release includes:
+
+- an atomic local final-outcome journal: the outcome insert and outbox drain
+  share one SQLite transaction in both TypeScript and Rust clients;
+- `applied`, `cached`, `conflict`, and `rejected` history with per-operation
+  results, stable error metadata, and the losing operation plus current server
+  row/version for conflict recovery;
+- restart restoration of active failures, explicit one-way resolution states,
+  and replacement-commit linkage for keep-local/custom-merge workflows;
+- configurable retention which never silently purges unresolved failures;
+- direct, worker/follower, React, Tauri, and React Native API/event parity,
+  including the reactive `useCommitOutcomes()` hook;
+- cross-host tests covering restart survival, worker RPC, React invalidation,
+  native persistence, Tauri/React Native bridges, and the complete Rust
+  conformance catalog.
 
 ## 0.7.0 release notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2654,6 +2654,40 @@ codegen wiring this rung.
   client gets its own changes back in the pull half, converging in one
   round-trip.
 
+#### 7.2.1 Durable final-outcome journal
+
+A client which exposes conflict or rejection recovery MUST persist every
+final commit result in protected local bookkeeping. The journal write and the
+removal of that commit from the durable outbox occur in the **same local SQLite
+transaction**. A process crash therefore cannot leave an absent outbox item
+without durable evidence explaining whether it was `applied`, `cached`,
+`conflict`, or `rejected`. The retryable `sync.idempotency_cache_miss` serving
+failure is not final and creates no journal entry.
+
+Each journal entry contains the `clientCommitId`, local recording time,
+newest-first local sequence, final status, and every operation result. A
+conflict retains its stable code and message, `serverVersion`, decoded
+`serverRow`, and the losing schema-agnostic local operation. An error retains
+its stable code, message, retryability, and local operation. The same rule
+applies to client-local terminal drops such as `sync.outbox_incompatible` and
+an outbox commit proven to be inside a revoked effective scope.
+
+The client exposes `commitOutcome(clientCommitId)` and
+`commitOutcomes({ limit?, activeOnly? })`. Active conflict/rejection entries
+are restored into the conflict surfaces on restart. Resolution is explicit,
+durable, and one-way:
+
+- a conflict becomes `resolved_keep_server` or `superseded`;
+- a rejection becomes `superseded`;
+- an applied/cached history entry may become `dismissed`;
+- `superseded` requires a distinct `replacementClientCommitId`.
+
+Resolved evidence is retained until ordinary journal retention removes it.
+Retention prunes old applied/cached or resolved entries first and MUST NEVER
+silently delete an active conflict or rejection; active failures may therefore
+temporarily exceed the configured cap. The default cap is 1,000 entries and
+clients expose it as `outcomeRetentionMaxEntries`.
+
 ### 7.3 Auth leases
 
 An **auth lease** is a server-issued, time-bounded grant recording the
@@ -2997,7 +3031,7 @@ in durable bookkeeping state. It starts at zero and increases exactly once in
 the same SQLite transaction as each committed observer-visible change. Such a
 change includes materialized or optimistic rows, subscription/window
 registration or completeness, deferred eviction, outbox/status state exposed
-by the client, conflicts/rejections, auth-lease or schema-floor state, and
+by the client, conflicts/rejections/outcome-resolution state, auth-lease or schema-floor state, and
 schema-reset/upgrading state. A transaction which rolls back consumes no
 revision and emits no change. The revision survives restart and schema reset;
 it is destroyed only with the client database. JavaScript APIs expose it as
@@ -3020,7 +3054,9 @@ one batch carrying its revision and the domains changed by that transaction:
   table; an omitted scope-key set means honestly table-wide;
 - window changes identify canonical base, table, and changed unit(s);
 - status carries the complete post-commit client status when status changed;
-- conflict/rejection flags identify their collection domains.
+- conflict/rejection flags identify their collection domains;
+- `outcomesChanged` identifies durable journal insertion, resolution, or
+  retention changes.
 
 An empty scope-key set never means global. Scope-changing row updates record
 the union of the row's before and after scope keys; deletes record before keys
@@ -3650,7 +3686,9 @@ for `blob.not_found`, as a push operation-result `error` record.
 ### 10.3 Reserved and out-of-scope codes
 
 Outside the wire catalog: all client-local codes
-(`sync.offline`, `sync.transport_failed`, `sync.outbox_incompatible`
+(`sync.offline`, `sync.transport_failed`, `sync.outcome_not_found`
+[§7.2.1 — an explicit resolution named no retained journal entry],
+`sync.outbox_incompatible`
 [§7.4.4 — a pending commit cannot re-encode under the new schema after a
 bump], `client.decrypt_failed` [§5.11 — an encrypted column failed to
 decrypt on apply: unknown envelope version, unknown `keyId`, GCM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/conformance/src/driver.ts
+++ b/packages/conformance/src/driver.ts
@@ -605,6 +605,7 @@ export interface DriverChangeBatch {
   };
   readonly conflictsChanged: boolean;
   readonly rejectionsChanged: boolean;
+  readonly outcomesChanged: boolean;
 }
 
 export type DriverSyncIntent =

--- a/packages/conformance/src/drivers/ts-client.ts
+++ b/packages/conformance/src/drivers/ts-client.ts
@@ -419,6 +419,7 @@ class TsClientInstance implements ClientInstance {
         : {}),
       conflictsChanged: batch.conflictsChanged,
       rejectionsChanged: batch.rejectionsChanged,
+      outcomesChanged: batch.outcomesChanged,
     }));
   }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -164,6 +164,9 @@ not need a custom retention effect.
   means an inbound pull/catch-up signal.
 - `useConflicts()` observes conflicts and rejections only when that domain
   changes.
+- `useCommitOutcomes()` observes the durable newest-first final-outcome journal
+  from exact `outcomesChanged` batches. Resolve entries through
+  `useSyncClient().resolveCommitOutcome(...)`.
 - `usePresence(scopeKey)` observes ephemeral realtime peers.
 - `useSyncClient()` and `useReactiveStore()` expose the normalized low-level
   surfaces for integrations.

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -13,6 +13,8 @@
  */
 import type {
   ClientChangeListener,
+  CommitOutcome,
+  CommitOutcomeQuery,
   ConflictRecord,
   InvalidationListener,
   LeaseState,
@@ -21,6 +23,7 @@ import type {
   QueryReadSpec,
   QuerySnapshot,
   RejectionRecord,
+  ResolveCommitOutcomeInput,
   SchemaFloor,
   SqlRow,
   SqlValue,
@@ -60,6 +63,15 @@ export interface SyncClientLike {
   rejections:
     | readonly RejectionRecord[]
     | (() => readonly RejectionRecord[] | Promise<readonly RejectionRecord[]>);
+  commitOutcome(
+    clientCommitId: string,
+  ): CommitOutcome | undefined | Promise<CommitOutcome | undefined>;
+  commitOutcomes(
+    query?: CommitOutcomeQuery,
+  ): readonly CommitOutcome[] | Promise<readonly CommitOutcome[]>;
+  resolveCommitOutcome(
+    input: ResolveCommitOutcomeInput,
+  ): CommitOutcome | Promise<CommitOutcome>;
   schemaFloor:
     | SchemaFloor
     | undefined
@@ -118,6 +130,11 @@ export interface NormalizedClient {
   statusSnapshot(): Promise<SyncStatusSnapshot>;
   conflicts(): Promise<readonly ConflictRecord[]>;
   rejections(): Promise<readonly RejectionRecord[]>;
+  commitOutcome(clientCommitId: string): Promise<CommitOutcome | undefined>;
+  commitOutcomes(query?: CommitOutcomeQuery): Promise<readonly CommitOutcome[]>;
+  resolveCommitOutcome(
+    input: ResolveCommitOutcomeInput,
+  ): Promise<CommitOutcome>;
   schemaFloor(): Promise<SchemaFloor | undefined>;
   leaseState(): Promise<LeaseState | undefined>;
   upgrading(): Promise<boolean>;
@@ -145,6 +162,11 @@ export function normalizeClient(client: SyncClientLike): NormalizedClient {
     statusSnapshot: () => Promise.resolve(client.statusSnapshot()),
     conflicts: () => resolveMember(client, 'conflicts'),
     rejections: () => resolveMember(client, 'rejections'),
+    commitOutcome: (clientCommitId) =>
+      Promise.resolve(client.commitOutcome(clientCommitId)),
+    commitOutcomes: (query) => Promise.resolve(client.commitOutcomes(query)),
+    resolveCommitOutcome: (input) =>
+      Promise.resolve(client.resolveCommitOutcome(input)),
     schemaFloor: () => resolveMember(client, 'schemaFloor'),
     leaseState: () => resolveMember(client, 'leaseState'),
     upgrading: () => resolveMember(client, 'upgrading'),

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -29,6 +29,10 @@ export {
   type SyncClientResourceSnapshot,
 } from './resource';
 export { useReactiveStore, useSyncClient } from './use-client';
+export {
+  type UseCommitOutcomesResult,
+  useCommitOutcomes,
+} from './use-commit-outcomes';
 export { type UseConflictsResult, useConflicts } from './use-conflicts';
 export {
   type SyncTableDescriptor,

--- a/packages/react/src/use-commit-outcomes.ts
+++ b/packages/react/src/use-commit-outcomes.ts
@@ -1,0 +1,30 @@
+import type { CommitOutcome } from '@syncular/client';
+import { useCallback, useSyncExternalStore } from 'react';
+import { useReactiveStore } from './use-client';
+
+export interface UseCommitOutcomesResult {
+  readonly outcomes: readonly CommitOutcome[];
+  readonly isLoading: boolean;
+  readonly error: Error | undefined;
+  readonly refresh: () => void;
+}
+
+/**
+ * Durable newest-first commit history. It updates from the exact
+ * `outcomesChanged` transaction event, including resolution transitions.
+ */
+export function useCommitOutcomes(): UseCommitOutcomesResult {
+  const entry = useReactiveStore().outcomes;
+  const snapshot = useSyncExternalStore(
+    entry.subscribe,
+    entry.getSnapshot,
+    entry.getSnapshot,
+  );
+  const refresh = useCallback(() => entry.refresh(), [entry]);
+  return {
+    outcomes: snapshot.outcomes,
+    isLoading: snapshot.isLoading,
+    error: snapshot.error,
+    refresh,
+  };
+}

--- a/packages/react/test/fake-client.ts
+++ b/packages/react/test/fake-client.ts
@@ -9,6 +9,8 @@
 import type {
   ClientChangeBatch,
   ClientChangeListener,
+  CommitOutcome,
+  CommitOutcomeQuery,
   ConflictRecord,
   InvalidationEvent,
   InvalidationListener,
@@ -18,6 +20,7 @@ import type {
   QueryReadSpec,
   QuerySnapshot,
   RejectionRecord,
+  ResolveCommitOutcomeInput,
   SchemaFloor,
   SqlRow,
   SyncStatusSnapshot,
@@ -35,6 +38,7 @@ export class FakeClient implements SyncClientLike {
   #presence = new Map<string, PresencePeer[]>();
   #conflicts: ConflictRecord[] = [];
   #rejections: RejectionRecord[] = [];
+  #outcomes: CommitOutcome[] = [];
   #pending: unknown[] = [];
   #upgrading = false;
   #leaseState: LeaseState | undefined;
@@ -58,6 +62,10 @@ export class FakeClient implements SyncClientLike {
 
   setConflicts(conflicts: ConflictRecord[]): void {
     this.#conflicts = conflicts;
+  }
+
+  setOutcomes(outcomes: CommitOutcome[]): void {
+    this.#outcomes = outcomes;
   }
 
   setUpgrading(value: boolean): void {
@@ -109,10 +117,24 @@ export class FakeClient implements SyncClientLike {
     });
   }
 
-  #emitChange(batch: Omit<ClientChangeBatch, 'revision'>): void {
+  emitOutcomes(): void {
+    this.#emitChange({
+      tables: [],
+      windows: [],
+      conflictsChanged: false,
+      rejectionsChanged: false,
+      outcomesChanged: true,
+    });
+  }
+
+  #emitChange(
+    batch: Omit<ClientChangeBatch, 'revision' | 'outcomesChanged'> &
+      Partial<Pick<ClientChangeBatch, 'outcomesChanged'>>,
+  ): void {
     this.#revision += 1n;
     const revisioned: ClientChangeBatch = {
       revision: this.#revision,
+      outcomesChanged: false,
       ...batch,
     };
     for (const listener of this.#changes) listener(revisioned);
@@ -273,6 +295,44 @@ export class FakeClient implements SyncClientLike {
 
   get rejections(): readonly RejectionRecord[] {
     return this.#rejections;
+  }
+
+  commitOutcome(clientCommitId: string): CommitOutcome | undefined {
+    return this.#outcomes.find(
+      (outcome) => outcome.clientCommitId === clientCommitId,
+    );
+  }
+
+  commitOutcomes(query: CommitOutcomeQuery = {}): readonly CommitOutcome[] {
+    const outcomes = query.activeOnly
+      ? this.#outcomes.filter(
+          (outcome) =>
+            outcome.resolution === 'active' &&
+            (outcome.status === 'conflict' || outcome.status === 'rejected'),
+        )
+      : this.#outcomes;
+    return query.limit === undefined
+      ? outcomes
+      : outcomes.slice(0, query.limit);
+  }
+
+  resolveCommitOutcome(input: ResolveCommitOutcomeInput): CommitOutcome {
+    const index = this.#outcomes.findIndex(
+      (outcome) => outcome.clientCommitId === input.clientCommitId,
+    );
+    if (index < 0) throw new Error('missing fake outcome');
+    const current = this.#outcomes[index] as CommitOutcome;
+    const resolved: CommitOutcome = {
+      ...current,
+      resolution: input.resolution,
+      resolvedAtMs: 1,
+      ...(input.replacementClientCommitId !== undefined
+        ? { replacementClientCommitId: input.replacementClientCommitId }
+        : {}),
+    };
+    this.#outcomes[index] = resolved;
+    this.emitOutcomes();
+    return resolved;
   }
 
   get schemaFloor(): SchemaFloor | undefined {

--- a/packages/react/test/handle-shape.ts
+++ b/packages/react/test/handle-shape.ts
@@ -29,6 +29,11 @@ export function handleShapeOf(client: SyncClient): SyncClientLike {
     // Getters on SyncClient become async methods on the handle.
     conflicts: () => Promise.resolve(client.conflicts),
     rejections: () => Promise.resolve(client.rejections),
+    commitOutcome: (clientCommitId) =>
+      Promise.resolve(client.commitOutcome(clientCommitId)),
+    commitOutcomes: (query) => Promise.resolve(client.commitOutcomes(query)),
+    resolveCommitOutcome: (input) =>
+      Promise.resolve(client.resolveCommitOutcome(input)),
     schemaFloor: () => Promise.resolve(client.schemaFloor),
     leaseState: () => Promise.resolve(client.leaseState),
     upgrading: () => Promise.resolve(client.upgrading),

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -16,6 +16,7 @@ import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { type ReactNode, StrictMode } from 'react';
 import {
   SyncProvider,
+  useCommitOutcomes,
   useConflicts,
   usePresence,
   useRawSql,
@@ -213,6 +214,29 @@ describe('useConflicts', () => {
     ]);
     act(() => client.emitConflicts());
     await waitFor(() => expect(result.current.conflicts).toHaveLength(1));
+  });
+});
+
+describe('useCommitOutcomes', () => {
+  test('surfaces durable history and re-reads only on outcome batches', async () => {
+    const client = new FakeClient();
+    const { result } = renderHook(() => useCommitOutcomes(), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    client.setOutcomes([
+      {
+        sequence: 1,
+        clientCommitId: 'c1',
+        status: 'applied',
+        recordedAtMs: 1,
+        results: [{ status: 'applied', opIndex: 0 }],
+        resolution: 'active',
+      },
+    ]);
+    act(() => client.emitOutcomes());
+    await waitFor(() => expect(result.current.outcomes).toHaveLength(1));
+    expect(result.current.outcomes[0]?.clientCommitId).toBe('c1');
   });
 });
 

--- a/packages/react/test/ssr.test.tsx
+++ b/packages/react/test/ssr.test.tsx
@@ -9,6 +9,7 @@ import { createElement, type ReactNode } from 'react';
 import { renderToString } from 'react-dom/server';
 import {
   SyncProvider,
+  useCommitOutcomes,
   useConflicts,
   useRawSql,
   useSyncStatus,
@@ -19,10 +20,11 @@ function App(): ReactNode {
   const { rows, isLoading } = useRawSql('SELECT * FROM tasks');
   const status = useSyncStatus();
   const { conflicts } = useConflicts();
+  const { outcomes } = useCommitOutcomes();
   return createElement(
     'div',
     null,
-    `rows=${rows.length} loading=${isLoading} outbox=${status.outbox} conflicts=${conflicts.length}`,
+    `rows=${rows.length} loading=${isLoading} outbox=${status.outbox} conflicts=${conflicts.length} outcomes=${outcomes.length}`,
   );
 }
 
@@ -37,5 +39,6 @@ describe('SSR safety', () => {
     expect(html).toContain('loading=true');
     expect(html).toContain('outbox=0');
     expect(html).toContain('conflicts=0');
+    expect(html).toContain('outcomes=0');
   });
 });

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -13,6 +13,11 @@ local Tauri views remain responsive while the native client is syncing over
 HTTP/WebSocket. Mutations, sync, and all durable writes remain serialized on
 the single mutable core owner.
 
+The bridge includes the native core's durable commit-outcome journal:
+`commitOutcome`, `commitOutcomes`, and `resolveCommitOutcome`. Final results
+and explicit conflict resolutions survive process restarts; active failures
+are never silently removed by retention.
+
 Part of [Syncular](https://syncular.dev) — an offline-first sync framework.
 See the [Syncular repository](https://github.com/syncular/syncular) for docs.
 

--- a/packages/tauri/src/index.ts
+++ b/packages/tauri/src/index.ts
@@ -33,6 +33,8 @@
 import type {
   ClientChangeBatch,
   ClientChangeListener,
+  CommitOutcome,
+  CommitOutcomeQuery,
   ConflictRecord,
   InvalidationEvent,
   InvalidationListener,
@@ -42,6 +44,7 @@ import type {
   QueryReadSpec,
   QuerySnapshot,
   RejectionRecord,
+  ResolveCommitOutcomeInput,
   SchemaFloor,
   SqlRow,
   SqlValue,
@@ -528,6 +531,33 @@ export class TauriSyncClient {
     return result.rejections;
   }
 
+  async commitOutcome(
+    clientCommitId: string,
+  ): Promise<CommitOutcome | undefined> {
+    const result = (await this.#command('commitOutcome', {
+      clientCommitId,
+    })) as { outcome?: CommitOutcome };
+    return result.outcome;
+  }
+
+  async commitOutcomes(
+    query: CommitOutcomeQuery = {},
+  ): Promise<readonly CommitOutcome[]> {
+    const result = (await this.#command('commitOutcomes', { query })) as {
+      outcomes: CommitOutcome[];
+    };
+    return result.outcomes;
+  }
+
+  async resolveCommitOutcome(
+    input: ResolveCommitOutcomeInput,
+  ): Promise<CommitOutcome> {
+    const result = (await this.#command('resolveCommitOutcome', {
+      input,
+    })) as { outcome: CommitOutcome };
+    return result.outcome;
+  }
+
   async schemaFloor(): Promise<SchemaFloor | undefined> {
     const result = (await this.#command('schemaFloor', {})) as {
       floor?: SchemaFloor;
@@ -659,6 +689,7 @@ function decodeChangeBatch(value: unknown): ClientChangeBatch | undefined {
       : {}),
     conflictsChanged: raw.conflictsChanged === true,
     rejectionsChanged: raw.rejectionsChanged === true,
+    outcomesChanged: raw.outcomesChanged === true,
   };
 }
 

--- a/packages/tauri/test/bridge.test.ts
+++ b/packages/tauri/test/bridge.test.ts
@@ -85,6 +85,31 @@ function defaultResponder(cmd: string, args: Record<string, unknown>): unknown {
       return OK({ conflicts: [] });
     case 'rejections':
       return OK({ rejections: [] });
+    case 'commitOutcome':
+      return OK({
+        outcome: {
+          sequence: 1,
+          clientCommitId: 'commit-1',
+          status: 'applied',
+          recordedAtMs: 1,
+          results: [{ status: 'applied', opIndex: 0 }],
+          resolution: 'active',
+        },
+      });
+    case 'commitOutcomes':
+      return OK({ outcomes: [] });
+    case 'resolveCommitOutcome':
+      return OK({
+        outcome: {
+          sequence: 1,
+          clientCommitId: 'commit-1',
+          status: 'applied',
+          recordedAtMs: 1,
+          results: [{ status: 'applied', opIndex: 0 }],
+          resolution: 'dismissed',
+          resolvedAtMs: 2,
+        },
+      });
     case 'schemaFloor':
       return OK({ floor: undefined });
     case 'leaseState':
@@ -254,6 +279,16 @@ describe('createTauriSyncClient', () => {
     expect(await client.syncNeeded()).toBe(true);
     expect(await client.upgrading()).toBe(false);
     expect(await client.conflicts()).toEqual([]);
+    expect(await client.commitOutcome('commit-1')).toMatchObject({
+      status: 'applied',
+    });
+    expect(await client.commitOutcomes({ activeOnly: true })).toEqual([]);
+    expect(
+      await client.resolveCommitOutcome({
+        clientCommitId: 'commit-1',
+        resolution: 'dismissed',
+      }),
+    ).toMatchObject({ resolution: 'dismissed' });
     expect(await client.pendingCommits()).toEqual(['commit-1']);
     expect(await client.schemaFloor()).toBeUndefined();
   });
@@ -386,6 +421,16 @@ describe('SyncClientLike parity', () => {
     );
     expect(await normalized.conflicts()).toEqual([]);
     expect(await normalized.rejections()).toEqual([]);
+    expect(await normalized.commitOutcome('commit-1')).toMatchObject({
+      status: 'applied',
+    });
+    expect(await normalized.commitOutcomes()).toEqual([]);
+    expect(
+      await normalized.resolveCommitOutcome({
+        clientCommitId: 'commit-1',
+        resolution: 'dismissed',
+      }),
+    ).toMatchObject({ resolution: 'dismissed' });
     expect(await normalized.schemaFloor()).toBeUndefined();
     expect(await normalized.leaseState()).toBeUndefined();
     expect(await normalized.upgrading()).toBe(false);

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -108,6 +108,20 @@ With `multiTab` off (the default) the single-tab contract is unchanged: a
 losing tab is an `isLeader === false` handle whose calls reject with
 `client.not_leader`.
 
+## Durable commit outcomes
+
+`SyncClient` and every host bridge expose `commitOutcome(id)`,
+`commitOutcomes({ limit?, activeOnly? })`, and `resolveCommitOutcome(input)`.
+Final `applied`, `cached`, `conflict`, and `rejected` results are journaled in
+the same SQLite transaction that drains their outbox commit. Conflict entries
+retain the losing operation plus `serverVersion`/`serverRow`; active failures
+restore after restart and are never removed by retention. Configure the
+history cap with `limits.outcomeRetentionMaxEntries` (default 1,000).
+
+Resolution is explicit and one-way: conflicts can keep the server result or
+link to a replacement commit, rejections can link to a replacement, and
+successful history may be dismissed. See SPEC §7.2.1.
+
 ## The support floor (no fallback ladder)
 
 - Persistence is **OPFS via `opfs-sahpool`, only**. No COOP/COEP headers

--- a/packages/web-client/src/client.ts
+++ b/packages/web-client/src/client.ts
@@ -89,6 +89,20 @@ import {
   OutboxEncodeError,
   type OutboxOperation,
 } from './outbox';
+import {
+  activeFailureRecords,
+  type CommitOperationOutcome,
+  type CommitOutcome,
+  type CommitOutcomeQuery,
+  type ConflictRecord,
+  listCommitOutcomes,
+  persistCommitOutcomeResolution,
+  pruneCommitOutcomes,
+  type RejectionRecord,
+  type ResolveCommitOutcomeInput,
+  commitOutcome as readCommitOutcome,
+  recordCommitOutcome,
+} from './outcomes';
 import { assertReadOnlyQuery } from './query-guard';
 import {
   type ClientSchema,
@@ -159,30 +173,14 @@ export type MutationInput =
       readonly baseVersion?: number;
     };
 
-/** A §6.3 conflict result, surfaced to the app — never auto-resolved. */
-export interface ConflictRecord {
-  readonly clientCommitId: string;
-  readonly opIndex: number;
-  readonly table: string;
-  readonly rowId: string;
-  readonly code: string;
-  readonly message: string;
-  readonly serverVersion: number;
-  /** The current server row, decoded — resolve without a round-trip. */
-  readonly serverRow: Readonly<Record<string, RowValue>>;
-  /** The losing local operation (absent only for malformed op indexes). */
-  readonly operation?: OutboxOperation;
-}
-
-/** A non-conflict `error` result from a rejected commit (§6.3). */
-export interface RejectionRecord {
-  readonly clientCommitId: string;
-  readonly opIndex: number;
-  readonly code: string;
-  readonly message: string;
-  readonly retryable: boolean;
-  readonly operation?: OutboxOperation;
-}
+export type {
+  CommitOperationOutcome,
+  CommitOutcome,
+  CommitOutcomeQuery,
+  ConflictRecord,
+  RejectionRecord,
+  ResolveCommitOutcomeInput,
+} from './outcomes';
 
 export interface SchemaFloor {
   readonly requiredSchemaVersion?: number;
@@ -246,6 +244,12 @@ export interface SyncClientLimits {
    * `withSqliteImage` and a segment downloader is configured (§5.3).
    */
   readonly accept?: number;
+  /**
+   * Maximum retained durable commit outcomes. Old applied/cached or resolved
+   * entries are pruned first; unresolved conflicts/rejections are never
+   * deleted to satisfy this cap. Defaults to 1,000.
+   */
+  readonly outcomeRetentionMaxEntries?: number;
 }
 
 export interface SyncClientConfig {
@@ -454,6 +458,7 @@ export class SyncClient {
   /** §5.11 client-side encryption config; undefined ⇒ E2EE off. */
   readonly #encryption: EncryptionConfig | undefined;
   readonly #now: () => number;
+  readonly #outcomeRetentionMaxEntries: number;
   #started = false;
   #lease: LeaderLease | undefined;
   #clientId = '';
@@ -511,6 +516,18 @@ export class SyncClient {
     this.#schema = compileClientSchema(config.schema);
     this.#encryption = config.encryption;
     this.#now = config.now ?? Date.now;
+    const outcomeRetentionMaxEntries =
+      config.limits?.outcomeRetentionMaxEntries ?? 1_000;
+    if (
+      !Number.isSafeInteger(outcomeRetentionMaxEntries) ||
+      outcomeRetentionMaxEntries < 1
+    ) {
+      throw new ClientSyncError(
+        'sync.invalid_request',
+        'outcomeRetentionMaxEntries must be a positive safe integer',
+      );
+    }
+    this.#outcomeRetentionMaxEntries = outcomeRetentionMaxEntries;
     this.#hasBlobs = schemaHasBlobs(this.#schema);
   }
 
@@ -525,6 +542,14 @@ export class SyncClient {
     );
     ensureLocalSchema(this.#db, this.#schema);
     if (this.#hasBlobs) ensureBlobSchema(this.#db);
+    this.#db.transaction(() => {
+      pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
+    });
+    const activeFailures = activeFailureRecords(
+      listCommitOutcomes(this.#db, { activeOnly: true }),
+    );
+    this.#conflicts = activeFailures.conflicts;
+    this.#rejections = activeFailures.rejections;
     const persisted = getMeta(this.#db, 'clientId');
     if (
       persisted !== undefined &&
@@ -1035,6 +1060,92 @@ export class SyncClient {
 
   get rejections(): readonly RejectionRecord[] {
     return this.#rejections;
+  }
+
+  /** One durable final outcome by the originating client commit id. */
+  commitOutcome(clientCommitId: string): CommitOutcome | undefined {
+    this.#requireStarted();
+    return readCommitOutcome(this.#db, clientCommitId);
+  }
+
+  /** Newest-first durable outcome journal. */
+  commitOutcomes(query: CommitOutcomeQuery = {}): readonly CommitOutcome[] {
+    this.#requireStarted();
+    return listCommitOutcomes(this.#db, query);
+  }
+
+  /**
+   * Mark a durable failure handled without deleting its evidence. Conflicts
+   * may keep the server row or link to a replacement commit; rejections may
+   * only be superseded by a named replacement. Applied/cached history may be
+   * dismissed. The transition is one-way and survives restart.
+   */
+  resolveCommitOutcome(input: ResolveCommitOutcomeInput): CommitOutcome {
+    this.#requireStarted();
+    const current = readCommitOutcome(this.#db, input.clientCommitId);
+    if (current === undefined) {
+      throw new ClientSyncError(
+        'sync.outcome_not_found',
+        `no durable outcome exists for ${JSON.stringify(input.clientCommitId)}`,
+      );
+    }
+    if (current.resolution !== 'active') return current;
+    const replacement = input.replacementClientCommitId;
+    if (input.resolution === 'superseded') {
+      if (
+        replacement === undefined ||
+        replacement.length === 0 ||
+        replacement === input.clientCommitId
+      ) {
+        throw new ClientSyncError(
+          'sync.invalid_request',
+          'superseded outcomes require a distinct replacementClientCommitId',
+        );
+      }
+    } else if (replacement !== undefined) {
+      throw new ClientSyncError(
+        'sync.invalid_request',
+        'replacementClientCommitId is valid only for superseded outcomes',
+      );
+    }
+    const allowed =
+      (current.status === 'conflict' &&
+        (input.resolution === 'resolved_keep_server' ||
+          input.resolution === 'superseded')) ||
+      (current.status === 'rejected' && input.resolution === 'superseded') ||
+      ((current.status === 'applied' || current.status === 'cached') &&
+        input.resolution === 'dismissed');
+    if (!allowed) {
+      throw new ClientSyncError(
+        'sync.invalid_request',
+        `resolution ${input.resolution} is invalid for ${current.status} outcome`,
+      );
+    }
+
+    return this.#applyBatch((batch) => {
+      const resolved = persistCommitOutcomeResolution(
+        this.#db,
+        input,
+        this.#now(),
+      );
+      if (resolved === undefined) {
+        throw new ClientSyncError(
+          'sync.outcome_not_found',
+          `no durable outcome exists for ${JSON.stringify(input.clientCommitId)}`,
+        );
+      }
+      this.#conflicts = this.#conflicts.filter(
+        (record) => record.clientCommitId !== input.clientCommitId,
+      );
+      this.#rejections = this.#rejections.filter(
+        (record) => record.clientCommitId !== input.clientCommitId,
+      );
+      pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
+      batch.outcomes();
+      if (current.status === 'conflict') batch.conflicts();
+      if (current.status === 'rejected') batch.rejections();
+      return resolved;
+    });
   }
 
   /** Non-undefined once the server declared a schema floor (§1.6). */
@@ -1595,7 +1706,7 @@ export class SyncClient {
           deleteLocalRow(this.#db, table, operation.rowId);
         }
       }
-      this.#rejections.push({
+      const rejection: RejectionRecord = {
         clientCommitId: commit.clientCommitId,
         opIndex: 0,
         code: OUTBOX_INCOMPATIBLE_CODE,
@@ -1604,9 +1715,18 @@ export class SyncClient {
         ...(commit.operations[0] !== undefined
           ? { operation: commit.operations[0] }
           : {}),
+      };
+      this.#rejections.push(rejection);
+      recordCommitOutcome(this.#db, {
+        clientCommitId: commit.clientCommitId,
+        status: 'rejected',
+        recordedAtMs: this.#now(),
+        results: [{ status: 'error', rejection }],
       });
+      pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
       batch.status();
       batch.rejections();
+      batch.outcomes();
     });
   }
 
@@ -2313,8 +2433,19 @@ export class SyncClient {
     if (frame.status === 'applied' || frame.status === 'cached') {
       // §6.3: applied and cached both drain the outbox — cached means
       // "already applied, you may have missed the ack".
+      recordCommitOutcome(this.#db, {
+        clientCommitId: frame.clientCommitId,
+        status: frame.status,
+        recordedAtMs: this.#now(),
+        results: frame.results.map((result) => ({
+          status: 'applied' as const,
+          opIndex: result.opIndex,
+        })),
+      });
       deleteOutboxCommit(this.#db, frame.clientCommitId);
+      pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
       batch.status();
+      batch.outcomes();
       summary.applied.push(frame.clientCommitId);
       return;
     }
@@ -2331,6 +2462,7 @@ export class SyncClient {
       summary.retryable.push(frame.clientCommitId);
       return;
     }
+    const outcomeResults: CommitOperationOutcome[] = [];
     for (const result of frame.results) {
       const operation = commit.operations[result.opIndex];
       if (result.status === 'conflict') {
@@ -2346,21 +2478,36 @@ export class SyncClient {
           ...(operation !== undefined ? { operation } : {}),
         };
         this.#conflicts.push(conflict);
+        outcomeResults.push({ status: 'conflict', conflict });
         batch.conflicts();
         summary.conflicts.push(conflict);
         this.#config.onConflict?.(conflict);
       } else if (result.status === 'error') {
-        this.#rejections.push({
+        const rejection: RejectionRecord = {
           clientCommitId: frame.clientCommitId,
           opIndex: result.opIndex,
           code: result.code,
           message: result.message,
           retryable: result.retryable,
           ...(operation !== undefined ? { operation } : {}),
-        });
+        };
+        this.#rejections.push(rejection);
+        outcomeResults.push({ status: 'error', rejection });
         batch.rejections();
+      } else {
+        outcomeResults.push({ status: 'applied', opIndex: result.opIndex });
       }
     }
+    recordCommitOutcome(this.#db, {
+      clientCommitId: frame.clientCommitId,
+      status: outcomeResults.some((result) => result.status === 'conflict')
+        ? 'conflict'
+        : 'rejected',
+      recordedAtMs: this.#now(),
+      results: outcomeResults,
+    });
+    pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
+    batch.outcomes();
     // §7.2: stop optimistic display and decide about dependents — the
     // commit leaves the outbox; rows it created that the server never
     // confirmed are undone here, rows it overwrote reconcile via the pull
@@ -2680,10 +2827,47 @@ export class SyncClient {
         try {
           deleteScopedRows(this.#db, table, lastEffective);
           batch.scopeMap(table, lastEffective);
-          if (
-            dropOutboxCommitsInScope(this.#db, table, lastEffective).length > 0
-          ) {
+          const pendingById = new Map(
+            listOutbox(this.#db).map((commit) => [
+              commit.clientCommitId,
+              commit,
+            ]),
+          );
+          const droppedIds = dropOutboxCommitsInScope(
+            this.#db,
+            table,
+            lastEffective,
+          );
+          if (droppedIds.length > 0) {
+            for (const clientCommitId of droppedIds) {
+              const commit = pendingById.get(clientCommitId);
+              if (commit === undefined) continue;
+              const results: CommitOperationOutcome[] = commit.operations.map(
+                (operation, opIndex) => {
+                  const rejection: RejectionRecord = {
+                    clientCommitId,
+                    opIndex,
+                    code: 'sync.scope_revoked',
+                    message:
+                      'the commit was dropped because its effective scope was revoked',
+                    retryable: false,
+                    operation,
+                  };
+                  this.#rejections.push(rejection);
+                  return { status: 'error', rejection };
+                },
+              );
+              recordCommitOutcome(this.#db, {
+                clientCommitId,
+                status: 'rejected',
+                recordedAtMs: this.#now(),
+                results,
+              });
+            }
+            pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
             batch.status();
+            batch.rejections();
+            batch.outcomes();
           }
           this.#reconcileBlobs(true);
         } catch (error) {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -22,6 +22,7 @@ export * from './leader-lock';
 export * from './multi-tab';
 export * from './naming';
 export * from './outbox';
+export * from './outcomes';
 export * from './query-guard';
 export * from './reactive-store';
 export * from './schema';

--- a/packages/web-client/src/invalidation.ts
+++ b/packages/web-client/src/invalidation.ts
@@ -38,6 +38,7 @@ export interface ClientChangeBatch {
   readonly status?: SyncStatusSnapshot;
   readonly conflictsChanged: boolean;
   readonly rejectionsChanged: boolean;
+  readonly outcomesChanged: boolean;
 }
 
 export type ClientChangeListener = (batch: ClientChangeBatch) => void;
@@ -81,6 +82,7 @@ export class ChangeAccumulator {
   #status = false;
   #conflicts = false;
   #rejections = false;
+  #outcomes = false;
 
   /** Mark a whole table dirty, discarding any weaker scope-only facts. */
   table(name: string): void {
@@ -126,6 +128,10 @@ export class ChangeAccumulator {
     this.#rejections = true;
   }
 
+  outcomes(): void {
+    this.#outcomes = true;
+  }
+
   /** Add precise keys for a requested/effective scope map. */
   scopeMap(table: CompiledClientTable, scopes: ScopeMap): void {
     for (const [variable, values] of Object.entries(scopes)) {
@@ -154,7 +160,8 @@ export class ChangeAccumulator {
       this.#windows.size > 0 ||
       this.#status ||
       this.#conflicts ||
-      this.#rejections
+      this.#rejections ||
+      this.#outcomes
     );
   }
 
@@ -192,6 +199,7 @@ export class ChangeAccumulator {
       ...(this.#status ? { status: status as SyncStatusSnapshot } : {}),
       conflictsChanged: this.#conflicts,
       rejectionsChanged: this.#rejections,
+      outcomesChanged: this.#outcomes,
     };
   }
 }

--- a/packages/web-client/src/outcomes.ts
+++ b/packages/web-client/src/outcomes.ts
@@ -1,0 +1,274 @@
+/**
+ * Durable per-client commit outcomes.
+ *
+ * The journal is client-local protected database state. A final push result is
+ * written in the same SQLite transaction that drains its outbox commit, so a
+ * restart can never turn "rejected" into an inferred success. Conflict payloads
+ * deliberately stay local; retention never deletes an unresolved failure.
+ */
+import type { RowValue } from '@syncular/core';
+import type { ClientDatabase } from './database';
+import { ClientSyncError } from './errors';
+import type { OutboxOperation } from './outbox';
+import { type JsonRowValue, jsonToRowValue, rowValueToJson } from './schema';
+
+export interface ConflictRecord {
+  readonly clientCommitId: string;
+  readonly opIndex: number;
+  readonly table: string;
+  readonly rowId: string;
+  readonly code: string;
+  readonly message: string;
+  readonly serverVersion: number;
+  /** The current server row, decoded — resolve without a round-trip. */
+  readonly serverRow: Readonly<Record<string, RowValue>>;
+  /** The losing local operation (absent only for malformed op indexes). */
+  readonly operation?: OutboxOperation;
+}
+
+export interface RejectionRecord {
+  readonly clientCommitId: string;
+  readonly opIndex: number;
+  readonly code: string;
+  readonly message: string;
+  readonly retryable: boolean;
+  readonly operation?: OutboxOperation;
+}
+
+export type CommitOutcomeStatus =
+  | 'applied'
+  | 'cached'
+  | 'conflict'
+  | 'rejected';
+
+export type CommitOutcomeResolution =
+  | 'active'
+  | 'resolved_keep_server'
+  | 'superseded'
+  | 'dismissed';
+
+export type CommitOperationOutcome =
+  | {
+      readonly status: 'applied';
+      readonly opIndex: number;
+    }
+  | {
+      readonly status: 'conflict';
+      readonly conflict: ConflictRecord;
+    }
+  | {
+      readonly status: 'error';
+      readonly rejection: RejectionRecord;
+    };
+
+export interface CommitOutcome {
+  /** Monotonic local journal order; not a server sequence. */
+  readonly sequence: number;
+  readonly clientCommitId: string;
+  readonly status: CommitOutcomeStatus;
+  readonly recordedAtMs: number;
+  readonly results: readonly CommitOperationOutcome[];
+  readonly resolution: CommitOutcomeResolution;
+  readonly resolvedAtMs?: number;
+  readonly replacementClientCommitId?: string;
+}
+
+export interface CommitOutcomeQuery {
+  /** Newest-first result cap. Defaults to all retained entries. */
+  readonly limit?: number;
+  /** Only unresolved conflict/rejection outcomes. */
+  readonly activeOnly?: boolean;
+}
+
+export interface ResolveCommitOutcomeInput {
+  readonly clientCommitId: string;
+  readonly resolution: Exclude<CommitOutcomeResolution, 'active'>;
+  readonly replacementClientCommitId?: string;
+}
+
+interface StoredConflictRecord extends Omit<ConflictRecord, 'serverRow'> {
+  readonly serverRow: Readonly<Record<string, JsonRowValue>>;
+}
+
+type StoredCommitOperationOutcome =
+  | Extract<CommitOperationOutcome, { status: 'applied' }>
+  | { readonly status: 'conflict'; readonly conflict: StoredConflictRecord }
+  | Extract<CommitOperationOutcome, { status: 'error' }>;
+
+function encodeResults(results: readonly CommitOperationOutcome[]): string {
+  const stored: StoredCommitOperationOutcome[] = results.map((result) => {
+    if (result.status !== 'conflict') return result;
+    return {
+      status: 'conflict',
+      conflict: {
+        ...result.conflict,
+        serverRow: Object.fromEntries(
+          Object.entries(result.conflict.serverRow).map(([key, value]) => [
+            key,
+            rowValueToJson(value),
+          ]),
+        ),
+      },
+    };
+  });
+  return JSON.stringify(stored);
+}
+
+function decodeResults(raw: string): CommitOperationOutcome[] {
+  const stored = JSON.parse(raw) as StoredCommitOperationOutcome[];
+  return stored.map((result) => {
+    if (result.status !== 'conflict') return result;
+    return {
+      status: 'conflict',
+      conflict: {
+        ...result.conflict,
+        serverRow: Object.fromEntries(
+          Object.entries(result.conflict.serverRow).map(([key, value]) => [
+            key,
+            jsonToRowValue(value),
+          ]),
+        ),
+      },
+    };
+  });
+}
+
+function parseOutcome(row: Readonly<Record<string, unknown>>): CommitOutcome {
+  return {
+    sequence: row.seq as number,
+    clientCommitId: row.client_commit_id as string,
+    status: row.status as CommitOutcomeStatus,
+    recordedAtMs: row.recorded_at_ms as number,
+    results: decodeResults(row.results as string),
+    resolution: row.resolution as CommitOutcomeResolution,
+    ...(typeof row.resolved_at_ms === 'number'
+      ? { resolvedAtMs: row.resolved_at_ms }
+      : {}),
+    ...(typeof row.replacement_client_commit_id === 'string'
+      ? { replacementClientCommitId: row.replacement_client_commit_id }
+      : {}),
+  };
+}
+
+export function recordCommitOutcome(
+  db: ClientDatabase,
+  outcome: Omit<CommitOutcome, 'sequence' | 'resolution'>,
+): CommitOutcome {
+  db.exec(
+    `INSERT INTO _syncular_commit_outcomes(
+       client_commit_id, status, recorded_at_ms, results, resolution
+     ) VALUES (?, ?, ?, ?, 'active')`,
+    [
+      outcome.clientCommitId,
+      outcome.status,
+      outcome.recordedAtMs,
+      encodeResults(outcome.results),
+    ],
+  );
+  return commitOutcome(db, outcome.clientCommitId) as CommitOutcome;
+}
+
+export function commitOutcome(
+  db: ClientDatabase,
+  clientCommitId: string,
+): CommitOutcome | undefined {
+  const row = db.query(
+    `SELECT seq, client_commit_id, status, recorded_at_ms, results,
+            resolution, resolved_at_ms, replacement_client_commit_id
+       FROM _syncular_commit_outcomes WHERE client_commit_id = ?`,
+    [clientCommitId],
+  )[0];
+  return row === undefined ? undefined : parseOutcome(row);
+}
+
+export function listCommitOutcomes(
+  db: ClientDatabase,
+  query: CommitOutcomeQuery = {},
+): CommitOutcome[] {
+  const limit = query.limit;
+  if (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1)) {
+    throw new ClientSyncError(
+      'sync.invalid_request',
+      'commit outcome limit must be a positive safe integer',
+    );
+  }
+  const where = query.activeOnly
+    ? "WHERE resolution = 'active' AND status IN ('conflict', 'rejected')"
+    : '';
+  const rows = db.query(
+    `SELECT seq, client_commit_id, status, recorded_at_ms, results,
+            resolution, resolved_at_ms, replacement_client_commit_id
+       FROM _syncular_commit_outcomes ${where}
+      ORDER BY seq DESC${limit === undefined ? '' : ' LIMIT ?'}`,
+    limit === undefined ? [] : [limit],
+  );
+  return rows.map(parseOutcome);
+}
+
+export function persistCommitOutcomeResolution(
+  db: ClientDatabase,
+  input: ResolveCommitOutcomeInput,
+  nowMs: number,
+): CommitOutcome | undefined {
+  db.exec(
+    `UPDATE _syncular_commit_outcomes
+        SET resolution = ?, resolved_at_ms = ?, replacement_client_commit_id = ?
+      WHERE client_commit_id = ? AND resolution = 'active'`,
+    [
+      input.resolution,
+      nowMs,
+      input.replacementClientCommitId ?? null,
+      input.clientCommitId,
+    ],
+  );
+  return commitOutcome(db, input.clientCommitId);
+}
+
+/**
+ * Bound journal growth without deleting active failures. If active failures
+ * alone exceed the cap the journal intentionally remains over-capacity.
+ */
+export function pruneCommitOutcomes(
+  db: ClientDatabase,
+  maxEntries: number,
+): number {
+  if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+    throw new ClientSyncError(
+      'sync.invalid_request',
+      'outcome retention maxEntries must be a positive safe integer',
+    );
+  }
+  const count = db.query(
+    'SELECT COUNT(*) AS count FROM _syncular_commit_outcomes',
+  )[0]?.count as number | undefined;
+  const excess = Math.max(0, (count ?? 0) - maxEntries);
+  if (excess === 0) return 0;
+  const candidates = db.query(
+    `SELECT seq FROM _syncular_commit_outcomes
+      WHERE status IN ('applied', 'cached') OR resolution != 'active'
+      ORDER BY seq ASC LIMIT ?`,
+    [excess],
+  );
+  for (const candidate of candidates) {
+    db.exec('DELETE FROM _syncular_commit_outcomes WHERE seq = ?', [
+      candidate.seq as number,
+    ]);
+  }
+  return candidates.length;
+}
+
+export function activeFailureRecords(outcomes: readonly CommitOutcome[]): {
+  readonly conflicts: ConflictRecord[];
+  readonly rejections: RejectionRecord[];
+} {
+  const conflicts: ConflictRecord[] = [];
+  const rejections: RejectionRecord[] = [];
+  for (const outcome of outcomes) {
+    if (outcome.resolution !== 'active') continue;
+    for (const result of outcome.results) {
+      if (result.status === 'conflict') conflicts.push(result.conflict);
+      if (result.status === 'error') rejections.push(result.rejection);
+    }
+  }
+  return { conflicts, rejections };
+}

--- a/packages/web-client/src/reactive-store.ts
+++ b/packages/web-client/src/reactive-store.ts
@@ -1,4 +1,5 @@
 import type {
+  CommitOutcome,
   QueryReadSpec,
   QuerySnapshot,
   WindowCoverage,
@@ -49,6 +50,9 @@ export interface ReactiveQueryClient {
   readonly rejections:
     | readonly unknown[]
     | (() => readonly unknown[] | Promise<readonly unknown[]>);
+  commitOutcomes():
+    | readonly CommitOutcome[]
+    | Promise<readonly CommitOutcome[]>;
   setWindow(base: WindowBase, units: readonly string[]): void | Promise<void>;
   windowState(base: WindowBase): WindowState | Promise<WindowState>;
 }
@@ -78,6 +82,12 @@ export interface ConflictStoreSnapshot<
 > {
   readonly conflicts: readonly Conflict[];
   readonly rejections: readonly Rejection[];
+  readonly error: Error | undefined;
+  readonly isLoading: boolean;
+}
+
+export interface OutcomeStoreSnapshot {
+  readonly outcomes: readonly CommitOutcome[];
   readonly error: Error | undefined;
   readonly isLoading: boolean;
 }
@@ -497,6 +507,7 @@ export class ReactiveClientStore {
   #offChange: (() => void) | undefined;
   readonly status: ExternalStoreEntry<StatusStoreSnapshot>;
   readonly conflicts: ExternalStoreEntry<ConflictStoreSnapshot>;
+  readonly outcomes: ExternalStoreEntry<OutcomeStoreSnapshot>;
 
   constructor(readonly client: ReactiveQueryClient) {
     const status = new ValueEntry<StatusStoreSnapshot>(
@@ -537,10 +548,26 @@ export class ReactiveClientStore {
         }
       },
     );
+    const outcomes = new ValueEntry<OutcomeStoreSnapshot>(
+      { outcomes: [], error: undefined, isLoading: true },
+      async () => {
+        try {
+          return {
+            outcomes: await client.commitOutcomes(),
+            error: undefined,
+            isLoading: false,
+          };
+        } catch (error) {
+          return { outcomes: [], error: errorOf(error), isLoading: false };
+        }
+      },
+    );
     this.status = status;
     this.conflicts = conflicts;
+    this.outcomes = outcomes;
     status.refresh();
     conflicts.refresh();
+    outcomes.refresh();
     this.start();
   }
 
@@ -681,6 +708,7 @@ export class ReactiveClientStore {
       if (batch.conflictsChanged || batch.rejectionsChanged) {
         this.conflicts.refresh();
       }
+      if (batch.outcomesChanged) this.outcomes.refresh();
     });
   }
 

--- a/packages/web-client/src/schema.ts
+++ b/packages/web-client/src/schema.ts
@@ -288,6 +288,18 @@ export function ensureLocalSchema(
       client_commit_id TEXT NOT NULL UNIQUE,
       created_at_ms INTEGER NOT NULL,
       operations TEXT NOT NULL)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS _syncular_commit_outcomes(
+      seq INTEGER PRIMARY KEY AUTOINCREMENT,
+      client_commit_id TEXT NOT NULL UNIQUE,
+      status TEXT NOT NULL CHECK(status IN ('applied', 'cached', 'conflict', 'rejected')),
+      recorded_at_ms INTEGER NOT NULL,
+      results TEXT NOT NULL,
+      resolution TEXT NOT NULL DEFAULT 'active'
+        CHECK(resolution IN ('active', 'resolved_keep_server', 'superseded', 'dismissed')),
+      resolved_at_ms INTEGER,
+      replacement_client_commit_id TEXT)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS _syncular_commit_outcomes_resolution_seq
+      ON _syncular_commit_outcomes(resolution, seq)`);
     db.exec(`CREATE TABLE IF NOT EXISTS _syncular_subscriptions(
       id TEXT PRIMARY KEY,
       tbl TEXT NOT NULL,

--- a/packages/web-client/src/worker-entry.ts
+++ b/packages/web-client/src/worker-entry.ts
@@ -378,6 +378,11 @@ export function startSyncWorker(overrides: SyncWorkerOverrides = {}): void {
     statusSnapshot: () => requireClient().statusSnapshot(),
     conflicts: () => requireClient().conflicts,
     rejections: () => requireClient().rejections,
+    commitOutcome: (clientCommitId) =>
+      requireClient().commitOutcome(clientCommitId),
+    commitOutcomes: (query) => requireClient().commitOutcomes(query),
+    resolveCommitOutcome: (input) =>
+      requireClient().resolveCommitOutcome(input),
     schemaFloor: () => requireClient().schemaFloor,
     leaseState: () => requireClient().leaseState,
     upgrading: () => requireClient().upgrading,

--- a/packages/web-client/src/worker-host.ts
+++ b/packages/web-client/src/worker-host.ts
@@ -64,6 +64,11 @@ import {
   newTabId,
 } from './multi-tab';
 import type { OutboxCommit } from './outbox';
+import type {
+  CommitOutcome,
+  CommitOutcomeQuery,
+  ResolveCommitOutcomeInput,
+} from './outcomes';
 import type { ClientSchema } from './schema';
 import type { SubscriptionRecord } from './state';
 import type { WindowBase } from './window';
@@ -383,6 +388,22 @@ export class SyncClientHandle {
 
   rejections(): Promise<readonly RejectionRecord[]> {
     return this.#call('rejections', []);
+  }
+
+  commitOutcome(clientCommitId: string): Promise<CommitOutcome | undefined> {
+    return this.#call('commitOutcome', [clientCommitId]);
+  }
+
+  commitOutcomes(
+    query: CommitOutcomeQuery = {},
+  ): Promise<readonly CommitOutcome[]> {
+    return this.#call('commitOutcomes', [query]);
+  }
+
+  resolveCommitOutcome(
+    input: ResolveCommitOutcomeInput,
+  ): Promise<CommitOutcome> {
+    return this.#call('resolveCommitOutcome', [input]);
   }
 
   schemaFloor(): Promise<SchemaFloor | undefined> {

--- a/packages/web-client/src/worker-protocol.ts
+++ b/packages/web-client/src/worker-protocol.ts
@@ -39,6 +39,11 @@ import type {
   SyncStatusSnapshot,
 } from './invalidation';
 import type { OutboxCommit } from './outbox';
+import type {
+  CommitOutcome,
+  CommitOutcomeQuery,
+  ResolveCommitOutcomeInput,
+} from './outcomes';
 import type { ClientSchema } from './schema';
 import type { SubscriptionRecord } from './state';
 import type { WindowBase } from './window';
@@ -133,6 +138,9 @@ export interface WorkerApi {
   statusSnapshot(): SyncStatusSnapshot;
   conflicts(): readonly ConflictRecord[];
   rejections(): readonly RejectionRecord[];
+  commitOutcome(clientCommitId: string): CommitOutcome | undefined;
+  commitOutcomes(query?: CommitOutcomeQuery): readonly CommitOutcome[];
+  resolveCommitOutcome(input: ResolveCommitOutcomeInput): CommitOutcome;
   schemaFloor(): SchemaFloor | undefined;
   /** §7.3.5: the opaque auth-lease state, or undefined. */
   leaseState(): LeaseState | undefined;

--- a/packages/web-client/test/client.test.ts
+++ b/packages/web-client/test/client.test.ts
@@ -5,6 +5,9 @@
  * rejection handling (§6.3), and the schema-floor stop state (§1.6).
  */
 import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { type ClientSchema, ClientSyncError } from '@syncular/client';
 import {
   CLIENT_SCHEMA,
@@ -262,6 +265,236 @@ describe('conflict surfacing (§6.2, §6.5)', () => {
     await a.client.syncUntilIdle();
     expect(tableRows(a.db, 'tasks').map((r) => r.id)).toEqual(['t1']);
     expect(tableRows(b.db, 'tasks').map((r) => r.id)).toEqual(['t1']);
+  });
+});
+
+describe('durable commit outcomes', () => {
+  test('journals the final result atomically with outbox drain and survives restart', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'syncular-outcomes-'));
+    const databasePath = join(directory, 'client.db');
+    const server = makeServer();
+    try {
+      const first = await makeClient(server, {
+        clientId: 'durable-client',
+        databasePath,
+      });
+      first.client.subscribe({
+        id: 's1',
+        table: 'tasks',
+        scopes: { project_id: ['durable'] },
+      });
+      const clientCommitId = first.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('durable-1', 'durable', 'persisted'),
+        },
+      ]);
+      await first.client.syncUntilIdle();
+      expect(first.client.pendingCommits()).toHaveLength(0);
+      expect(first.client.commitOutcome(clientCommitId)).toMatchObject({
+        clientCommitId,
+        status: 'applied',
+        resolution: 'active',
+        results: [{ status: 'applied', opIndex: 0 }],
+      });
+      await first.client.close();
+      first.db.close();
+
+      const reopened = await makeClient(server, {
+        clientId: 'durable-client',
+        databasePath,
+      });
+      expect(reopened.client.pendingCommits()).toHaveLength(0);
+      expect(reopened.client.commitOutcome(clientCommitId)).toMatchObject({
+        status: 'applied',
+        results: [{ status: 'applied', opIndex: 0 }],
+      });
+      await reopened.client.close();
+      reopened.db.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test('restores exact conflict evidence and its one-way resolution lifecycle', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'syncular-conflict-'));
+    const databasePath = join(directory, 'loser.db');
+    const server = makeServer();
+    try {
+      const winner = await makeClient(server, { clientId: 'winner' });
+      const loser = await makeClient(server, {
+        clientId: 'loser',
+        databasePath,
+      });
+      for (const entry of [winner, loser]) {
+        entry.client.subscribe({
+          id: 's1',
+          table: 'tasks',
+          scopes: { project_id: ['conflict'] },
+        });
+      }
+      winner.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('conflict-1', 'conflict', 'base'),
+        },
+      ]);
+      await winner.client.syncUntilIdle();
+      await loser.client.syncUntilIdle();
+      winner.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('conflict-1', 'conflict', 'winner'),
+          baseVersion: 1,
+        },
+      ]);
+      await winner.client.syncUntilIdle();
+      const losingCommitId = loser.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('conflict-1', 'conflict', 'loser'),
+          baseVersion: 1,
+        },
+      ]);
+      await loser.client.syncUntilIdle();
+
+      const outcome = loser.client.commitOutcome(losingCommitId);
+      expect(outcome).toMatchObject({
+        status: 'conflict',
+        resolution: 'active',
+        results: [
+          {
+            status: 'conflict',
+            conflict: {
+              clientCommitId: losingCommitId,
+              opIndex: 0,
+              table: 'tasks',
+              rowId: 'conflict-1',
+              code: 'sync.version_conflict',
+              serverVersion: 2,
+              serverRow: { title: 'winner' },
+              operation: {
+                op: 'upsert',
+                rowId: 'conflict-1',
+                baseVersion: 1,
+              },
+            },
+          },
+        ],
+      });
+      await loser.client.close();
+      loser.db.close();
+
+      const reopened = await makeClient(server, {
+        clientId: 'loser',
+        databasePath,
+      });
+      expect(reopened.client.conflicts).toHaveLength(1);
+      expect(reopened.client.conflicts[0]?.serverRow.title).toBe('winner');
+      const resolved = reopened.client.resolveCommitOutcome({
+        clientCommitId: losingCommitId,
+        resolution: 'resolved_keep_server',
+      });
+      expect(resolved.resolution).toBe('resolved_keep_server');
+      expect(reopened.client.conflicts).toHaveLength(0);
+      // Resolution is one-way and idempotent; a later choice cannot rewrite it.
+      expect(
+        reopened.client.resolveCommitOutcome({
+          clientCommitId: losingCommitId,
+          resolution: 'superseded',
+          replacementClientCommitId: 'replacement',
+        }),
+      ).toEqual(resolved);
+      await reopened.client.close();
+      reopened.db.close();
+
+      const twice = await makeClient(server, {
+        clientId: 'loser',
+        databasePath,
+      });
+      expect(twice.client.conflicts).toHaveLength(0);
+      expect(twice.client.commitOutcome(losingCommitId)?.resolution).toBe(
+        'resolved_keep_server',
+      );
+      await twice.client.close();
+      twice.db.close();
+      await winner.client.close();
+      winner.db.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test('retention never purges unresolved failures and records replacement links', async () => {
+    const server = makeServer();
+    const winner = await makeClient(server, { clientId: 'retention-winner' });
+    const loser = await makeClient(server, {
+      clientId: 'retention-loser',
+      limits: { outcomeRetentionMaxEntries: 1 },
+    });
+    for (const entry of [winner, loser]) {
+      entry.client.subscribe({
+        id: 's1',
+        table: 'tasks',
+        scopes: { project_id: ['retention'] },
+      });
+    }
+    winner.client.mutate([
+      {
+        table: 'tasks',
+        op: 'upsert',
+        values: taskValues('retention-1', 'retention', 'base'),
+      },
+    ]);
+    await winner.client.syncUntilIdle();
+    await loser.client.syncUntilIdle();
+    winner.client.patch(
+      'tasks',
+      'retention-1',
+      { title: 'winner' },
+      {
+        baseVersion: 1,
+      },
+    );
+    await winner.client.syncUntilIdle();
+    const conflictId = loser.client.patch(
+      'tasks',
+      'retention-1',
+      { title: 'loser' },
+      { baseVersion: 1 },
+    );
+    await loser.client.syncUntilIdle();
+    const appliedId = loser.client.mutate([
+      {
+        table: 'tasks',
+        op: 'upsert',
+        values: taskValues('retention-2', 'retention', 'applied'),
+      },
+    ]);
+    await loser.client.syncUntilIdle();
+    expect(loser.client.commitOutcome(conflictId)?.status).toBe('conflict');
+    expect(loser.client.commitOutcome(appliedId)).toBeUndefined();
+
+    const replacementId = loser.client.patch(
+      'tasks',
+      'retention-1',
+      { title: 'replacement' },
+      { baseVersion: 2 },
+    );
+    const resolved = loser.client.resolveCommitOutcome({
+      clientCommitId: conflictId,
+      resolution: 'superseded',
+      replacementClientCommitId: replacementId,
+    });
+    expect(resolved.replacementClientCommitId).toBe(replacementId);
+    await winner.client.close();
+    winner.db.close();
+    await loser.client.close();
+    loser.db.close();
   });
 });
 

--- a/packages/web-client/test/helpers.ts
+++ b/packages/web-client/test/helpers.ts
@@ -200,6 +200,8 @@ export interface TestClient {
 
 export interface MakeClientOptions {
   readonly clientId: string;
+  /** Re-openable local SQLite path; defaults to an isolated in-memory DB. */
+  readonly databasePath?: string;
   readonly actorId?: string;
   readonly schema?: ClientSchema;
   readonly limits?: SyncClientLimits;
@@ -210,7 +212,7 @@ export async function makeClient(
   server: TestServer,
   options: MakeClientOptions,
 ): Promise<TestClient> {
-  const db = new BunClientDatabase();
+  const db = new BunClientDatabase(options.databasePath);
   const actorId = options.actorId ?? 'actor-1';
   const faults: ClientFaults = {
     dropResponseOnce: false,

--- a/packages/web-client/test/reactive-store.test.ts
+++ b/packages/web-client/test/reactive-store.test.ts
@@ -39,6 +39,7 @@ function batch(
     windows: [],
     conflictsChanged: false,
     rejectionsChanged: false,
+    outcomesChanged: false,
     ...overrides,
   };
 }
@@ -105,6 +106,10 @@ class FakeReactiveClient implements ReactiveQueryClient {
 
   rejections(): readonly unknown[] {
     this.rejectionCalls += 1;
+    return [];
+  }
+
+  commitOutcomes(): readonly never[] {
     return [];
   }
 

--- a/packages/web-client/test/worker-rpc.test.ts
+++ b/packages/web-client/test/worker-rpc.test.ts
@@ -125,6 +125,13 @@ test('boot → subscribe → mutate → sync → query, all over the RPC', async
   expect(summary.applied).toEqual([commitId]);
   await handle.syncUntilIdle();
   expect((await handle.pendingCommits()).length).toBe(0);
+  expect(await handle.commitOutcome(commitId)).toMatchObject({
+    status: 'applied',
+    results: [{ status: 'applied', opIndex: 0 }],
+  });
+  expect(
+    (await handle.commitOutcomes()).map((outcome) => outcome.clientCommitId),
+  ).toContain(commitId);
 
   const rows = await handle.query(
     'SELECT id, title, done FROM tasks ORDER BY id',
@@ -239,7 +246,7 @@ test('conflicts surface as RPC events and via conflicts()', async () => {
     },
   ]);
   await b.syncUntilIdle();
-  await a.mutate([
+  const losingCommitId = await a.mutate([
     {
       table: 'tasks',
       op: 'upsert',
@@ -256,6 +263,18 @@ test('conflicts surface as RPC events and via conflicts()', async () => {
   expect(conflicts.length).toBe(1);
   expect(conflicts[0]?.rowId).toBe('t3');
   expect(conflicts[0]?.serverRow.title).toBe('b wins');
+  expect(await a.commitOutcome(losingCommitId)).toMatchObject({
+    status: 'conflict',
+    resolution: 'active',
+  });
+  expect(await a.commitOutcomes({ activeOnly: true })).toHaveLength(1);
+  const resolved = await a.resolveCommitOutcome({
+    clientCommitId: losingCommitId,
+    resolution: 'resolved_keep_server',
+  });
+  expect(resolved.resolution).toBe('resolved_keep_server');
+  expect(await a.conflicts()).toHaveLength(0);
+  expect(await a.commitOutcomes({ activeOnly: true })).toHaveLength(0);
   await waitFor(() => events.conflicts === 1, 'conflict event delivery');
 
   // The losing pane converges to the server row.

--- a/rust/crates/client/src/api.rs
+++ b/rust/crates/client/src/api.rs
@@ -72,6 +72,7 @@ pub struct ClientChangeBatch {
     pub status: Option<SyncStatusSnapshot>,
     pub conflicts_changed: bool,
     pub rejections_changed: bool,
+    pub outcomes_changed: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -242,7 +243,7 @@ impl SyncOutcome {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConflictRecord {
     pub client_commit_id: String,
@@ -250,19 +251,102 @@ pub struct ConflictRecord {
     pub table: String,
     pub row_id: String,
     pub code: String,
+    pub message: String,
     pub server_version: i64,
     /// Driver row (bytes as `{"$bytes": hex}`), decoded from the conflict
     /// record's `serverRow` (§6.3).
     pub server_row: Map<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<CommitOperation>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RejectionRecord {
     pub client_commit_id: String,
     pub op_index: i32,
     pub code: String,
+    pub message: String,
     pub retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<CommitOperation>,
+}
+
+/// Schema-agnostic local operation retained with a failed final outcome.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitOperation {
+    pub table: String,
+    pub row_id: String,
+    pub op: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_version: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<Map<String, Value>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitOutcomeStatus {
+    Applied,
+    Cached,
+    Conflict,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitOutcomeResolution {
+    Active,
+    ResolvedKeepServer,
+    Superseded,
+    Dismissed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CommitOperationOutcome {
+    Applied {
+        #[serde(rename = "opIndex")]
+        op_index: i32,
+    },
+    Conflict {
+        conflict: ConflictRecord,
+    },
+    Error {
+        rejection: RejectionRecord,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitOutcome {
+    pub sequence: i64,
+    pub client_commit_id: String,
+    pub status: CommitOutcomeStatus,
+    pub recorded_at_ms: i64,
+    pub results: Vec<CommitOperationOutcome>,
+    pub resolution: CommitOutcomeResolution,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_at_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement_client_commit_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitOutcomeQuery {
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub active_only: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveCommitOutcomeInput {
+    pub client_commit_id: String,
+    pub resolution: CommitOutcomeResolution,
+    pub replacement_client_commit_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -303,4 +387,7 @@ pub struct ClientLimits {
     /// body sizes exceeds it, zero-ref, non-pinned bodies are evicted LRU-first
     /// after each cache write. `None` ⇒ retain until storage pressure (default).
     pub blob_cache_max_bytes: Option<i64>,
+    /// Maximum durable final outcomes. Active conflicts/rejections are never
+    /// pruned to satisfy the cap. Defaults to 1,000.
+    pub outcome_retention_max_entries: Option<usize>,
 }

--- a/rust/crates/client/src/client.rs
+++ b/rust/crates/client/src/client.rs
@@ -11,7 +11,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 
 use rusqlite::types::{ToSqlOutput, Value as SqlValue, ValueRef};
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use ssp2::model::{Frame, MediaType, Message, MsgKind, Op, OpResult, PushStatus, SubStatus};
@@ -23,10 +23,12 @@ use ssp2::{
 };
 
 use crate::api::{
-    ClientChangeBatch, ClientLimits, CommandEffects, ConflictRecord, CoverageSnapshot, LeaseState,
-    Mutation, PresencePeer, QuerySnapshot, RejectionRecord, RowState, SchemaFloor,
-    SubscriptionStateView, SyncIntent, SyncOutcome, SyncReport, SyncStatusSnapshot, TableChange,
-    WindowBase, WindowChange, WindowCoverage, WindowState, WindowUnitRef,
+    ClientChangeBatch, ClientLimits, CommandEffects, CommitOperation, CommitOperationOutcome,
+    CommitOutcome, CommitOutcomeQuery, CommitOutcomeResolution, CommitOutcomeStatus,
+    ConflictRecord, CoverageSnapshot, LeaseState, Mutation, PresencePeer, QuerySnapshot,
+    RejectionRecord, ResolveCommitOutcomeInput, RowState, SchemaFloor, SubscriptionStateView,
+    SyncIntent, SyncOutcome, SyncReport, SyncStatusSnapshot, TableChange, WindowBase, WindowChange,
+    WindowCoverage, WindowState, WindowUnitRef,
 };
 use crate::schema::{parse_schema_json, ClientSchema};
 use crate::transport::{BlobDownload, BlobUploadGrant, SegmentRequest, Transport, TransportError};
@@ -166,6 +168,126 @@ mod observation_tests {
     }
 
     #[test]
+    fn durable_conflict_outcome_and_resolution_survive_reopen() {
+        let path = std::env::temp_dir().join(format!(
+            "syncular-durable-outcome-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let schema = json!({
+            "version": 1,
+            "tables": [{
+                "name": "tasks",
+                "primaryKey": "id",
+                "columns": [
+                    { "name": "id", "type": "string", "nullable": false },
+                    { "name": "project_id", "type": "string", "nullable": false }
+                ],
+                "scopes": [{ "pattern": "project:{project_id}" }]
+            }]
+        });
+        let conflict = ConflictRecord {
+            client_commit_id: "losing-commit".to_owned(),
+            op_index: 0,
+            table: "tasks".to_owned(),
+            row_id: "t1".to_owned(),
+            code: "sync.version_conflict".to_owned(),
+            message: "stale base version".to_owned(),
+            server_version: 2,
+            server_row: Map::from_iter([("id".to_owned(), json!("t1"))]),
+            operation: Some(CommitOperation {
+                table: "tasks".to_owned(),
+                row_id: "t1".to_owned(),
+                op: "upsert".to_owned(),
+                base_version: Some(1),
+                values: None,
+            }),
+        };
+
+        {
+            let mut first = SyncClient::open_path(
+                "durable-native".to_owned(),
+                &schema,
+                ClientLimits::default(),
+                path.to_str().expect("UTF-8 temp path"),
+            )
+            .expect("first open");
+            first
+                .begin_observation("test_outcome")
+                .expect("begin outcome");
+            first
+                .persist_commit_outcome(
+                    "losing-commit",
+                    CommitOutcomeStatus::Conflict,
+                    &[CommitOperationOutcome::Conflict {
+                        conflict: conflict.clone(),
+                    }],
+                )
+                .expect("persist outcome");
+            first.conflicts.push(conflict);
+            first
+                .finish_observation(
+                    "test_outcome",
+                    ChangeAccumulator {
+                        conflicts: true,
+                        outcomes: true,
+                        ..ChangeAccumulator::default()
+                    },
+                )
+                .expect("commit outcome");
+        }
+
+        {
+            let mut reopened = SyncClient::open_path(
+                "durable-native".to_owned(),
+                &schema,
+                ClientLimits::default(),
+                path.to_str().expect("UTF-8 temp path"),
+            )
+            .expect("reopen");
+            assert_eq!(reopened.conflicts().len(), 1);
+            assert_eq!(
+                reopened
+                    .commit_outcome("losing-commit")
+                    .expect("read outcome")
+                    .expect("outcome")
+                    .status,
+                CommitOutcomeStatus::Conflict
+            );
+            let resolved = reopened
+                .resolve_commit_outcome(ResolveCommitOutcomeInput {
+                    client_commit_id: "losing-commit".to_owned(),
+                    resolution: CommitOutcomeResolution::ResolvedKeepServer,
+                    replacement_client_commit_id: None,
+                })
+                .expect("resolve");
+            assert_eq!(
+                resolved.resolution,
+                CommitOutcomeResolution::ResolvedKeepServer
+            );
+            assert!(reopened.conflicts().is_empty());
+        }
+
+        let reopened = SyncClient::open_path(
+            "durable-native".to_owned(),
+            &schema,
+            ClientLimits::default(),
+            path.to_str().expect("UTF-8 temp path"),
+        )
+        .expect("second reopen");
+        assert!(reopened.conflicts().is_empty());
+        assert_eq!(
+            reopened
+                .commit_outcome("losing-commit")
+                .expect("read outcome")
+                .expect("outcome")
+                .resolution,
+            CommitOutcomeResolution::ResolvedKeepServer
+        );
+        drop(reopened);
+        std::fs::remove_file(path).expect("remove temp database");
+    }
+
+    #[test]
     fn file_snapshot_reader_matches_owner_rows_revision_and_coverage() {
         let path =
             std::env::temp_dir().join(format!("syncular-read-sidecar-{}.db", uuid::Uuid::new_v4()));
@@ -292,6 +414,18 @@ struct OutboxOp {
     values: Option<Map<String, Value>>,
 }
 
+impl From<&OutboxOp> for CommitOperation {
+    fn from(operation: &OutboxOp) -> Self {
+        Self {
+            table: operation.table.clone(),
+            row_id: operation.row_id.clone(),
+            op: if operation.upsert { "upsert" } else { "delete" }.to_owned(),
+            base_version: operation.base_version,
+            values: operation.values.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct OutboxCommit {
     client_commit_id: String,
@@ -325,6 +459,7 @@ struct ChangeAccumulator {
     status: bool,
     conflicts: bool,
     rejections: bool,
+    outcomes: bool,
 }
 
 impl ChangeAccumulator {
@@ -358,6 +493,7 @@ impl ChangeAccumulator {
             || self.status
             || self.conflicts
             || self.rejections
+            || self.outcomes
     }
 }
 
@@ -907,6 +1043,11 @@ impl SyncClient {
         limits: ClientLimits,
         conn: Connection,
     ) -> Result<Self, String> {
+        if limits.outcome_retention_max_entries == Some(0) {
+            return Err(
+                "sync.invalid_request: outcomeRetentionMaxEntries must be positive".to_owned(),
+            );
+        }
         let schema = parse_schema_json(schema_json)?;
         let mut client = SyncClient {
             conn,
@@ -1000,6 +1141,18 @@ impl SyncClient {
                 "CREATE TABLE IF NOT EXISTS _syncular_outbox (
                    seq INTEGER PRIMARY KEY AUTOINCREMENT,
                    commit_id TEXT NOT NULL UNIQUE, ops_json TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS _syncular_commit_outcomes (
+                   seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                   client_commit_id TEXT NOT NULL UNIQUE,
+                   status TEXT NOT NULL CHECK(status IN ('applied', 'cached', 'conflict', 'rejected')),
+                   recorded_at_ms INTEGER NOT NULL,
+                   results_json TEXT NOT NULL,
+                   resolution TEXT NOT NULL DEFAULT 'active'
+                     CHECK(resolution IN ('active', 'resolved_keep_server', 'superseded', 'dismissed')),
+                   resolved_at_ms INTEGER,
+                   replacement_client_commit_id TEXT);
+                 CREATE INDEX IF NOT EXISTS _syncular_commit_outcomes_resolution_seq
+                   ON _syncular_commit_outcomes(resolution, seq);
                  CREATE TABLE IF NOT EXISTS _syncular_subscriptions (
                    id TEXT PRIMARY KEY, tbl TEXT NOT NULL, state_json TEXT NOT NULL);
                  CREATE TABLE IF NOT EXISTS _syncular_meta (
@@ -1184,6 +1337,28 @@ impl SyncClient {
             commits
         };
 
+        self.prune_commit_outcomes()?;
+        let active = self.commit_outcomes(CommitOutcomeQuery {
+            active_only: true,
+            ..CommitOutcomeQuery::default()
+        })?;
+        self.conflicts = active
+            .iter()
+            .flat_map(|outcome| outcome.results.iter())
+            .filter_map(|result| match result {
+                CommitOperationOutcome::Conflict { conflict } => Some(conflict.clone()),
+                _ => None,
+            })
+            .collect();
+        self.rejections = active
+            .iter()
+            .flat_map(|outcome| outcome.results.iter())
+            .filter_map(|result| match result {
+                CommitOperationOutcome::Error { rejection } => Some(rejection.clone()),
+                _ => None,
+            })
+            .collect();
+
         self.lease_state = self
             .get_meta(LEASE_STATE_KEY)
             .map(|raw| serde_json::from_str(&raw))
@@ -1311,6 +1486,7 @@ impl SyncClient {
             status,
             conflicts_changed: batch.conflicts,
             rejections_changed: batch.rejections,
+            outcomes_changed: batch.outcomes,
         };
         self.conn
             .execute_batch(&format!("RELEASE {name}"))
@@ -1580,9 +1756,10 @@ impl SyncClient {
         // §7.4.4: drop outbox commits that cannot re-encode under the new
         // schema (a referenced column/table the bump removed), surfacing each
         // as a `sync.outbox_incompatible` rejection.
-        if self.drop_incompatible_outbox() {
+        if self.drop_incompatible_outbox()? {
             batch.rejections = true;
             batch.status = true;
+            batch.outcomes = true;
         }
         // Re-apply the surviving outbox optimistically over the empty tables.
         self.rebuild_overlay();
@@ -1592,39 +1769,67 @@ impl SyncClient {
     /// §7.4.4: a persisted upsert whose values reference a column the current
     /// schema lacks (or a removed table) cannot be encoded. Drop the commit
     /// and raise a client-local `sync.outbox_incompatible` rejection.
-    fn drop_incompatible_outbox(&mut self) -> bool {
+    fn drop_incompatible_outbox(&mut self) -> Result<bool, String> {
         let schema = &self.schema;
-        let mut incompatible: Vec<String> = Vec::new();
-        self.outbox.retain(|commit| {
-            let bad = commit.ops.iter().any(|op| {
-                if !op.upsert {
-                    return false;
-                }
-                match schema.table(&op.table) {
-                    None => true,
-                    Some(table) => op.values.as_ref().is_some_and(|values| {
-                        values
-                            .keys()
-                            .any(|key| !table.columns.iter().any(|c| &c.name == key))
-                    }),
-                }
-            });
-            if bad {
-                incompatible.push(commit.client_commit_id.clone());
-            }
-            !bad
-        });
-        let changed = !incompatible.is_empty();
-        for client_commit_id in incompatible {
-            self.persist_outbox_delete(&client_commit_id);
-            self.rejections.push(RejectionRecord {
-                client_commit_id,
-                op_index: 0,
-                code: OUTBOX_INCOMPATIBLE_CODE.to_owned(),
-                retryable: false,
-            });
+        let incompatible = self
+            .outbox
+            .iter()
+            .filter(|commit| {
+                commit.ops.iter().any(|op| {
+                    if !op.upsert {
+                        return false;
+                    }
+                    match schema.table(&op.table) {
+                        None => true,
+                        Some(table) => op.values.as_ref().is_some_and(|values| {
+                            values
+                                .keys()
+                                .any(|key| !table.columns.iter().any(|c| &c.name == key))
+                        }),
+                    }
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if incompatible.is_empty() {
+            return Ok(false);
         }
-        changed
+        let mut rejections = Vec::new();
+        for commit in &incompatible {
+            let results = commit
+                .ops
+                .iter()
+                .enumerate()
+                .map(|(op_index, operation)| {
+                    let rejection = RejectionRecord {
+                        client_commit_id: commit.client_commit_id.clone(),
+                        op_index: op_index as i32,
+                        code: OUTBOX_INCOMPATIBLE_CODE.to_owned(),
+                        message: "the persisted commit cannot encode under the current schema"
+                            .to_owned(),
+                        retryable: false,
+                        operation: Some(CommitOperation::from(operation)),
+                    };
+                    rejections.push(rejection.clone());
+                    CommitOperationOutcome::Error { rejection }
+                })
+                .collect::<Vec<_>>();
+            self.persist_commit_outcome(
+                &commit.client_commit_id,
+                CommitOutcomeStatus::Rejected,
+                &results,
+            )?;
+            self.delete_outbox_persisted(&commit.client_commit_id)?;
+        }
+        self.prune_commit_outcomes()?;
+        let incompatible_ids = incompatible
+            .iter()
+            .map(|commit| commit.client_commit_id.as_str())
+            .collect::<BTreeSet<_>>();
+        self.outbox
+            .retain(|commit| !incompatible_ids.contains(commit.client_commit_id.as_str()));
+        self.rejections.extend(rejections);
+        Ok(true)
     }
 
     /// §7.4.3: (re)create the base + visible table pair for every synced
@@ -1710,11 +1915,218 @@ impl SyncClient {
         );
     }
 
-    fn persist_outbox_delete(&self, client_commit_id: &str) {
-        let _ = self.conn.execute(
-            "DELETE FROM _syncular_outbox WHERE commit_id = ?1",
-            rusqlite::params![client_commit_id],
+    fn delete_outbox_persisted(&self, client_commit_id: &str) -> Result<(), String> {
+        self.conn
+            .execute(
+                "DELETE FROM _syncular_outbox WHERE commit_id = ?1",
+                rusqlite::params![client_commit_id],
+            )
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    fn outcome_status_name(status: CommitOutcomeStatus) -> &'static str {
+        match status {
+            CommitOutcomeStatus::Applied => "applied",
+            CommitOutcomeStatus::Cached => "cached",
+            CommitOutcomeStatus::Conflict => "conflict",
+            CommitOutcomeStatus::Rejected => "rejected",
+        }
+    }
+
+    fn outcome_resolution_name(resolution: CommitOutcomeResolution) -> &'static str {
+        match resolution {
+            CommitOutcomeResolution::Active => "active",
+            CommitOutcomeResolution::ResolvedKeepServer => "resolved_keep_server",
+            CommitOutcomeResolution::Superseded => "superseded",
+            CommitOutcomeResolution::Dismissed => "dismissed",
+        }
+    }
+
+    fn parse_outcome_status(value: &str) -> Result<CommitOutcomeStatus, String> {
+        match value {
+            "applied" => Ok(CommitOutcomeStatus::Applied),
+            "cached" => Ok(CommitOutcomeStatus::Cached),
+            "conflict" => Ok(CommitOutcomeStatus::Conflict),
+            "rejected" => Ok(CommitOutcomeStatus::Rejected),
+            _ => Err(format!("invalid persisted commit outcome status {value:?}")),
+        }
+    }
+
+    fn parse_outcome_resolution(value: &str) -> Result<CommitOutcomeResolution, String> {
+        match value {
+            "active" => Ok(CommitOutcomeResolution::Active),
+            "resolved_keep_server" => Ok(CommitOutcomeResolution::ResolvedKeepServer),
+            "superseded" => Ok(CommitOutcomeResolution::Superseded),
+            "dismissed" => Ok(CommitOutcomeResolution::Dismissed),
+            _ => Err(format!(
+                "invalid persisted commit outcome resolution {value:?}"
+            )),
+        }
+    }
+
+    fn persist_commit_outcome(
+        &self,
+        client_commit_id: &str,
+        status: CommitOutcomeStatus,
+        results: &[CommitOperationOutcome],
+    ) -> Result<(), String> {
+        let results_json = serde_json::to_string(results).map_err(|error| error.to_string())?;
+        self.conn
+            .execute(
+                "INSERT INTO _syncular_commit_outcomes (
+                   client_commit_id, status, recorded_at_ms, results_json, resolution
+                 ) VALUES (?1, ?2, ?3, ?4, 'active')",
+                rusqlite::params![
+                    client_commit_id,
+                    Self::outcome_status_name(status),
+                    self.clock_now_ms(),
+                    results_json
+                ],
+            )
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    fn outcome_from_tuple(
+        row: (
+            i64,
+            String,
+            String,
+            i64,
+            String,
+            String,
+            Option<i64>,
+            Option<String>,
+        ),
+    ) -> Result<CommitOutcome, String> {
+        let (
+            sequence,
+            client_commit_id,
+            status,
+            recorded_at_ms,
+            results_json,
+            resolution,
+            resolved_at_ms,
+            replacement_client_commit_id,
+        ) = row;
+        Ok(CommitOutcome {
+            sequence,
+            client_commit_id,
+            status: Self::parse_outcome_status(&status)?,
+            recorded_at_ms,
+            results: serde_json::from_str(&results_json)
+                .map_err(|error| format!("invalid persisted commit outcome results: {error}"))?,
+            resolution: Self::parse_outcome_resolution(&resolution)?,
+            resolved_at_ms,
+            replacement_client_commit_id,
+        })
+    }
+
+    pub fn commit_outcome(&self, client_commit_id: &str) -> Result<Option<CommitOutcome>, String> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT seq, client_commit_id, status, recorded_at_ms, results_json,
+                        resolution, resolved_at_ms, replacement_client_commit_id
+                   FROM _syncular_commit_outcomes WHERE client_commit_id = ?1",
+                rusqlite::params![client_commit_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())?;
+        row.map(Self::outcome_from_tuple).transpose()
+    }
+
+    pub fn commit_outcomes(&self, query: CommitOutcomeQuery) -> Result<Vec<CommitOutcome>, String> {
+        if query.limit == Some(0) {
+            return Err("sync.invalid_request: commit outcome limit must be positive".to_owned());
+        }
+        let mut sql = String::from(
+            "SELECT seq, client_commit_id, status, recorded_at_ms, results_json,
+                    resolution, resolved_at_ms, replacement_client_commit_id
+               FROM _syncular_commit_outcomes",
         );
+        if query.active_only {
+            sql.push_str(" WHERE resolution = 'active' AND status IN ('conflict', 'rejected')");
+        }
+        sql.push_str(" ORDER BY seq DESC");
+        if let Some(limit) = query.limit {
+            sql.push_str(&format!(" LIMIT {limit}"));
+        }
+        let mut stmt = self.conn.prepare(&sql).map_err(|error| error.to_string())?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            })
+            .map_err(|error| error.to_string())?;
+        let mut outcomes = Vec::new();
+        for row in rows {
+            outcomes.push(Self::outcome_from_tuple(
+                row.map_err(|error| error.to_string())?,
+            )?);
+        }
+        Ok(outcomes)
+    }
+
+    fn prune_commit_outcomes(&self) -> Result<(), String> {
+        let max_entries = self.limits.outcome_retention_max_entries.unwrap_or(1_000);
+        let count = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM _syncular_commit_outcomes",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|error| error.to_string())? as usize;
+        let excess = count.saturating_sub(max_entries);
+        if excess == 0 {
+            return Ok(());
+        }
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT seq FROM _syncular_commit_outcomes
+                  WHERE status IN ('applied', 'cached') OR resolution != 'active'
+                  ORDER BY seq ASC LIMIT ?1",
+            )
+            .map_err(|error| error.to_string())?;
+        let rows = stmt
+            .query_map(rusqlite::params![excess as i64], |row| row.get::<_, i64>(0))
+            .map_err(|error| error.to_string())?;
+        let sequences = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        drop(stmt);
+        for sequence in sequences {
+            self.conn
+                .execute(
+                    "DELETE FROM _syncular_commit_outcomes WHERE seq = ?1",
+                    rusqlite::params![sequence],
+                )
+                .map_err(|error| error.to_string())?;
+        }
+        Ok(())
     }
 
     // -- driver surface ---------------------------------------------------------
@@ -2251,6 +2663,109 @@ impl SyncClient {
 
     pub fn rejections(&self) -> &[RejectionRecord] {
         &self.rejections
+    }
+
+    pub fn resolve_commit_outcome(
+        &mut self,
+        input: ResolveCommitOutcomeInput,
+    ) -> Result<CommitOutcome, String> {
+        let current = self
+            .commit_outcome(&input.client_commit_id)?
+            .ok_or_else(|| {
+                format!(
+                    "sync.outcome_not_found: no durable outcome exists for {:?}",
+                    input.client_commit_id
+                )
+            })?;
+        if current.resolution != CommitOutcomeResolution::Active {
+            return Ok(current);
+        }
+        if input.resolution == CommitOutcomeResolution::Active {
+            return Err("sync.invalid_request: resolution must leave active state".to_owned());
+        }
+        match input.resolution {
+            CommitOutcomeResolution::Superseded => {
+                let replacement = input
+                    .replacement_client_commit_id
+                    .as_deref()
+                    .filter(|value| !value.is_empty() && *value != input.client_commit_id)
+                    .ok_or_else(|| {
+                        "sync.invalid_request: superseded outcomes require a distinct replacementClientCommitId"
+                            .to_owned()
+                    })?;
+                let _ = replacement;
+            }
+            _ if input.replacement_client_commit_id.is_some() => {
+                return Err(
+                    "sync.invalid_request: replacementClientCommitId is valid only for superseded outcomes"
+                        .to_owned(),
+                );
+            }
+            _ => {}
+        }
+        let allowed = match current.status {
+            CommitOutcomeStatus::Conflict => matches!(
+                input.resolution,
+                CommitOutcomeResolution::ResolvedKeepServer | CommitOutcomeResolution::Superseded
+            ),
+            CommitOutcomeStatus::Rejected => {
+                input.resolution == CommitOutcomeResolution::Superseded
+            }
+            CommitOutcomeStatus::Applied | CommitOutcomeStatus::Cached => {
+                input.resolution == CommitOutcomeResolution::Dismissed
+            }
+        };
+        if !allowed {
+            return Err(format!(
+                "sync.invalid_request: resolution {:?} is invalid for {:?} outcome",
+                input.resolution, current.status
+            ));
+        }
+
+        self.begin_observation("syncular_outcome_resolution")?;
+        let result = (|| {
+            self.conn
+                .execute(
+                    "UPDATE _syncular_commit_outcomes
+                        SET resolution = ?1, resolved_at_ms = ?2,
+                            replacement_client_commit_id = ?3
+                      WHERE client_commit_id = ?4 AND resolution = 'active'",
+                    rusqlite::params![
+                        Self::outcome_resolution_name(input.resolution),
+                        self.clock_now_ms(),
+                        input.replacement_client_commit_id,
+                        input.client_commit_id
+                    ],
+                )
+                .map_err(|error| error.to_string())?;
+            let resolved = self
+                .commit_outcome(&current.client_commit_id)?
+                .ok_or_else(|| "sync.outcome_not_found: outcome disappeared".to_owned())?;
+            self.prune_commit_outcomes()?;
+            Ok(resolved)
+        })();
+        let resolved = match result {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                self.rollback_observation("syncular_outcome_resolution");
+                return Err(error);
+            }
+        };
+        self.conflicts
+            .retain(|record| record.client_commit_id != current.client_commit_id);
+        self.rejections
+            .retain(|record| record.client_commit_id != current.client_commit_id);
+        let batch = ChangeAccumulator {
+            conflicts: current.status == CommitOutcomeStatus::Conflict,
+            rejections: current.status == CommitOutcomeStatus::Rejected,
+            outcomes: true,
+            ..ChangeAccumulator::default()
+        };
+        if let Err(error) = self.finish_observation("syncular_outcome_resolution", batch) {
+            self.rollback_observation("syncular_outcome_resolution");
+            return Err(error);
+        }
+        Ok(resolved)
     }
 
     pub fn schema_floor(&self) -> Option<&SchemaFloor> {
@@ -3004,102 +3519,170 @@ impl SyncClient {
         }
         let mut batch = ChangeAccumulator::default();
         let operations = self.outbox[index].ops.clone();
-        // Every non-retryable outcome below removes the commit from the
-        // outbox, so the optimistic overlay must be rebuilt.
-        self.overlay_dirty.set(true);
         match status {
             PushStatus::Applied | PushStatus::Cached => {
                 // §7.2: a lost ack replays as `cached` — proceed as if the
                 // ack had arrived.
+                let journal_results = results
+                    .iter()
+                    .map(|result| {
+                        let op_index = match result {
+                            OpResult::Applied { op_index }
+                            | OpResult::Conflict { op_index, .. }
+                            | OpResult::Error { op_index, .. } => *op_index,
+                        };
+                        CommitOperationOutcome::Applied { op_index }
+                    })
+                    .collect::<Vec<_>>();
+                let outcome_status = if status == PushStatus::Applied {
+                    CommitOutcomeStatus::Applied
+                } else {
+                    CommitOutcomeStatus::Cached
+                };
+                if self
+                    .persist_commit_outcome(client_commit_id, outcome_status, &journal_results)
+                    .and_then(|()| self.delete_outbox_persisted(client_commit_id))
+                    .and_then(|()| self.prune_commit_outcomes())
+                    .is_err()
+                {
+                    self.rollback_observation("syncular_push_result");
+                    return;
+                }
                 report.applied.push(client_commit_id.to_owned());
                 self.outbox.remove(index);
-                self.persist_outbox_delete(client_commit_id);
+                self.overlay_dirty.set(true);
                 batch.status = true;
+                batch.outcomes = true;
             }
             PushStatus::Rejected => {
-                let terminating = results
-                    .iter()
-                    .find(|r| !matches!(r, OpResult::Applied { .. }));
-                match terminating {
-                    Some(OpResult::Conflict {
-                        op_index,
-                        code,
-                        message: _,
-                        server_version,
-                        server_row,
-                    }) => {
-                        let commit = &self.outbox[index];
-                        let (table, row_id) = commit
-                            .ops
-                            .get(*op_index as usize)
-                            .map(|op| (op.table.clone(), op.row_id.clone()))
-                            .unwrap_or_default();
-                        let server_row_json = self
-                            .schema
-                            .table(&table)
-                            .and_then(|t| {
-                                decode_row_bytes(t, server_row, &self.encryption)
-                                    .ok()
-                                    .map(|row| (t, row))
-                            })
-                            .map(|(t, row)| {
-                                let mut map = Map::new();
-                                for (i, column) in t.columns.iter().enumerate() {
-                                    map.insert(
-                                        column.name.clone(),
-                                        column_value_to_json(row.get(i).unwrap_or(&None)),
-                                    );
-                                }
-                                map
-                            })
-                            .unwrap_or_default();
-                        self.conflicts.push(ConflictRecord {
-                            client_commit_id: client_commit_id.to_owned(),
-                            op_index: *op_index,
-                            table,
-                            row_id,
-                            code: code.clone(),
-                            server_version: *server_version,
-                            server_row: server_row_json,
-                        });
-                        batch.conflicts = true;
-                        report.conflicts += 1;
-                        report.rejected.push(client_commit_id.to_owned());
-                        self.outbox.remove(index);
-                        self.persist_outbox_delete(client_commit_id);
-                        batch.status = true;
+                if results.iter().any(|result| {
+                    matches!(
+                        result,
+                        OpResult::Error {
+                            code,
+                            retryable: true,
+                            ..
+                        } if code == "sync.idempotency_cache_miss"
+                    )
+                }) {
+                    // §6.3/§7.2: a serving failure, not an outcome — keep the
+                    // exact commit queued for an identical retry.
+                    report.retryable.push(client_commit_id.to_owned());
+                    if self
+                        .finish_observation("syncular_push_result", batch)
+                        .is_err()
+                    {
+                        self.rollback_observation("syncular_push_result");
                     }
-                    Some(OpResult::Error {
-                        op_index,
-                        code,
-                        message: _,
-                        retryable,
-                    }) => {
-                        if code == "sync.idempotency_cache_miss" {
-                            // §6.3/§7.2: a serving failure, not an outcome —
-                            // the commit stays queued for an identical retry.
-                            report.retryable.push(client_commit_id.to_owned());
-                        } else {
-                            self.rejections.push(RejectionRecord {
+                    return;
+                }
+
+                let mut journal_results = Vec::with_capacity(results.len());
+                let mut conflicts = Vec::new();
+                let mut rejections = Vec::new();
+                for result in results {
+                    match result {
+                        OpResult::Applied { op_index } => {
+                            journal_results.push(CommitOperationOutcome::Applied {
+                                op_index: *op_index,
+                            });
+                        }
+                        OpResult::Conflict {
+                            op_index,
+                            code,
+                            message,
+                            server_version,
+                            server_row,
+                        } => {
+                            let operation = operations
+                                .get(*op_index as usize)
+                                .map(CommitOperation::from);
+                            let (table, row_id) = operation
+                                .as_ref()
+                                .map(|op| (op.table.clone(), op.row_id.clone()))
+                                .unwrap_or_default();
+                            let server_row_json = self
+                                .schema
+                                .table(&table)
+                                .and_then(|t| {
+                                    decode_row_bytes(t, server_row, &self.encryption)
+                                        .ok()
+                                        .map(|row| (t, row))
+                                })
+                                .map(|(t, row)| {
+                                    let mut map = Map::new();
+                                    for (i, column) in t.columns.iter().enumerate() {
+                                        map.insert(
+                                            column.name.clone(),
+                                            column_value_to_json(row.get(i).unwrap_or(&None)),
+                                        );
+                                    }
+                                    map
+                                })
+                                .unwrap_or_default();
+                            let conflict = ConflictRecord {
+                                client_commit_id: client_commit_id.to_owned(),
+                                op_index: *op_index,
+                                table,
+                                row_id,
+                                code: code.clone(),
+                                message: message.clone(),
+                                server_version: *server_version,
+                                server_row: server_row_json,
+                                operation,
+                            };
+                            journal_results.push(CommitOperationOutcome::Conflict {
+                                conflict: conflict.clone(),
+                            });
+                            conflicts.push(conflict);
+                        }
+                        OpResult::Error {
+                            op_index,
+                            code,
+                            message,
+                            retryable,
+                        } => {
+                            let rejection = RejectionRecord {
                                 client_commit_id: client_commit_id.to_owned(),
                                 op_index: *op_index,
                                 code: code.clone(),
+                                message: message.clone(),
                                 retryable: *retryable,
+                                operation: operations
+                                    .get(*op_index as usize)
+                                    .map(CommitOperation::from),
+                            };
+                            journal_results.push(CommitOperationOutcome::Error {
+                                rejection: rejection.clone(),
                             });
-                            batch.rejections = true;
-                            report.rejected.push(client_commit_id.to_owned());
-                            self.outbox.remove(index);
-                            self.persist_outbox_delete(client_commit_id);
-                            batch.status = true;
+                            rejections.push(rejection);
                         }
                     }
-                    _ => {
-                        report.rejected.push(client_commit_id.to_owned());
-                        self.outbox.remove(index);
-                        self.persist_outbox_delete(client_commit_id);
-                        batch.status = true;
-                    }
                 }
+                let outcome_status = if conflicts.is_empty() {
+                    CommitOutcomeStatus::Rejected
+                } else {
+                    CommitOutcomeStatus::Conflict
+                };
+                if self
+                    .persist_commit_outcome(client_commit_id, outcome_status, &journal_results)
+                    .and_then(|()| self.delete_outbox_persisted(client_commit_id))
+                    .and_then(|()| self.prune_commit_outcomes())
+                    .is_err()
+                {
+                    self.rollback_observation("syncular_push_result");
+                    return;
+                }
+                report.conflicts += conflicts.len() as u32;
+                report.rejected.push(client_commit_id.to_owned());
+                batch.conflicts = !conflicts.is_empty();
+                batch.rejections = !rejections.is_empty();
+                batch.status = true;
+                batch.outcomes = true;
+                self.conflicts.extend(conflicts);
+                self.rejections.extend(rejections);
+                self.outbox.remove(index);
+                self.overlay_dirty.set(true);
             }
         }
         if batch.status {
@@ -3163,10 +3746,15 @@ impl SyncClient {
                         let doomed_effective = effective;
                         let sub_table = table;
                         self.persist_sub(&self.subs[sub_index].clone());
-                        let outbox_before = self.outbox.len();
-                        self.drop_doomed_outbox(&sub_table, &doomed_effective);
-                        if self.outbox.len() != outbox_before {
+                        let dropped = self
+                            .drop_doomed_outbox(&sub_table, &doomed_effective)
+                            .map_err(|message| {
+                                SectionError::Abort("storage.failed".to_owned(), message)
+                            })?;
+                        if dropped {
                             batch.status = true;
+                            batch.rejections = true;
+                            batch.outcomes = true;
                         }
                         // §5.9.7 B2: revocation deletes now-unauthorized blob
                         // bodies (evicted ≠ revoked).
@@ -3872,21 +4460,25 @@ impl SyncClient {
 
     /// §3.3: drop pending commits whose upserts provably land in the
     /// revoked effective scopes — whole-commit, never per-operation.
-    fn drop_doomed_outbox(&mut self, table_name: &str, effective: &[(String, Vec<String>)]) {
+    fn drop_doomed_outbox(
+        &mut self,
+        table_name: &str,
+        effective: &[(String, Vec<String>)],
+    ) -> Result<bool, String> {
         if effective.is_empty() {
-            return;
+            return Ok(false);
         }
         let Some(table) = self.schema.table(table_name).cloned() else {
-            return;
+            return Ok(false);
         };
         let mut mappings: Vec<(&str, &Vec<String>)> = Vec::new();
         for (variable, values) in effective {
             match table.scope_column(variable) {
                 Some(column) => mappings.push((column, values)),
-                None => return, // not provable without a mapping
+                None => return Ok(false), // not provable without a mapping
             }
         }
-        let doomed: Vec<String> = self
+        let doomed: Vec<OutboxCommit> = self
             .outbox
             .iter()
             .filter(|commit| {
@@ -3904,13 +4496,48 @@ impl SyncClient {
                         })
                 })
             })
-            .map(|c| c.client_commit_id.clone())
+            .cloned()
             .collect();
-        for id in doomed {
-            self.overlay_dirty.set(true);
-            self.outbox.retain(|c| c.client_commit_id != id);
-            self.persist_outbox_delete(&id);
+        if doomed.is_empty() {
+            return Ok(false);
         }
+        let mut rejections = Vec::new();
+        for commit in &doomed {
+            let results = commit
+                .ops
+                .iter()
+                .enumerate()
+                .map(|(op_index, operation)| {
+                    let rejection = RejectionRecord {
+                        client_commit_id: commit.client_commit_id.clone(),
+                        op_index: op_index as i32,
+                        code: "sync.scope_revoked".to_owned(),
+                        message: "the commit was dropped because its effective scope was revoked"
+                            .to_owned(),
+                        retryable: false,
+                        operation: Some(CommitOperation::from(operation)),
+                    };
+                    rejections.push(rejection.clone());
+                    CommitOperationOutcome::Error { rejection }
+                })
+                .collect::<Vec<_>>();
+            self.persist_commit_outcome(
+                &commit.client_commit_id,
+                CommitOutcomeStatus::Rejected,
+                &results,
+            )?;
+            self.delete_outbox_persisted(&commit.client_commit_id)?;
+        }
+        self.prune_commit_outcomes()?;
+        let doomed_ids = doomed
+            .iter()
+            .map(|commit| commit.client_commit_id.as_str())
+            .collect::<BTreeSet<_>>();
+        self.outbox
+            .retain(|commit| !doomed_ids.contains(commit.client_commit_id.as_str()));
+        self.rejections.extend(rejections);
+        self.overlay_dirty.set(true);
+        Ok(true)
     }
 
     // -- blobs (§5.9) ----------------------------------------------------------------

--- a/rust/crates/client/src/lib.rs
+++ b/rust/crates/client/src/lib.rs
@@ -28,9 +28,11 @@ pub mod transport;
 pub mod values;
 
 pub use api::{
-    ClientChangeBatch, ClientLimits, CommandEffects, ConflictRecord, CoverageSnapshot, Mutation,
-    PresencePeer, QuerySnapshot, RejectionRecord, RowState, SchemaFloor, SubscriptionStateView,
-    SyncIntent, SyncOutcome, SyncReport, SyncStatusSnapshot, TableChange, WindowBase, WindowChange,
+    ClientChangeBatch, ClientLimits, CommandEffects, CommitOperation, CommitOperationOutcome,
+    CommitOutcome, CommitOutcomeQuery, CommitOutcomeResolution, CommitOutcomeStatus,
+    ConflictRecord, CoverageSnapshot, Mutation, PresencePeer, QuerySnapshot, RejectionRecord,
+    ResolveCommitOutcomeInput, RowState, SchemaFloor, SubscriptionStateView, SyncIntent,
+    SyncOutcome, SyncReport, SyncStatusSnapshot, TableChange, WindowBase, WindowChange,
     WindowCoverage, WindowState, WindowUnitRef,
 };
 pub use client::{FileQuerySnapshotReader, SyncClient};

--- a/rust/crates/command/src/lib.rs
+++ b/rust/crates/command/src/lib.rs
@@ -20,7 +20,8 @@ use ssp2::{
     ControlMessage,
 };
 use syncular_client::{
-    ClientLimits, CommandEffects, Mutation, SyncClient, Transport, WindowBase, WindowCoverage,
+    ClientLimits, CommandEffects, CommitOutcomeQuery, Mutation, ResolveCommitOutcomeInput,
+    SyncClient, Transport, WindowBase, WindowCoverage,
 };
 
 // -- bytes <-> {"$bytes": hex} (the driver-protocol byte envelope) ----------
@@ -62,7 +63,7 @@ fn client_err(message: String) -> CommandError {
     let code = message
         .split_once(':')
         .map(|(candidate, _)| candidate)
-        .filter(|candidate| candidate.starts_with("client."))
+        .filter(|candidate| candidate.starts_with("client.") || candidate.starts_with("sync."))
         .unwrap_or("client.failed");
     (code.to_owned(), message)
 }
@@ -95,6 +96,10 @@ pub fn parse_limits(value: Option<&Value>) -> ClientLimits {
         .and_then(Value::as_u64)
         .map(|v| v as u8);
     limits.blob_cache_max_bytes = object.get("blobCacheMaxBytes").and_then(Value::as_i64);
+    limits.outcome_retention_max_entries = object
+        .get("outcomeRetentionMaxEntries")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize);
     limits
 }
 
@@ -567,6 +572,52 @@ pub fn dispatch<T: Transport>(
         "rejections" => {
             let rejections = need_client(client)?.rejections().to_vec();
             Ok(json!({ "rejections": rejections }))
+        }
+        "commitOutcome" => {
+            let client_commit_id = params
+                .get("clientCommitId")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    client_err(
+                        "sync.invalid_request: commitOutcome missing clientCommitId".to_owned(),
+                    )
+                })?;
+            let outcome = need_client(client)?
+                .commit_outcome(client_commit_id)
+                .map_err(client_err)?;
+            Ok(json!({ "outcome": outcome }))
+        }
+        "commitOutcomes" => {
+            let query = serde_json::from_value::<CommitOutcomeQuery>(
+                params.get("query").cloned().unwrap_or_else(|| json!({})),
+            )
+            .map_err(|error| {
+                client_err(format!(
+                    "sync.invalid_request: invalid commit outcome query: {error}"
+                ))
+            })?;
+            let outcomes = need_client(client)?
+                .commit_outcomes(query)
+                .map_err(client_err)?;
+            Ok(json!({ "outcomes": outcomes }))
+        }
+        "resolveCommitOutcome" => {
+            let input = serde_json::from_value::<ResolveCommitOutcomeInput>(
+                params.get("input").cloned().ok_or_else(|| {
+                    client_err(
+                        "sync.invalid_request: resolveCommitOutcome missing input".to_owned(),
+                    )
+                })?,
+            )
+            .map_err(|error| {
+                client_err(format!(
+                    "sync.invalid_request: invalid outcome resolution: {error}"
+                ))
+            })?;
+            let outcome = need_client(client)?
+                .resolve_commit_outcome(input)
+                .map_err(client_err)?;
+            Ok(json!({ "outcome": outcome }))
         }
         "pendingCommitIds" => {
             let ids = need_client(client)?.pending_commit_ids();


### PR DESCRIPTION
## Summary

- persist final applied, cached, conflict, and rejected commit outcomes atomically with outbox drain
- restore unresolved failures across restarts and add explicit one-way resolution with replacement linkage
- expose outcome APIs/events across TypeScript, Rust, workers, React, Tauri, and React Native
- protect active failures from configurable retention pruning
- prepare the lockstep 0.8.0 release

## Verification

- `bun run check` (1189 tests across main + isolated suites)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Tauri, React Native, and Swift binding checks
- package and sites builds
- `git diff --check` / `bun run version:check`

Kotlin and Flutter binding checks were not run locally because this machine does not have a working JDK 21+ or Dart/Flutter SDK; their unchanged native surfaces are covered by CI.