### PR TITLE
Add structured rejection recovery metadata

### DIFF
--- a/apps/docs/src/content/concepts-conflicts.md
+++ b/apps/docs/src/content/concepts-conflicts.md
@@ -60,6 +60,22 @@ client.conflicts; // readonly ConflictRecord[]
 Without a `baseVersion`, upserts are last-write-wins on the server; conflicts
 only arise when you opt into version checking.
 
+For an edit form, prefer `patch` after reading the row locally. It still sends
+the full row required by the wire protocol, but records the fields the user
+actually changed in local durable metadata:
+
+```ts
+client.patch('notes', 'n1', { body: 'revised' }, { baseVersion: 3 });
+
+const [conflict] = client.conflicts;
+conflict.operation?.changedFields; // ['body']
+```
+
+`changedFields` survives restart and is available on both conflict and
+rejection records. It is never sent to or trusted by the server. A full-row
+`mutate` intentionally omits it because Syncular cannot safely infer user
+intent by diffing against a changing local base.
+
 ## Rejections vs conflicts
 
 A rejected commit that is not a version conflict (e.g. `sync.forbidden` from a
@@ -67,3 +83,51 @@ scope check, or a serving hiccup that is retryable) surfaces as a
 **rejection** instead, with its own list (`client.rejections`) and retry
 semantics driven by the error's `retryable` flag. The
 [error catalog](https://github.com/syncular/syncular/blob/main/docs/SPEC.md#10-errors) is normative.
+
+## Safe, structured validation recovery
+
+A server write validator can attach a small, strictly bounded recovery object
+to a deliberate host rejection:
+
+```ts
+import { ValidationRejection } from '@syncular/server';
+
+const validators = {
+  notes: ({ row }) => {
+    if (typeof row?.body === 'string' && row.body.length > 500) {
+      throw new ValidationRejection('notes.body_too_long', 'diagnostic only', {
+        fieldPaths: ['body'],
+        reason: 'max_length_exceeded',
+        requiredAction: 'edit_fields',
+        references: { limit: '500' },
+      });
+    }
+  },
+};
+```
+
+After sync, the client persists that object with the durable rejection:
+
+```ts
+const [rejection] = client.rejections;
+rejection.code;                         // 'notes.body_too_long'
+rejection.details?.fieldPaths;          // ['body']
+rejection.details?.requiredAction;      // 'edit_fields'
+rejection.operation?.changedFields;     // the local patch intent, if known
+```
+
+Only put non-sensitive, explicitly approved machine values in `details`.
+Syncular rejects unknown keys, free-form values, malformed paths, and data over
+the protocol limits. Map known codes and tokens to localized app copy; do not
+render the server's diagnostic `message` directly to an end user. Older
+clients ignore the additive details frame and still process the ordinary
+rejection, while newer clients also accept older servers that omit details.
+
+## Durable correction flow
+
+Final outcomes are journaled in the same local transaction that drains the
+outbox. Use `commitOutcome(id)` or `commitOutcomes({ activeOnly: true })` to
+restore recovery UI after restart. Once the user keeps the server value or
+creates a corrected replacement commit, call `resolveCommitOutcome(...)`;
+resolution is explicit and one-way, so the app never silently loses evidence
+of an offline write that did not land.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,31 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.8.0** (`v0.8.0`). All artifacts use Apache-2.0, except
+current release is **0.9.0** (`v0.9.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.9.0 release notes
+
+0.9.0 makes offline correction UI precise without putting application edit
+intent or arbitrary server diagnostics on the wire.
+
+The release includes:
+
+- bounded, privacy-safe `RejectionDetails` for deliberate write-validator
+  failures: field paths, stable reason/action tokens, and explicitly approved
+  non-sensitive references;
+- an additive `PUSH_RESULT_DETAILS` companion frame on `0x1B`, preserving
+  compatibility with older clients and older servers while keeping the legacy
+  `PUSH_RESULT` record unchanged;
+- idempotent server persistence and durable TypeScript/Rust client persistence
+  of structured details, including restart recovery;
+- local-only `changedFields` intent for `patch` operations, retained through
+  conflicts, rejections, final-outcome journaling, and restart without entering
+  `PUSH_COMMIT` or becoming server-trusted data;
+- matching TypeScript/Rust conformance scenarios, strict companion-frame
+  validation, WebSocket/HTTP validator parity, and app-facing test-kit coverage;
+- expanded conflict, validator, correction, and multi-client test guidance,
+  plus corrected published `@syncular/testkit` installation instructions.
 
 ## 0.8.0 release notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -303,7 +303,7 @@ Rules:
    *either* message kind: a frame type registered for the other message
    kind (e.g. `SUB_START` in a request) is not unknown — it is a decode
    error. Registry entries that are *reserved* without a message kind
-   (`0x17`, `0x18`, `0x1A`, `0x20`–`0x2F`) have no layout in wire version 1 and
+   (`0x17`, `0x18`, `0x1A`, `0x1C`–`0x1E`, `0x20`–`0x2F`) have no layout in wire version 1 and
    are therefore unknown — skippable, not errors — until a future
    version assigns them one. Preservation is the **only** source of
    unknown frames on the encode side: an encoder MUST NOT emit an
@@ -341,6 +341,7 @@ Frame type registry (wire version 1):
 | `0x18` | *reserved* (CRDT state vectors) | — | §0 |
 | `0x19` | `LEASE` | response | 7.3.2 |
 | `0x1A` | *reserved* (request-side lease assertion) | — | §7.3.2 |
+| `0x1B` | `PUSH_RESULT_DETAILS` | response | 6.3.1 |
 | `0x1F` | `ERROR` | response | 1.6 |
 | `0x20`–`0x2F` | *reserved* (realtime extensions, presence) | — | §8.6 |
 
@@ -422,7 +423,9 @@ envelope codec rejects a no-content request as a **decode error** under
 ```
 RESP_HEADER                     exactly once, first
 LEASE                           0 or 1 (§7.3.2), immediately after RESP_HEADER
-PUSH_RESULT × N                 one per PUSH_COMMIT, in request order
+(PUSH_RESULT [PUSH_RESULT_DETAILS]) × N
+                                one result per PUSH_COMMIT, in request order;
+                                optional details immediately follow their result
 per subscription, in request order:
   SUB_START
   COMMIT × k                    incremental changes (§4.5)
@@ -2454,6 +2457,55 @@ Semantics:
   subsequent occurrences return the persisted result per the replay rule
   (§2.3): `cached` if it applied, `rejected` if it rejected.
 
+#### 6.3.1 `PUSH_RESULT_DETAILS` additive companion frame
+
+A server MAY emit one `PUSH_RESULT_DETAILS` immediately after a rejected
+`PUSH_RESULT` when at least one terminating error carries host-approved
+recovery metadata. This is a new frame rather than an extension of the
+`PUSH_RESULT` record so a client that predates this section treats it as an
+unknown frame, preserves or skips it under §1.2, and still processes the
+legacy result unchanged. A client that understands this frame MUST continue
+to accept a response which omits it.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `clientCommitId` | `str` | Matches the immediately preceding rejected `PUSH_RESULT` |
+| `entries` | `u32` count × detail entry | Non-empty; at most one entry for each terminating error operation |
+
+Detail entry:
+
+| Field | Type | Semantics |
+|---|---|---|
+| `opIndex` | `i32` | Unique, non-negative index of an `error` record in the companion result |
+| `detailsJson` | `str` | UTF-8 JSON object conforming to the bounded shape below |
+
+The normalized `detailsJson` object has only these optional members and MUST
+contain at least one of them:
+
+| Member | Shape | Semantics |
+|---|---|---|
+| `fieldPaths` | 1–32 unique schema paths | Fields the app may focus or explain; each path is at most 160 characters and matches `identifier(.identifier)*` |
+| `reason` | stable token | Machine reason, at most 96 characters |
+| `requiredAction` | stable token | Machine recovery action, at most 96 characters |
+| `references` | 1–16 string entries | Explicitly approved, non-sensitive recovery identifiers; keys are stable tokens ≤ 64 characters and trimmed values contain no control characters and are ≤ 256 UTF-8 bytes |
+
+`reason`, `requiredAction`, and reference keys use lowercase code-like tokens:
+`[a-z][a-z0-9]*([._-][a-z0-9]+)*`. The encoded normalized JSON object MUST
+not exceed 4,096 bytes. Unknown members, duplicates, empty members, malformed
+paths or tokens, and over-limit values are decode errors. The details frame
+MUST NOT carry diagnostic prose, stack traces, arbitrary host values, row
+contents, protected health information, or authorization data. A host opts
+every reference into replication and is responsible for classifying it as
+safe for the already-authorized client.
+
+The server persists these details with the idempotency outcome, so a replayed
+rejection emits the identical companion. The client persists accepted details
+with its durable rejection journal (§7.2.1). Details are recovery hints, not
+trusted display copy: an app SHOULD map known codes, paths, reasons, actions,
+and references to its own localized UI and MUST ignore unknown values. The
+legacy `message` remains diagnostic and MUST NOT be rendered directly to end
+users.
+
 ### 6.4 Atomicity and ordering
 
 - Commits in a request are processed **sequentially in frame order**. A
@@ -2569,6 +2621,15 @@ opaque to the client runtime, which applies the generic rejection
 handling (drop the commit from the outbox; the app decides whether to
 re-push a corrected write).
 
+A deliberate host rejection MAY additionally attach the bounded
+`RejectionDetails` object of §6.3.1. The server validates and normalizes it at
+`ValidationRejection` construction time, persists it with the idempotent
+result, and emits it only through the additive companion frame. Invalid or
+over-limit details fail loudly as a host programming error; the server never
+falls back to replicating arbitrary exception data. Details do not broaden
+authorization and MUST contain only identifiers the host has explicitly
+classified as safe for the actor that already passed the row write gate.
+
 **Host codes MUST be distinguishable from protocol codes.** A host
 validation code **MUST NOT** begin with any reserved protocol-family
 prefix: **`sync.`**, **`blob.`**, **`presence.`**, or **`client.`**. These
@@ -2668,9 +2729,21 @@ Each journal entry contains the `clientCommitId`, local recording time,
 newest-first local sequence, final status, and every operation result. A
 conflict retains its stable code and message, `serverVersion`, decoded
 `serverRow`, and the losing schema-agnostic local operation. An error retains
-its stable code, message, retryability, and local operation. The same rule
+its stable code, message, retryability, accepted §6.3.1 details when present,
+and local operation. The same rule
 applies to client-local terminal drops such as `sync.outbox_incompatible` and
 an outbox commit proven to be inside a revoked effective scope.
+
+The operation journal also preserves **local edit intent** for an upsert made
+through the client's partial-update API: `changedFields` is the normalized,
+sorted set of non-primary-key fields supplied to `patch`. It survives restart
+and appears on conflict and rejection records so recovery UI can distinguish
+the fields the user meant to change from the rest of the full row payload.
+This metadata is deliberately local-only: it is stored beside the
+schema-agnostic outbox operation and MUST NOT be encoded into `PUSH_COMMIT` or
+trusted by the server. A full-row `mutate` has unknown intent and therefore
+omits `changedFields`; clients MUST NOT infer it by diffing against a mutable
+local base.
 
 The client exposes `commitOutcome(clientCommitId)` and
 `commitOutcomes({ limit?, activeOnly? })`. Active conflict/rejection entries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/conformance/src/catalog/conflict.ts
+++ b/packages/conformance/src/catalog/conflict.ts
@@ -47,14 +47,7 @@ export const conflictScenarios: readonly Scenario[] = [
       await syncIdle(a);
 
       // B pushes from the same stale base: conflict, not silent overwrite.
-      const mLoser = await b.api.mutate([
-        {
-          op: 'upsert',
-          table: 'tasks',
-          values: task('t1', 'p1', 'b-stale'),
-          baseVersion: 1,
-        },
-      ]);
+      const mLoser = await b.api.patch('tasks', 't1', { title: 'b-stale' }, 1);
       const report = await syncOk(b);
       checkEqual(report.rejected, [mLoser], 'the losing commit was rejected');
       checkEqual(report.conflicts, 1, 'exactly one conflict surfaced');
@@ -67,6 +60,11 @@ export const conflictScenarios: readonly Scenario[] = [
         conflict?.serverRow.title,
         'a-wins',
         'the server row rides the conflict record — no extra round-trip (§6.3)',
+      );
+      checkEqual(
+        conflict?.operation?.changedFields,
+        ['title'],
+        'patch intent survives the outbox and identifies the intentional field',
       );
 
       // keep-server: apply nothing, just pull — local state equals server.

--- a/packages/conformance/src/catalog/validators.ts
+++ b/packages/conformance/src/catalog/validators.ts
@@ -104,6 +104,15 @@ export const validatorScenarios: readonly Scenario[] = [
         false,
         'a validation rejection is not retryable',
       );
+      checkEqual(
+        rejection?.details,
+        {
+          fieldPaths: ['title'],
+          reason: 'max_length_exceeded',
+          requiredAction: 'edit_fields',
+        },
+        'bounded structured correction details round-trip on both client cores',
+      );
 
       // §6.4: NOTHING from the commit reached storage — the sibling insert
       // rolled back with the rejected operation.

--- a/packages/conformance/src/driver.ts
+++ b/packages/conformance/src/driver.ts
@@ -517,6 +517,9 @@ export interface ClientConflict {
   readonly code: string;
   readonly serverVersion: number;
   readonly serverRow: DriverRow;
+  readonly operation?: {
+    readonly changedFields?: readonly string[];
+  };
 }
 
 export interface ClientRejection {
@@ -524,6 +527,15 @@ export interface ClientRejection {
   readonly opIndex: number;
   readonly code: string;
   readonly retryable: boolean;
+  readonly details?: {
+    readonly fieldPaths?: readonly string[];
+    readonly reason?: string;
+    readonly requiredAction?: string;
+    readonly references?: Readonly<Record<string, string>>;
+  };
+  readonly operation?: {
+    readonly changedFields?: readonly string[];
+  };
 }
 
 export interface ClientRowState {
@@ -672,6 +684,12 @@ export interface ClientInstance {
 
   /** Record one atomic local commit (§7.1); returns its clientCommitId. */
   mutate(mutations: readonly ClientMutation[]): Promise<string>;
+  patch(
+    table: string,
+    rowId: string,
+    partial: DriverRow,
+    baseVersion?: number,
+  ): Promise<string>;
 
   /** One combined push+pull round (§1.5, §7.2). Never throws: transport
    * and protocol failures come back as `{ ok: false }`. */

--- a/packages/conformance/src/drivers/rust-client.ts
+++ b/packages/conformance/src/drivers/rust-client.ts
@@ -38,6 +38,7 @@ import type {
   CodecDriver,
   CodecRoundtrip,
   DriverChangeBatch,
+  DriverRow,
   DriverRowValue,
   DriverSchema,
   DriverSyncIntent,
@@ -595,6 +596,30 @@ class RustClientInstance implements ClientInstance {
     );
     if (typeof result.clientCommitId !== 'string') {
       throw new Error('mutate: shim returned no clientCommitId');
+    }
+    const intent = (result.effects as { sync?: DriverSyncIntent } | undefined)
+      ?.sync;
+    if (intent !== undefined) this.#intents.push(intent);
+    return result.clientCommitId;
+  }
+
+  async patch(
+    table: string,
+    rowId: string,
+    partial: DriverRow,
+    baseVersion?: number,
+  ): Promise<string> {
+    const result = asObject(
+      await this.#shim.call('patch', {
+        table,
+        rowId,
+        partial: partial as JsonValue,
+        ...(baseVersion !== undefined ? { baseVersion } : {}),
+      }),
+      'patch',
+    );
+    if (typeof result.clientCommitId !== 'string') {
+      throw new Error('patch: shim returned no clientCommitId');
     }
     const intent = (result.effects as { sync?: DriverSyncIntent } | undefined)
       ?.sync;

--- a/packages/conformance/src/drivers/ts-client.ts
+++ b/packages/conformance/src/drivers/ts-client.ts
@@ -330,6 +330,26 @@ class TsClientInstance implements ClientInstance {
     return result.value;
   }
 
+  async patch(
+    table: string,
+    rowId: string,
+    partial: DriverRow,
+    baseVersion?: number,
+  ): Promise<string> {
+    const values: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(partial)) {
+      values[key] = toRowValue(value);
+    }
+    const result = this.#client.patchCommand(
+      table,
+      rowId,
+      values,
+      baseVersion !== undefined ? { baseVersion } : undefined,
+    );
+    this.#intents.push(result.effects.sync);
+    return result.value;
+  }
+
   async localRevision(): Promise<string> {
     return this.#client.localRevision.toString();
   }
@@ -482,6 +502,15 @@ class TsClientInstance implements ClientInstance {
         code: conflict.code,
         serverVersion: conflict.serverVersion,
         serverRow: serverRow as DriverRow,
+        ...(conflict.operation !== undefined
+          ? {
+              operation: {
+                ...(conflict.operation.changedFields !== undefined
+                  ? { changedFields: conflict.operation.changedFields }
+                  : {}),
+              },
+            }
+          : {}),
       };
     });
   }
@@ -492,6 +521,18 @@ class TsClientInstance implements ClientInstance {
       opIndex: rejection.opIndex,
       code: rejection.code,
       retryable: rejection.retryable,
+      ...(rejection.details !== undefined
+        ? { details: rejection.details }
+        : {}),
+      ...(rejection.operation !== undefined
+        ? {
+            operation: {
+              ...(rejection.operation.changedFields !== undefined
+                ? { changedFields: rejection.operation.changedFields }
+                : {}),
+            },
+          }
+        : {}),
     }));
   }
 

--- a/packages/conformance/src/drivers/ts-server.ts
+++ b/packages/conformance/src/drivers/ts-server.ts
@@ -106,6 +106,11 @@ function compileValidatorRule(spec: ValidatorInstallSpec): Validator {
         throw new ValidationRejection(
           rule.code,
           `${rule.column} exceeds ${rule.max} chars (§6.7)`,
+          {
+            fieldPaths: [rule.column],
+            reason: 'max_length_exceeded',
+            requiredAction: 'edit_fields',
+          },
         );
       }
     };
@@ -119,6 +124,11 @@ function compileValidatorRule(spec: ValidatorInstallSpec): Validator {
       throw new ValidationRejection(
         rule.code,
         `${rule.column} is immutable while ${rule.guardColumn}=${String(rule.guardValue)} (§6.7)`,
+        {
+          fieldPaths: [rule.column],
+          reason: 'immutable_state',
+          requiredAction: 'keep_server',
+        },
       );
     }
   };

--- a/packages/core/src/frames.ts
+++ b/packages/core/src/frames.ts
@@ -13,6 +13,7 @@ export const FrameType = {
   SEGMENT_INLINE: 0x15,
   SUB_END: 0x16,
   LEASE: 0x19,
+  PUSH_RESULT_DETAILS: 0x1b,
   ERROR: 0x1f,
 } as const;
 
@@ -36,6 +37,7 @@ export const RESPONSE_FRAME_TYPES: ReadonlySet<number> = new Set([
   FrameType.SEGMENT_INLINE,
   FrameType.SUB_END,
   FrameType.LEASE,
+  FrameType.PUSH_RESULT_DETAILS,
   FrameType.ERROR,
 ]);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './errors';
 export * from './frames';
 export * from './message';
 export * from './realtime';
+export * from './rejection-details';
 export * from './render';
 export * from './row-codec';
 export * from './segment';

--- a/packages/core/src/message.test.ts
+++ b/packages/core/src/message.test.ts
@@ -5,6 +5,8 @@ import {
   decodeMessage,
   encodeMessage,
   FrameType,
+  type PushResultDetailsFrame,
+  type PushResultFrame,
   type RequestMessage,
   type ResponseMessage,
   utf8Encode,
@@ -165,6 +167,148 @@ describe('SSP2 envelope (SPEC.md §1.2)', () => {
       'PULL_HEADER',
     ]);
     expect(encodeMessage(message)).toEqual(bytes);
+  });
+});
+
+describe('PUSH_RESULT_DETAILS additive companion', () => {
+  it('round-trips bounded structured rejection metadata', () => {
+    const message: ResponseMessage = {
+      wireVersion: 1,
+      msgKind: 'response',
+      frames: [
+        { type: 'RESP_HEADER' },
+        {
+          type: 'PUSH_RESULT',
+          clientCommitId: 'commit-1',
+          status: 'rejected',
+          results: [
+            {
+              opIndex: 0,
+              status: 'error',
+              code: 'app.invalid_duration',
+              message: 'diagnostic only',
+              retryable: false,
+            },
+          ],
+        },
+        {
+          type: 'PUSH_RESULT_DETAILS',
+          clientCommitId: 'commit-1',
+          entries: [
+            {
+              opIndex: 0,
+              details: {
+                fieldPaths: ['duration_minutes'],
+                reason: 'outside_allowed_range',
+                requiredAction: 'edit_fields',
+                references: { surgery_id: 'surgery-1' },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const encoded = encodeMessage(message);
+    expect(decodeMessage(encoded)).toEqual(message);
+  });
+
+  it('rejects free-form and over-broad metadata', () => {
+    const message: ResponseMessage = {
+      wireVersion: 1,
+      msgKind: 'response',
+      frames: [
+        { type: 'RESP_HEADER' },
+        {
+          type: 'PUSH_RESULT',
+          clientCommitId: 'commit-1',
+          status: 'rejected',
+          results: [
+            {
+              opIndex: 0,
+              status: 'error',
+              code: 'app.invalid',
+              message: 'diagnostic only',
+              retryable: false,
+            },
+          ],
+        },
+        {
+          type: 'PUSH_RESULT_DETAILS',
+          clientCommitId: 'commit-1',
+          entries: [
+            {
+              opIndex: 0,
+              details: {
+                requiredAction: 'Show this arbitrary sentence',
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => encodeMessage(message)).toThrow('lowercase stable token');
+  });
+
+  it('rejects orphaned, duplicated, and mismatched companions', () => {
+    const result: PushResultFrame = {
+      type: 'PUSH_RESULT',
+      clientCommitId: 'commit-1',
+      status: 'rejected',
+      results: [
+        {
+          opIndex: 0,
+          status: 'error',
+          code: 'app.invalid',
+          message: 'diagnostic only',
+          retryable: false,
+        },
+      ],
+    };
+    const details: PushResultDetailsFrame = {
+      type: 'PUSH_RESULT_DETAILS',
+      clientCommitId: 'commit-1',
+      entries: [{ opIndex: 0, details: { reason: 'invalid_value' } }],
+    };
+
+    expect(() =>
+      encodeMessage({
+        wireVersion: 1,
+        msgKind: 'response',
+        frames: [{ type: 'RESP_HEADER' }, details],
+      }),
+    ).toThrow('without a preceding PUSH_RESULT');
+    expect(() =>
+      encodeMessage({
+        wireVersion: 1,
+        msgKind: 'response',
+        frames: [{ type: 'RESP_HEADER' }, result, details, details],
+      }),
+    ).toThrow('duplicate PUSH_RESULT_DETAILS');
+    expect(() =>
+      encodeMessage({
+        wireVersion: 1,
+        msgKind: 'response',
+        frames: [
+          { type: 'RESP_HEADER' },
+          result,
+          { ...details, clientCommitId: 'other-commit' },
+        ],
+      }),
+    ).toThrow('does not match its rejected PUSH_RESULT');
+    expect(() =>
+      encodeMessage({
+        wireVersion: 1,
+        msgKind: 'response',
+        frames: [
+          { type: 'RESP_HEADER' },
+          result,
+          {
+            ...details,
+            entries: [{ opIndex: 1, details: { reason: 'invalid_value' } }],
+          },
+        ],
+      }),
+    ).toThrow('does not match an error result');
   });
 });
 

--- a/packages/core/src/message.ts
+++ b/packages/core/src/message.ts
@@ -28,6 +28,10 @@ import {
   REQUEST_FRAME_TYPES,
   RESPONSE_FRAME_TYPES,
 } from './frames';
+import {
+  normalizeRejectionDetails,
+  type RejectionDetails,
+} from './rejection-details';
 import { decodeRowsSegment } from './segment';
 
 const MAGIC_BYTES = utf8Encode(SYNC_PACK_MAGIC);
@@ -119,6 +123,11 @@ export type PushOperationResult =
       code: string;
       message: string;
       retryable: boolean;
+      /**
+       * Host-safe structured metadata. It is emitted on the wire through the
+       * additive PUSH_RESULT_DETAILS companion frame, not the legacy record.
+       */
+      details?: RejectionDetails;
     };
 
 export interface PushResultFrame {
@@ -128,6 +137,16 @@ export interface PushResultFrame {
   /** Present iff `status` is `applied` or `cached` (§6.3). */
   commitSeq?: number;
   results: PushOperationResult[];
+}
+
+/**
+ * Additive companion metadata for host validation errors. Older clients see
+ * this as an unknown frame and continue processing the normative PUSH_RESULT.
+ */
+export interface PushResultDetailsFrame {
+  type: 'PUSH_RESULT_DETAILS';
+  clientCommitId: string;
+  entries: Array<{ opIndex: number; details: RejectionDetails }>;
 }
 
 export interface SubStartFrame {
@@ -202,6 +221,7 @@ export type ResponseFrame =
   | RespHeaderFrame
   | LeaseFrame
   | PushResultFrame
+  | PushResultDetailsFrame
   | SubStartFrame
   | CommitFrame
   | SegmentRefFrame
@@ -397,6 +417,36 @@ function decodePushResult(r: ByteReader): PushResultFrame {
   };
 }
 
+function decodePushResultDetails(r: ByteReader): PushResultDetailsFrame {
+  const clientCommitId = r.str();
+  if (clientCommitId.length === 0) {
+    invalid('PUSH_RESULT_DETAILS.clientCommitId must be non-empty');
+  }
+  const count = r.u32();
+  if (count === 0) invalid('PUSH_RESULT_DETAILS must carry at least one entry');
+  const entries: PushResultDetailsFrame['entries'] = [];
+  const seen = new Set<number>();
+  for (let index = 0; index < count; index++) {
+    const opIndex = r.i32();
+    if (opIndex < 0 || seen.has(opIndex)) {
+      invalid(
+        'PUSH_RESULT_DETAILS opIndex values must be unique and non-negative',
+      );
+    }
+    seen.add(opIndex);
+    let details: RejectionDetails;
+    try {
+      details = normalizeRejectionDetails(JSON.parse(r.str()) as unknown);
+    } catch (error) {
+      invalid(
+        `invalid PUSH_RESULT_DETAILS.details: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    entries.push({ opIndex, details });
+  }
+  return { type: 'PUSH_RESULT_DETAILS', clientCommitId, entries };
+}
+
 function decodeSubStart(r: ByteReader): SubStartFrame {
   const id = r.str();
   const statusByte = r.u8();
@@ -581,6 +631,9 @@ function decodeResponseFrame(
     case FrameType.PUSH_RESULT:
       frame = decodePushResult(r);
       break;
+    case FrameType.PUSH_RESULT_DETAILS:
+      frame = decodePushResultDetails(r);
+      break;
     case FrameType.SUB_START:
       frame = decodeSubStart(r);
       break;
@@ -659,6 +712,8 @@ function validateResponseSequence(frames: readonly ResponseFrame[]): void {
   let subscriptionHasCommits = false;
   let subscriptionHasSegments = false;
   let errorSeen = false;
+  let lastPushResult: PushResultFrame | undefined;
+  let lastPushResultHasDetails = false;
   for (const frame of frames.slice(1)) {
     if (errorSeen) invalid('frames after ERROR (the next frame must be END)');
     switch (frame.type) {
@@ -674,8 +729,40 @@ function validateResponseSequence(frames: readonly ResponseFrame[]): void {
         break;
       case 'PUSH_RESULT':
         if (sawSubscription) invalid('PUSH_RESULT frame after SUB_START');
+        lastPushResult = frame;
+        lastPushResultHasDetails = false;
         sawBody = true;
         break;
+      case 'PUSH_RESULT_DETAILS': {
+        if (sawSubscription) {
+          invalid('PUSH_RESULT_DETAILS frame after SUB_START');
+        }
+        if (lastPushResult === undefined) {
+          invalid('PUSH_RESULT_DETAILS without a preceding PUSH_RESULT');
+        }
+        if (lastPushResultHasDetails) {
+          invalid('duplicate PUSH_RESULT_DETAILS companion');
+        }
+        if (
+          lastPushResult.clientCommitId !== frame.clientCommitId ||
+          lastPushResult.status !== 'rejected'
+        ) {
+          invalid(
+            'PUSH_RESULT_DETAILS does not match its rejected PUSH_RESULT',
+          );
+        }
+        const errorIndexes = new Set(
+          lastPushResult.results.flatMap((result) =>
+            result.status === 'error' ? [result.opIndex] : [],
+          ),
+        );
+        if (frame.entries.some((entry) => !errorIndexes.has(entry.opIndex))) {
+          invalid('PUSH_RESULT_DETAILS entry does not match an error result');
+        }
+        lastPushResultHasDetails = true;
+        sawBody = true;
+        break;
+      }
       case 'SUB_START':
         if (inSubscription) invalid('nested SUB_START frame');
         inSubscription = true;
@@ -837,6 +924,32 @@ function encodeFrame(frame: RequestFrame | ResponseFrame): {
         }
       }
       return { frameType: FrameType.PUSH_RESULT, payload: w.finish() };
+    }
+    case 'PUSH_RESULT_DETAILS': {
+      if (frame.clientCommitId.length === 0) {
+        throw new Error('PUSH_RESULT_DETAILS.clientCommitId must be non-empty');
+      }
+      if (frame.entries.length === 0) {
+        throw new Error('PUSH_RESULT_DETAILS must carry at least one entry');
+      }
+      const seen = new Set<number>();
+      w.str(frame.clientCommitId);
+      w.u32(frame.entries.length);
+      for (const entry of frame.entries) {
+        if (!Number.isInteger(entry.opIndex) || entry.opIndex < 0) {
+          throw new Error('PUSH_RESULT_DETAILS.opIndex must be non-negative');
+        }
+        if (seen.has(entry.opIndex)) {
+          throw new Error('PUSH_RESULT_DETAILS.opIndex must be unique');
+        }
+        seen.add(entry.opIndex);
+        w.i32(entry.opIndex);
+        w.str(JSON.stringify(normalizeRejectionDetails(entry.details)));
+      }
+      return {
+        frameType: FrameType.PUSH_RESULT_DETAILS,
+        payload: w.finish(),
+      };
     }
     case 'SUB_START': {
       w.str(frame.id);

--- a/packages/core/src/rejection-details.ts
+++ b/packages/core/src/rejection-details.ts
@@ -1,0 +1,183 @@
+/**
+ * Bounded host rejection metadata carried by the additive
+ * `PUSH_RESULT_DETAILS` companion frame.
+ *
+ * Every member is deliberately code-like rather than free-form display text.
+ * A host opts values into replication by placing them here, so references MUST
+ * be non-sensitive identifiers that are safe for the authorized client to
+ * persist and render. Diagnostic prose stays in the ordinary `message` field.
+ */
+export interface RejectionDetails {
+  /** Schema/domain paths affected by the rejection. */
+  readonly fieldPaths?: readonly string[];
+  /** Stable machine reason, for example `outside_schedule_day`. */
+  readonly reason?: string;
+  /** Stable recovery action, for example `edit_fields`. */
+  readonly requiredAction?: string;
+  /** Explicitly safe, non-sensitive identifiers needed by recovery UI. */
+  readonly references?: Readonly<Record<string, string>>;
+}
+
+export const REJECTION_DETAILS_LIMITS = {
+  maxEncodedBytes: 4_096,
+  maxFieldPaths: 32,
+  maxFieldPathLength: 160,
+  maxTokenLength: 96,
+  maxReferences: 16,
+  maxReferenceKeyLength: 64,
+  maxReferenceValueBytes: 256,
+} as const;
+
+const FIELD_PATH = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+const TOKEN = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/;
+
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+  }
+  return false;
+}
+
+function recordOf(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('rejection details must be an object');
+  }
+  return value as Record<string, unknown>;
+}
+
+function stableToken(value: unknown, label: string, maxLength: number): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    !TOKEN.test(value)
+  ) {
+    throw new Error(
+      `${label} must be a lowercase stable token of at most ${maxLength} characters`,
+    );
+  }
+  return value;
+}
+
+/** Validate, clone, and normalize a host-supplied details object. */
+export function normalizeRejectionDetails(value: unknown): RejectionDetails {
+  const source = recordOf(value);
+  const allowed = new Set([
+    'fieldPaths',
+    'reason',
+    'requiredAction',
+    'references',
+  ]);
+  for (const key of Object.keys(source)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `unknown rejection details member ${JSON.stringify(key)}`,
+      );
+    }
+  }
+
+  const normalized: {
+    fieldPaths?: string[];
+    reason?: string;
+    requiredAction?: string;
+    references?: Record<string, string>;
+  } = {};
+
+  if (source.fieldPaths !== undefined) {
+    if (
+      !Array.isArray(source.fieldPaths) ||
+      source.fieldPaths.length === 0 ||
+      source.fieldPaths.length > REJECTION_DETAILS_LIMITS.maxFieldPaths
+    ) {
+      throw new Error(
+        `fieldPaths must contain 1-${REJECTION_DETAILS_LIMITS.maxFieldPaths} paths`,
+      );
+    }
+    const paths: string[] = [];
+    const seen = new Set<string>();
+    for (const path of source.fieldPaths) {
+      if (
+        typeof path !== 'string' ||
+        path.length === 0 ||
+        path.length > REJECTION_DETAILS_LIMITS.maxFieldPathLength ||
+        !FIELD_PATH.test(path)
+      ) {
+        throw new Error(
+          `fieldPaths entries must be schema paths of at most ${REJECTION_DETAILS_LIMITS.maxFieldPathLength} characters`,
+        );
+      }
+      if (seen.has(path))
+        throw new Error(`duplicate field path ${JSON.stringify(path)}`);
+      seen.add(path);
+      paths.push(path);
+    }
+    normalized.fieldPaths = paths;
+  }
+
+  if (source.reason !== undefined) {
+    normalized.reason = stableToken(
+      source.reason,
+      'reason',
+      REJECTION_DETAILS_LIMITS.maxTokenLength,
+    );
+  }
+  if (source.requiredAction !== undefined) {
+    normalized.requiredAction = stableToken(
+      source.requiredAction,
+      'requiredAction',
+      REJECTION_DETAILS_LIMITS.maxTokenLength,
+    );
+  }
+
+  if (source.references !== undefined) {
+    const references = recordOf(source.references);
+    const keys = Object.keys(references).sort();
+    if (
+      keys.length === 0 ||
+      keys.length > REJECTION_DETAILS_LIMITS.maxReferences
+    ) {
+      throw new Error(
+        `references must contain 1-${REJECTION_DETAILS_LIMITS.maxReferences} entries`,
+      );
+    }
+    const safe: Record<string, string> = {};
+    for (const key of keys) {
+      stableToken(
+        key,
+        'reference key',
+        REJECTION_DETAILS_LIMITS.maxReferenceKeyLength,
+      );
+      const member = references[key];
+      if (
+        typeof member !== 'string' ||
+        member.length === 0 ||
+        new TextEncoder().encode(member).length >
+          REJECTION_DETAILS_LIMITS.maxReferenceValueBytes ||
+        member.trim() !== member ||
+        hasControlCharacter(member)
+      ) {
+        throw new Error(
+          `reference values must be non-empty safe strings of at most ${REJECTION_DETAILS_LIMITS.maxReferenceValueBytes} encoded bytes`,
+        );
+      }
+      safe[key] = member;
+    }
+    normalized.references = safe;
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    throw new Error(
+      'rejection details must contain at least one supported member',
+    );
+  }
+  const encodedBytes = new TextEncoder().encode(
+    JSON.stringify(normalized),
+  ).length;
+  if (encodedBytes > REJECTION_DETAILS_LIMITS.maxEncodedBytes) {
+    throw new Error(
+      `rejection details exceed ${REJECTION_DETAILS_LIMITS.maxEncodedBytes} encoded bytes`,
+    );
+  }
+  return normalized;
+}

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -192,6 +192,28 @@ function renderFrame(frame: RequestFrame | ResponseFrame): JsonValue {
           : {}),
         results: frame.results.map(renderResult),
       };
+    case 'PUSH_RESULT_DETAILS':
+      return {
+        type: 'PUSH_RESULT_DETAILS',
+        clientCommitId: frame.clientCommitId,
+        entries: frame.entries.map((entry) => ({
+          opIndex: entry.opIndex,
+          details: {
+            ...(entry.details.fieldPaths !== undefined
+              ? { fieldPaths: [...entry.details.fieldPaths] }
+              : {}),
+            ...(entry.details.reason !== undefined
+              ? { reason: entry.details.reason }
+              : {}),
+            ...(entry.details.requiredAction !== undefined
+              ? { requiredAction: entry.details.requiredAction }
+              : {}),
+            ...(entry.details.references !== undefined
+              ? { references: { ...entry.details.references } }
+              : {}),
+          },
+        })),
+      };
     case 'SUB_START':
       return {
         type: 'SUB_START',

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -60,6 +60,55 @@ done by a binding of the core or by in-database fanout — a relay would add a
 hop, a second protocol surface, and a managed dependency for zero capability
 the core lacks.
 
+## Write validators and recovery metadata
+
+`validators` is the server-authoritative seam for row business rules that
+scope grants cannot express. A validator runs after row decode and scope
+authorization, inside the commit transaction, for HTTP and WebSocket sync
+rounds alike. Throw `ValidationRejection` for a deliberate host rejection:
+
+```ts
+import {
+  ValidationRejection,
+  type SyncServerConfig,
+} from '@syncular/server';
+
+const config: SyncServerConfig = {
+  schema,
+  storage,
+  segments,
+  resolveScopes,
+  validators: {
+    surgeries: ({ row }) => {
+      if (typeof row?.duration_minutes === 'number' && row.duration_minutes < 5) {
+        throw new ValidationRejection(
+          'surgery.duration_too_short',
+          'diagnostic only',
+          {
+            fieldPaths: ['duration_minutes'],
+            reason: 'below_minimum',
+            requiredAction: 'edit_fields',
+            references: { minimum_minutes: '5' },
+          },
+        );
+      }
+    },
+  },
+};
+```
+
+The third argument is optional. When supplied, Syncular validates and
+normalizes a bounded `RejectionDetails` object and persists it with the
+idempotency result. Its values replicate to the authorized client, so include
+only non-sensitive identifiers that the host explicitly approves for recovery
+UI. Unknown members, free-form tokens, malformed paths, and over-limit data
+fail at construction. Diagnostic prose stays in `message`; apps should map
+the stable code/details to localized copy instead of displaying that message.
+
+Validators are per-operation. They do not make multi-row or multi-table
+invariants atomic; those require a server-authoritative command or a future
+whole-commit validation seam. A validator must not mutate the row it receives.
+
 ## Structured events (the ops seam)
 
 One optional interface, `SyncularServerEvents`, carries every

--- a/packages/server/src/frame-bytes.ts
+++ b/packages/server/src/frame-bytes.ts
@@ -11,6 +11,7 @@
 import {
   encodeMessage,
   PROTOCOL_WIRE_VERSION,
+  type PushResultFrame,
   type RespHeaderFrame,
   type ResponseFrame,
   type SubEndFrame,
@@ -54,6 +55,21 @@ function wrapperFor(frame: ResponseFrame): {
     case 'ERROR':
     case 'UNKNOWN':
       return { frames: [STUB_HEADER, frame], index: 1 };
+    case 'PUSH_RESULT_DETAILS': {
+      const result: PushResultFrame = {
+        type: 'PUSH_RESULT',
+        clientCommitId: frame.clientCommitId,
+        status: 'rejected',
+        results: frame.entries.map((entry) => ({
+          opIndex: entry.opIndex,
+          status: 'error',
+          code: 'sync.constraint_violation',
+          message: '',
+          retryable: false,
+        })),
+      };
+      return { frames: [STUB_HEADER, result, frame], index: 2 };
+    }
     case 'SUB_START':
       return { frames: [STUB_HEADER, frame, STUB_SUB_END], index: 1 };
     case 'SUB_END':

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -14,6 +14,7 @@ import {
   decodeMessage,
   type PullHeaderFrame,
   type PushCommitFrame,
+  type PushResultDetailsFrame,
   type PushResultFrame,
   type ReqHeaderFrame,
   type RequestMessage,
@@ -316,6 +317,23 @@ interface RequestReport {
   errorCode?: string;
 }
 
+function pushResultDetailsFrame(
+  frame: PushResultFrame,
+): PushResultDetailsFrame | undefined {
+  const entries = frame.results.flatMap((result) =>
+    result.status === 'error' && result.details !== undefined
+      ? [{ opIndex: result.opIndex, details: result.details }]
+      : [],
+  );
+  return entries.length === 0
+    ? undefined
+    : {
+        type: 'PUSH_RESULT_DETAILS',
+        clientCommitId: frame.clientCommitId,
+        entries,
+      };
+}
+
 function emitPushEvent(
   events: SyncularServerEvents,
   ctx: SyncRequestContext,
@@ -416,6 +434,8 @@ async function* streamResponse(
         emitPushEvent(events, ctx, plan.header.clientId, push, frame);
       }
       yield encodeResponseFrame(frame);
+      const details = pushResultDetailsFrame(frame);
+      if (details !== undefined) yield encodeResponseFrame(details);
     }
 
     // Pull half (§4): subscriptions echoed in request order.

--- a/packages/server/src/postgres-storage.ts
+++ b/packages/server/src/postgres-storage.ts
@@ -165,6 +165,7 @@ interface SerializedResult {
   serverVersion?: number;
   serverRow?: string;
   retryable?: boolean;
+  details?: import('@syncular/core').RejectionDetails;
 }
 
 function toBase64(bytes: Uint8Array): string {
@@ -201,6 +202,7 @@ function serializePushResult(result: StoredPushResult): unknown {
           code: record.code,
           message: record.message,
           retryable: record.retryable,
+          ...(record.details !== undefined ? { details: record.details } : {}),
         };
       }
       return { opIndex: record.opIndex, status: record.status };
@@ -232,6 +234,7 @@ function deserializePushResult(value: unknown): StoredPushResult {
         code: record.code ?? '',
         message: record.message ?? '',
         retryable: record.retryable ?? false,
+        ...(record.details !== undefined ? { details: record.details } : {}),
       };
     }
     return { opIndex: record.opIndex, status: 'applied' };

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -25,6 +25,7 @@ import {
   type PushOperationResult,
   type PushResultFrame,
   parseBlobRef,
+  type RejectionDetails,
   type RowValue,
 } from '@syncular/core';
 import type { BlobStore } from './blob-store';
@@ -70,10 +71,18 @@ function errorRecord(
   code: string,
   message: string,
   retryable = false,
+  details?: RejectionDetails,
 ): OperationOutcome {
   return {
     kind: 'terminate',
-    record: { opIndex, status: 'error', code, message, retryable },
+    record: {
+      opIndex,
+      status: 'error',
+      code,
+      message,
+      retryable,
+      ...(details !== undefined ? { details } : {}),
+    },
   };
 }
 
@@ -141,7 +150,13 @@ async function runValidator(
     );
   } catch (error) {
     if (error instanceof ValidationRejection) {
-      return errorRecord(opIndex, error.code, error.message);
+      return errorRecord(
+        opIndex,
+        error.code,
+        error.message,
+        false,
+        error.details,
+      );
     }
     // §6.7: a non-ValidationRejection throw is still a rejection, mapped to
     // the generic server-side constraint code (§10.2) — the validator's

--- a/packages/server/src/realtime.ts
+++ b/packages/server/src/realtime.ts
@@ -50,11 +50,14 @@ import {
 import type { SegmentStore } from './segment-store';
 import type { SegmentUrlConfig } from './signed-url';
 import type { ServerStorage, StoredCommit } from './storage';
+import type { ValidatorRegistry } from './validate';
 
 export interface RealtimeHubConfig {
   readonly schema: ServerSchema;
   readonly storage: ServerStorage;
   readonly resolveScopes: ResolveScopes;
+  /** §6.7 validators used by sync rounds carried over this socket. */
+  readonly validators?: ValidatorRegistry;
   readonly clock?: () => number;
   /** Deltas larger than this become `delta-too-large` wake-ups (§8.2). */
   readonly maxDeltaBytes?: number;
@@ -926,6 +929,9 @@ export class RealtimeHub {
       storage: this.#config.storage,
       segments,
       resolveScopes: this.#config.resolveScopes,
+      ...(this.#config.validators !== undefined
+        ? { validators: this.#config.validators }
+        : {}),
       ...(this.#config.clock !== undefined
         ? { clock: this.#config.clock }
         : {}),

--- a/packages/server/src/sqlite-dialect.ts
+++ b/packages/server/src/sqlite-dialect.ts
@@ -126,6 +126,7 @@ interface SerializedResult {
   serverVersion?: number;
   serverRow?: string;
   retryable?: boolean;
+  details?: import('@syncular/core').RejectionDetails;
 }
 
 /** Serialize a push result to the JSON `TEXT` stored in `sync_push_results`. */
@@ -151,6 +152,7 @@ export function serializePushResult(result: StoredPushResult): string {
           code: record.code,
           message: record.message,
           retryable: record.retryable,
+          ...(record.details !== undefined ? { details: record.details } : {}),
         };
       }
       return { opIndex: record.opIndex, status: record.status };
@@ -182,6 +184,7 @@ export function deserializePushResult(text: string): StoredPushResult {
         code: record.code ?? '',
         message: record.message ?? '',
         retryable: record.retryable ?? false,
+        ...(record.details !== undefined ? { details: record.details } : {}),
       };
     }
     return { opIndex: record.opIndex, status: 'applied' };

--- a/packages/server/src/validate.ts
+++ b/packages/server/src/validate.ts
@@ -13,7 +13,12 @@
  * path pays only an `undefined` check per operation and builds no context
  * object — zero cost, the events-seam discipline.
  */
-import type { RowColumn, RowValue } from '@syncular/core';
+import {
+  normalizeRejectionDetails,
+  type RejectionDetails,
+  type RowColumn,
+  type RowValue,
+} from '@syncular/core';
 
 /**
  * §6.7 reserved code prefixes. A host validator code MUST NOT start with
@@ -93,8 +98,13 @@ export type ValidatorRegistry = Readonly<Record<string, Validator>>;
 export class ValidationRejection extends Error {
   override readonly name = 'ValidationRejection';
   readonly code: string;
+  /**
+   * Bounded code-like metadata explicitly safe to replicate to authorized
+   * clients. Never place diagnostic prose, secrets, or clinical values here.
+   */
+  readonly details: RejectionDetails | undefined;
 
-  constructor(code: string, message?: string) {
+  constructor(code: string, message?: string, details?: RejectionDetails) {
     super(message ?? code);
     if (code.length === 0) {
       throw new Error('ValidationRejection code must be non-empty (§6.7)');
@@ -107,6 +117,8 @@ export class ValidationRejection extends Error {
       }
     }
     this.code = code;
+    this.details =
+      details === undefined ? undefined : normalizeRejectionDetails(details);
   }
 }
 

--- a/packages/server/test/write-validation.test.ts
+++ b/packages/server/test/write-validation.test.ts
@@ -42,6 +42,31 @@ describe('ValidationRejection reserved-prefix guard (§6.7)', () => {
   test('an empty code throws', () => {
     expect(() => new ValidationRejection('')).toThrow();
   });
+
+  test('structured details are bounded and code-like', () => {
+    const rejection = new ValidationRejection(
+      'app.invalid_duration',
+      'diagnostic',
+      {
+        fieldPaths: ['duration_minutes'],
+        reason: 'outside_allowed_range',
+        requiredAction: 'edit_fields',
+        references: { surgery_id: 'surgery-1' },
+      },
+    );
+    expect(rejection.details).toEqual({
+      fieldPaths: ['duration_minutes'],
+      reason: 'outside_allowed_range',
+      requiredAction: 'edit_fields',
+      references: { surgery_id: 'surgery-1' },
+    });
+    expect(
+      () =>
+        new ValidationRejection('app.invalid', 'diagnostic', {
+          requiredAction: 'Render arbitrary prose',
+        }),
+    ).toThrow('lowercase stable token');
+  });
 });
 
 /** A validator rejecting a title longer than `max`. */
@@ -64,6 +89,50 @@ function capture(): Captured {
 }
 
 describe('write validation apply (§6.7)', () => {
+  test('emits and idempotently replays a privacy-safe details companion', async () => {
+    const t = makeContext({
+      validators: {
+        tasks: () => {
+          throw new ValidationRejection(
+            'app.invalid_title',
+            'diagnostic only',
+            {
+              fieldPaths: ['title'],
+              reason: 'invalid_value',
+              requiredAction: 'edit_fields',
+              references: { task_id: 't1' },
+            },
+          );
+        },
+      },
+    });
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const message = await sync(t, [
+        pushCommit('structured-c1', [
+          upsert('tasks', 't1', taskRow('t1', 'p1', 'invalid')),
+        ]),
+      ]);
+      expect(pushResults(message)[0]?.status).toBe('rejected');
+      expect(
+        message.frames.find((frame) => frame.type === 'PUSH_RESULT_DETAILS'),
+      ).toEqual({
+        type: 'PUSH_RESULT_DETAILS',
+        clientCommitId: 'structured-c1',
+        entries: [
+          {
+            opIndex: 0,
+            details: {
+              fieldPaths: ['title'],
+              reason: 'invalid_value',
+              requiredAction: 'edit_fields',
+              references: { task_id: 't1' },
+            },
+          },
+        ],
+      });
+    }
+  });
+
   test('a rejecting validator rolls the whole commit back atomically', async () => {
     const cap = capture();
     const t = makeContext({

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -16,15 +16,10 @@ green test here is real sync behaviour, not a fake.
 
 ## Install
 
-Workspace-internal only:
+Install it as a development dependency:
 
-```jsonc
-// package.json
-{
-  "devDependencies": {
-    "@syncular/testkit": "workspace:*"
-  }
-}
+```bash
+bun add --dev @syncular/testkit
 ```
 
 Requires the Bun runtime (the in-memory client backend is `bun:sqlite`). The
@@ -71,6 +66,7 @@ adds the test-only controls below.
 | `partition`     | `"test"`               | the §1.1 partition every client lives in                      |
 | `actorId`       | `"test-actor"`         | default actor a client authenticates as                       |
 | `resolveScopes` | grant-all              | host authorization (§3.2); omit to grant `'*'` for every var  |
+| `validators`    | off                    | real per-table write validators (§6.7), including structured rejection details |
 | `startMs`       | `1_750_000_000_000`    | epoch ms the shared virtual clock starts at                   |
 
 `TestSync`:
@@ -167,6 +163,35 @@ await a.sync();                     // the hub fans the commit to b as a delta
 ```
 
 `goOffline()` also drops the socket; reconnect with `connectRealtime()`.
+
+### Multi-client conflicts and correction metadata
+
+Create the common server row, let both clients pull it, then make their edits
+from the same observed version. Push one client first so the second write is a
+deterministic conflict—no timers or transport mocks are needed:
+
+```ts
+await sync.syncAll();
+const [{ version }] = a.api.query(
+  'SELECT _sync_version AS version FROM notes WHERE id = ?',
+  ['n1'],
+) as Array<{ version: number }>;
+
+a.api.patch('notes', 'n1', { body: 'A' }, { baseVersion: version });
+b.api.patch('notes', 'n1', { body: 'B' }, { baseVersion: version });
+
+await a.sync(); // wins version + 1
+await b.sync(); // loses against the stale base
+
+expect(b.api.conflicts[0]?.serverRow.body).toBe('A');
+expect(b.api.conflicts[0]?.operation?.changedFields).toEqual(['body']);
+```
+
+Pass `validators` to `createTestSync` to exercise the same business rules as
+production. A `ValidationRejection` with structured details reaches
+`client.api.rejections` through both loopback and socket sync rounds, so app
+tests can assert field focus and correction routing without displaying server
+diagnostics.
 
 ## React
 

--- a/packages/testing/src/create-test-sync.ts
+++ b/packages/testing/src/create-test-sync.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ClientSchema, SyncClientConfig } from '@syncular/client';
-import type { ResolveScopes } from '@syncular/server';
+import type { ResolveScopes, ValidatorRegistry } from '@syncular/server';
 import { buildTestClient, type TestClient } from './client';
 import { createVirtualClock, type VirtualClock } from './clock';
 import {
@@ -44,6 +44,8 @@ export interface CreateTestSyncOptions {
    * in the server exactly as it would in production.
    */
   readonly resolveScopes?: ResolveScopes;
+  /** Optional §6.7 write validators, executed by the real test server. */
+  readonly validators?: ValidatorRegistry;
   /** Epoch ms the shared virtual clock starts at (default 1_750_000_000_000). */
   readonly startMs?: number;
 }
@@ -97,6 +99,9 @@ export async function createTestSync(
     partition,
     ...(options.resolveScopes !== undefined
       ? { resolveScopes: options.resolveScopes }
+      : {}),
+    ...(options.validators !== undefined
+      ? { validators: options.validators }
       : {}),
   });
 

--- a/packages/testing/src/server.ts
+++ b/packages/testing/src/server.ts
@@ -17,6 +17,7 @@ import {
   type ServerSchema,
   SqliteServerStorage,
   type SyncRequestContext,
+  type ValidatorRegistry,
 } from '@syncular/server';
 import type { VirtualClock } from './clock';
 
@@ -50,6 +51,8 @@ export interface TestServerOptions {
   readonly partition: string;
   /** Defaults to {@link allowAllScopes}. */
   readonly resolveScopes?: ResolveScopes;
+  /** Optional §6.7 validators, shared by HTTP-like and socket rounds. */
+  readonly validators?: ValidatorRegistry;
 }
 
 /**
@@ -79,6 +82,9 @@ export function createTestServer(options: TestServerOptions): TestServer {
     resolveScopes,
     clock: clockFn,
     segments,
+    ...(options.validators !== undefined
+      ? { validators: options.validators }
+      : {}),
   });
   return {
     storage,
@@ -92,6 +98,9 @@ export function createTestServer(options: TestServerOptions): TestServer {
       storage,
       segments,
       resolveScopes,
+      ...(options.validators !== undefined
+        ? { validators: options.validators }
+        : {}),
       clock: clockFn,
       realtime: hub,
     }),

--- a/packages/testing/test/kit.test.ts
+++ b/packages/testing/test/kit.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import type { ClientSchema } from '@syncular/client';
+import { ValidationRejection } from '@syncular/server';
 import { createTestSync, TransportFault } from '../src/index';
 
 /** A minimal one-table app schema: notes scoped by list. */
@@ -219,6 +220,58 @@ describe('createTestSync — realtime deltas', () => {
       expect(b.api.query('SELECT id, body FROM notes ORDER BY id')).toEqual([
         { id: 'n1', body: 'live' },
       ]);
+    } finally {
+      await sync.dispose();
+    }
+  });
+});
+
+describe('createTestSync — write validation', () => {
+  test('validators and structured recovery details also apply to socket sync rounds', async () => {
+    const sync = await createTestSync({
+      schema: SCHEMA,
+      validators: {
+        notes: ({ row }) => {
+          if (row?.body === 'blocked') {
+            throw new ValidationRejection(
+              'app.body_blocked',
+              'diagnostic only',
+              {
+                fieldPaths: ['body'],
+                reason: 'reserved_term',
+                requiredAction: 'edit_fields',
+              },
+            );
+          }
+        },
+      },
+    });
+    try {
+      const a = await sync.client('a');
+      a.api.subscribe(SUB);
+      await a.sync();
+      a.api.mutate([
+        {
+          table: 'notes',
+          op: 'upsert',
+          values: note('n1', 'welcome', 'allowed'),
+        },
+      ]);
+      await a.sync();
+      await a.connectRealtime();
+
+      a.api.patch('notes', 'n1', {
+        body: 'blocked',
+      });
+      await a.sync();
+
+      expect(a.api.rejections).toHaveLength(1);
+      expect(a.api.rejections[0]?.details).toEqual({
+        fieldPaths: ['body'],
+        reason: 'reserved_term',
+        requiredAction: 'edit_fields',
+      });
+      expect(a.api.rejections[0]?.operation?.changedFields).toEqual(['body']);
     } finally {
       await sync.dispose();
     }

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -118,6 +118,17 @@ retain the losing operation plus `serverVersion`/`serverRow`; active failures
 restore after restart and are never removed by retention. Configure the
 history cap with `limits.outcomeRetentionMaxEntries` (default 1,000).
 
+Use `patch(table, rowId, partial, { baseVersion? })` for editor-style partial
+updates. The wire still carries a full row, but the durable local operation
+records a sorted `changedFields` list so conflict and rejection UI knows which
+fields the user intended to touch. That intent is local-only and never enters
+`PUSH_COMMIT`; full-row `mutate` operations omit it.
+
+Validator rejections may include bounded `details` (`fieldPaths`, `reason`,
+`requiredAction`, and explicitly safe `references`). The details persist with
+the rejection. Treat every value as a machine hint: map known values to
+localized app UI and never render the diagnostic `message` directly.
+
 Resolution is explicit and one-way: conflicts can keep the server result or
 link to a replacement commit, rejections can link to a replacement, and
 successful history may be dismissed. See SPEC §7.2.1.

--- a/packages/web-client/src/client.ts
+++ b/packages/web-client/src/client.ts
@@ -22,6 +22,7 @@ import {
   parseRealtimeServerEvent,
   REALTIME_TAG_DELTA,
   REALTIME_TAG_ROUND,
+  type RejectionDetails,
   type RequestFrame,
   type ResponseMessage,
   type RowColumn,
@@ -1502,9 +1503,16 @@ export class SyncClient {
    * Returns the generated `clientCommitId`.
    */
   mutate(mutations: readonly MutationInput[]): string {
+    return this.#recordMutations(mutations);
+  }
+
+  #recordMutations(
+    mutations: readonly MutationInput[],
+    changedFieldsByIndex: readonly (readonly string[] | undefined)[] = [],
+  ): string {
     this.#requireStarted();
     const clientCommitId = crypto.randomUUID();
-    const operations: OutboxOperation[] = mutations.map((mutation) => {
+    const operations: OutboxOperation[] = mutations.map((mutation, index) => {
       const table = this.#table(mutation.table);
       if (mutation.op === 'delete') {
         return {
@@ -1536,6 +1544,9 @@ export class SyncClient {
           ? { baseVersion: mutation.baseVersion }
           : {}),
         values: json,
+        ...(changedFieldsByIndex[index] !== undefined
+          ? { changedFields: [...(changedFieldsByIndex[index] ?? [])] }
+          : {}),
       };
     });
     this.#applyBatch((batch) => {
@@ -1588,19 +1599,23 @@ export class SyncClient {
     for (const column of compiled.columns as readonly RowColumn[]) {
       record[column.name] = fromSqlValue(column, row[column.name] ?? null);
     }
-    for (const [name, value] of normalizeRecordKeys(compiled, partial)) {
+    const normalizedPartial = normalizeRecordKeys(compiled, partial);
+    for (const [name, value] of normalizedPartial) {
       record[name] = value;
     }
-    return this.mutate([
-      {
-        table,
-        op: 'upsert',
-        values: record,
-        ...(options?.baseVersion !== undefined
-          ? { baseVersion: options.baseVersion }
-          : {}),
-      },
-    ]);
+    return this.#recordMutations(
+      [
+        {
+          table,
+          op: 'upsert',
+          values: record,
+          ...(options?.baseVersion !== undefined
+            ? { baseVersion: options.baseVersion }
+            : {}),
+        },
+      ],
+      [[...normalizedPartial.keys()].sort()],
+    );
   }
 
   /** Host-facing patch result with explicit network work intent (§7.5). */
@@ -2150,6 +2165,17 @@ export class SyncClient {
     const subsById = new Map(
       (sentSubs ?? loadSubscriptions(this.#db)).map((sub) => [sub.id, sub]),
     );
+    const rejectionDetailsByCommit = new Map<
+      string,
+      ReadonlyMap<number, RejectionDetails>
+    >();
+    for (const frame of message.frames) {
+      if (frame.type !== 'PUSH_RESULT_DETAILS') continue;
+      rejectionDetailsByCommit.set(
+        frame.clientCommitId,
+        new Map(frame.entries.map((entry) => [entry.opIndex, entry.details])),
+      );
+    }
 
     const header = message.frames[0];
     if (header?.type !== 'RESP_HEADER') {
@@ -2198,8 +2224,17 @@ export class SyncClient {
             break;
           case 'PUSH_RESULT':
             this.#applyBatch((batch) =>
-              this.#handlePushResult(frame, commitsById, summary, batch),
+              this.#handlePushResult(
+                frame,
+                commitsById,
+                summary,
+                batch,
+                rejectionDetailsByCommit.get(frame.clientCommitId),
+              ),
             );
+            break;
+          case 'PUSH_RESULT_DETAILS':
+            // Pre-indexed above so companion ordering remains wire-additive.
             break;
           case 'SUB_START': {
             const sub = subsById.get(frame.id);
@@ -2427,6 +2462,7 @@ export class SyncClient {
     commitsById: ReadonlyMap<string, OutboxCommit>,
     summary: MutableSummary,
     batch: ChangeAccumulator,
+    rejectionDetails: ReadonlyMap<number, RejectionDetails> | undefined,
   ): void {
     const commit = commitsById.get(frame.clientCommitId);
     if (commit === undefined) return;
@@ -2483,12 +2519,14 @@ export class SyncClient {
         summary.conflicts.push(conflict);
         this.#config.onConflict?.(conflict);
       } else if (result.status === 'error') {
+        const details = rejectionDetails?.get(result.opIndex);
         const rejection: RejectionRecord = {
           clientCommitId: frame.clientCommitId,
           opIndex: result.opIndex,
           code: result.code,
           message: result.message,
           retryable: result.retryable,
+          ...(details !== undefined ? { details } : {}),
           ...(operation !== undefined ? { operation } : {}),
         };
         this.#rejections.push(rejection);

--- a/packages/web-client/src/outbox.ts
+++ b/packages/web-client/src/outbox.ts
@@ -29,6 +29,11 @@ export interface OutboxOperation {
   readonly baseVersion?: number;
   /** Full-row values keyed by column name; present iff `op` is `upsert`. */
   readonly values?: Readonly<Record<string, JsonRowValue>>;
+  /**
+   * Local-only normalized columns intentionally supplied to `patch()`.
+   * Absent for full-row mutate/upsert because intent is then unknown.
+   */
+  readonly changedFields?: readonly string[];
 }
 
 export interface OutboxCommit {

--- a/packages/web-client/src/outcomes.ts
+++ b/packages/web-client/src/outcomes.ts
@@ -6,7 +6,7 @@
  * restart can never turn "rejected" into an inferred success. Conflict payloads
  * deliberately stay local; retention never deletes an unresolved failure.
  */
-import type { RowValue } from '@syncular/core';
+import type { RejectionDetails, RowValue } from '@syncular/core';
 import type { ClientDatabase } from './database';
 import { ClientSyncError } from './errors';
 import type { OutboxOperation } from './outbox';
@@ -32,6 +32,8 @@ export interface RejectionRecord {
   readonly code: string;
   readonly message: string;
   readonly retryable: boolean;
+  /** Bounded host-declared metadata safe for authorized recovery UI. */
+  readonly details?: RejectionDetails;
   readonly operation?: OutboxOperation;
 }
 

--- a/packages/web-client/test/client.test.ts
+++ b/packages/web-client/test/client.test.ts
@@ -9,6 +9,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { type ClientSchema, ClientSyncError } from '@syncular/client';
+import { ValidationRejection } from '@syncular/server';
 import {
   CLIENT_SCHEMA,
   makeClient,
@@ -352,14 +353,12 @@ describe('durable commit outcomes', () => {
         },
       ]);
       await winner.client.syncUntilIdle();
-      const losingCommitId = loser.client.mutate([
-        {
-          table: 'tasks',
-          op: 'upsert',
-          values: taskValues('conflict-1', 'conflict', 'loser'),
-          baseVersion: 1,
-        },
-      ]);
+      const losingCommitId = loser.client.patch(
+        'tasks',
+        'conflict-1',
+        { title: 'loser' },
+        { baseVersion: 1 },
+      );
       await loser.client.syncUntilIdle();
 
       const outcome = loser.client.commitOutcome(losingCommitId);
@@ -381,6 +380,7 @@ describe('durable commit outcomes', () => {
                 op: 'upsert',
                 rowId: 'conflict-1',
                 baseVersion: 1,
+                changedFields: ['title'],
               },
             },
           },
@@ -395,6 +395,9 @@ describe('durable commit outcomes', () => {
       });
       expect(reopened.client.conflicts).toHaveLength(1);
       expect(reopened.client.conflicts[0]?.serverRow.title).toBe('winner');
+      expect(reopened.client.conflicts[0]?.operation?.changedFields).toEqual([
+        'title',
+      ]);
       const resolved = reopened.client.resolveCommitOutcome({
         clientCommitId: losingCommitId,
         resolution: 'resolved_keep_server',
@@ -495,6 +498,91 @@ describe('durable commit outcomes', () => {
     winner.db.close();
     await loser.client.close();
     loser.db.close();
+  });
+
+  test('structured rejection details and patch intent survive restart', async () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), 'syncular-rejection-details-'),
+    );
+    const databasePath = join(directory, 'client.db');
+    const server = makeServer(CLIENT_SCHEMA, {
+      validators: {
+        tasks: (operation) => {
+          if (operation.row?.title === 'invalid') {
+            throw new ValidationRejection(
+              'app.invalid_title',
+              'diagnostic only',
+              {
+                fieldPaths: ['title'],
+                reason: 'invalid_value',
+                requiredAction: 'edit_fields',
+                references: { task_id: operation.rowId },
+              },
+            );
+          }
+        },
+      },
+    });
+    try {
+      const first = await makeClient(server, {
+        clientId: 'rejection-details',
+        databasePath,
+      });
+      first.client.subscribe({
+        id: 's1',
+        table: 'tasks',
+        scopes: { project_id: ['details'] },
+      });
+      first.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('details-1', 'details', 'valid'),
+        },
+      ]);
+      await first.client.syncUntilIdle();
+      const rejectedId = first.client.patch(
+        'tasks',
+        'details-1',
+        { title: 'invalid' },
+        { baseVersion: 1 },
+      );
+      await first.client.syncUntilIdle();
+      expect(first.client.commitOutcome(rejectedId)).toMatchObject({
+        status: 'rejected',
+        results: [
+          {
+            status: 'error',
+            rejection: {
+              code: 'app.invalid_title',
+              details: {
+                fieldPaths: ['title'],
+                reason: 'invalid_value',
+                requiredAction: 'edit_fields',
+                references: { task_id: 'details-1' },
+              },
+              operation: { changedFields: ['title'] },
+            },
+          },
+        ],
+      });
+      await first.client.close();
+      first.db.close();
+
+      const reopened = await makeClient(server, {
+        clientId: 'rejection-details',
+        databasePath,
+      });
+      expect(reopened.client.rejections[0]).toMatchObject({
+        clientCommitId: rejectedId,
+        details: { fieldPaths: ['title'], requiredAction: 'edit_fields' },
+        operation: { changedFields: ['title'] },
+      });
+      await reopened.client.close();
+      reopened.db.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/web-client/test/helpers.ts
+++ b/packages/web-client/test/helpers.ts
@@ -28,6 +28,7 @@ import {
   SqliteServerStorage,
   SyncError,
   type SyncRequestContext,
+  type ValidatorRegistry,
 } from '@syncular/server';
 
 export const PARTITION = 'part-1';
@@ -128,7 +129,10 @@ function wrapStorage(
   };
 }
 
-export function makeServer(schema: ServerSchema = SERVER_SCHEMA): TestServer {
+export function makeServer(
+  schema: ServerSchema = SERVER_SCHEMA,
+  options: { readonly validators?: ValidatorRegistry } = {},
+): TestServer {
   const storage = new SqliteServerStorage();
   const segments = new MemorySegmentStore();
   const allowed: Record<string, ScopeMap> = {};
@@ -158,6 +162,9 @@ export function makeServer(schema: ServerSchema = SERVER_SCHEMA): TestServer {
     // the HTTP binding (one handler, two framings).
     segments,
     limits,
+    ...(options.validators !== undefined
+      ? { validators: options.validators }
+      : {}),
   });
   const server: TestServer = {
     storage,
@@ -177,6 +184,9 @@ export function makeServer(schema: ServerSchema = SERVER_SCHEMA): TestServer {
       resolveScopes,
       clock: () => now.ms,
       limits,
+      ...(options.validators !== undefined
+        ? { validators: options.validators }
+        : {}),
       realtime: hub,
     }),
   };

--- a/packages/web-client/test/outbox.test.ts
+++ b/packages/web-client/test/outbox.test.ts
@@ -50,6 +50,7 @@ describe('schema-agnostic persistence (§0 outbox rule)', () => {
       priority: 7,
       meta: '{"k":1}',
     });
+    expect(op?.changedFields).toBeUndefined();
     // The persisted form is JSON-serializable — no binary in the outbox.
     expect(() => JSON.stringify(op)).not.toThrow();
   });
@@ -157,6 +158,26 @@ describe('encode-at-send (§6.1)', () => {
       second,
       third,
     ]);
+  });
+
+  test('patch records normalized field intent locally without changing the wire', async () => {
+    const server = makeServer();
+    const a = await makeClient(server, { clientId: 'patch-intent' });
+    a.client.mutate([
+      { table: 'tasks', op: 'upsert', values: taskValues('t1', 'p1') },
+    ]);
+    await a.client.syncUntilIdle();
+    a.client.patch('tasks', 't1', { title: 'changed', projectId: 'p1' });
+    const commit = a.client.pendingCommits()[0];
+    expect(commit?.operations[0]?.changedFields).toEqual([
+      'project_id',
+      'title',
+    ]);
+    const frame = await encodeOutboxCommit(
+      compiled,
+      commit as NonNullable<typeof commit>,
+    );
+    expect(frame.operations[0]).not.toHaveProperty('changedFields');
   });
 });
 

--- a/rust/crates/client/src/api.rs
+++ b/rust/crates/client/src/api.rs
@@ -3,6 +3,8 @@
 //! states, subscription states. Serialized as camelCase to cross the shim
 //! boundary unchanged.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
@@ -260,6 +262,106 @@ pub struct ConflictRecord {
     pub operation: Option<CommitOperation>,
 }
 
+/// Bounded code-like metadata explicitly declared safe for authorized client
+/// recovery UI. Diagnostic prose remains in `RejectionRecord.message`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RejectionDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_paths: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub references: Option<BTreeMap<String, String>>,
+}
+
+impl RejectionDetails {
+    pub(crate) fn parse(raw: &str) -> Result<Self, String> {
+        if raw.len() > 4_096 {
+            return Err("rejection details exceed 4096 encoded bytes".to_owned());
+        }
+        let details: Self = serde_json::from_str(raw)
+            .map_err(|error| format!("invalid rejection details: {error}"))?;
+        details.validate()?;
+        Ok(details)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        let mut members = 0;
+        if let Some(paths) = &self.field_paths {
+            members += 1;
+            if paths.is_empty() || paths.len() > 32 {
+                return Err("fieldPaths must contain 1-32 paths".to_owned());
+            }
+            let mut seen = std::collections::BTreeSet::new();
+            for path in paths {
+                if path.len() > 160 || !path.split('.').all(valid_identifier) || !seen.insert(path)
+                {
+                    return Err("fieldPaths contains an invalid or duplicate path".to_owned());
+                }
+            }
+        }
+        if let Some(reason) = &self.reason {
+            members += 1;
+            if !valid_token(reason, 96) {
+                return Err("reason must be a lowercase stable token".to_owned());
+            }
+        }
+        if let Some(action) = &self.required_action {
+            members += 1;
+            if !valid_token(action, 96) {
+                return Err("requiredAction must be a lowercase stable token".to_owned());
+            }
+        }
+        if let Some(references) = &self.references {
+            members += 1;
+            if references.is_empty() || references.len() > 16 {
+                return Err("references must contain 1-16 entries".to_owned());
+            }
+            for (key, value) in references {
+                if !valid_token(key, 64)
+                    || value.is_empty()
+                    || value.len() > 256
+                    || value.trim() != value
+                    || value.chars().any(char::is_control)
+                {
+                    return Err("references contains an invalid key or value".to_owned());
+                }
+            }
+        }
+        if members == 0 {
+            return Err("rejection details must not be empty".to_owned());
+        }
+        Ok(())
+    }
+}
+
+fn valid_identifier(segment: &str) -> bool {
+    let mut chars = segment.chars();
+    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn valid_token(token: &str, max: usize) -> bool {
+    if token.is_empty() || token.len() > max || !token.starts_with(|c: char| c.is_ascii_lowercase())
+    {
+        return false;
+    }
+    let mut previous_separator = false;
+    for character in token.chars() {
+        if character.is_ascii_lowercase() || character.is_ascii_digit() {
+            previous_separator = false;
+        } else if matches!(character, '.' | '_' | '-') && !previous_separator {
+            previous_separator = true;
+        } else {
+            return false;
+        }
+    }
+    !previous_separator
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RejectionRecord {
@@ -268,6 +370,8 @@ pub struct RejectionRecord {
     pub code: String,
     pub message: String,
     pub retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<RejectionDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation: Option<CommitOperation>,
 }
@@ -283,6 +387,10 @@ pub struct CommitOperation {
     pub base_version: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Map<String, Value>>,
+    /// Normalized columns intentionally supplied to `patch()`; absent for a
+    /// full-row mutate/upsert because intent is unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_fields: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/rust/crates/client/src/client.rs
+++ b/rust/crates/client/src/client.rs
@@ -26,9 +26,9 @@ use crate::api::{
     ClientChangeBatch, ClientLimits, CommandEffects, CommitOperation, CommitOperationOutcome,
     CommitOutcome, CommitOutcomeQuery, CommitOutcomeResolution, CommitOutcomeStatus,
     ConflictRecord, CoverageSnapshot, LeaseState, Mutation, PresencePeer, QuerySnapshot,
-    RejectionRecord, ResolveCommitOutcomeInput, RowState, SchemaFloor, SubscriptionStateView,
-    SyncIntent, SyncOutcome, SyncReport, SyncStatusSnapshot, TableChange, WindowBase, WindowChange,
-    WindowCoverage, WindowState, WindowUnitRef,
+    RejectionDetails, RejectionRecord, ResolveCommitOutcomeInput, RowState, SchemaFloor,
+    SubscriptionStateView, SyncIntent, SyncOutcome, SyncReport, SyncStatusSnapshot, TableChange,
+    WindowBase, WindowChange, WindowCoverage, WindowState, WindowUnitRef,
 };
 use crate::schema::{parse_schema_json, ClientSchema};
 use crate::transport::{BlobDownload, BlobUploadGrant, SegmentRequest, Transport, TransportError};
@@ -200,6 +200,7 @@ mod observation_tests {
                 op: "upsert".to_owned(),
                 base_version: Some(1),
                 values: None,
+                changed_fields: None,
             }),
         };
 
@@ -412,6 +413,8 @@ struct OutboxOp {
     /// Schema-agnostic local form (§0): driver JSON values, encoded with
     /// the current codec at send time.
     values: Option<Map<String, Value>>,
+    /// Local-only patch intent; never encoded into SSP2 PUSH_COMMIT.
+    changed_fields: Option<Vec<String>>,
 }
 
 impl From<&OutboxOp> for CommitOperation {
@@ -422,6 +425,7 @@ impl From<&OutboxOp> for CommitOperation {
             op: if operation.upsert { "upsert" } else { "delete" }.to_owned(),
             base_version: operation.base_version,
             values: operation.values.clone(),
+            changed_fields: operation.changed_fields.clone(),
         }
     }
 }
@@ -1327,6 +1331,15 @@ impl SyncClient {
                             .to_owned(),
                         base_version: entry.get("baseVersion").and_then(Value::as_i64),
                         values: entry.get("values").and_then(Value::as_object).cloned(),
+                        changed_fields: entry.get("changedFields").and_then(Value::as_array).map(
+                            |values| {
+                                values
+                                    .iter()
+                                    .filter_map(Value::as_str)
+                                    .map(str::to_owned)
+                                    .collect()
+                            },
+                        ),
                     });
                 }
                 commits.push(OutboxCommit {
@@ -1808,6 +1821,7 @@ impl SyncClient {
                         message: "the persisted commit cannot encode under the current schema"
                             .to_owned(),
                         retryable: false,
+                        details: None,
                         operation: Some(CommitOperation::from(operation)),
                     };
                     rejections.push(rejection.clone());
@@ -1906,6 +1920,7 @@ impl SyncClient {
                     "rowId": op.row_id,
                     "baseVersion": op.base_version,
                     "values": op.values.clone().map(Value::Object),
+                    "changedFields": op.changed_fields,
                 })
             })
             .collect();
@@ -2561,6 +2576,7 @@ impl SyncClient {
                         row_id,
                         base_version,
                         values: Some(values),
+                        changed_fields: None,
                     });
                 }
                 Mutation::Delete {
@@ -2577,10 +2593,15 @@ impl SyncClient {
                         row_id,
                         base_version,
                         values: None,
+                        changed_fields: None,
                     });
                 }
             }
         }
+        self.record_outbox_commit(ops)
+    }
+
+    fn record_outbox_commit(&mut self, ops: Vec<OutboxOp>) -> Result<String, String> {
         let commit = OutboxCommit {
             client_commit_id: uuid::Uuid::new_v4().to_string(),
             ops,
@@ -2642,11 +2663,21 @@ impl SyncClient {
                     "sync.invalid_request: table {table:?} has no local row with primary key {row_id:?} to patch"
                 )
             })?;
+        let mut changed_fields = partial.keys().cloned().collect::<Vec<_>>();
+        changed_fields.sort();
         values.extend(partial);
-        self.mutate(vec![Mutation::Upsert {
+        let row_id_from_values = render_row_id_json(values.get(&schema_table.primary_key))?;
+        if row_id_from_values != row_id {
+            return Err("sync.invalid_request: patch cannot change the primary key".to_owned());
+        }
+        encode_row_json(schema_table, row_id, &values, &self.encryption)?;
+        self.record_outbox_commit(vec![OutboxOp {
+            upsert: true,
             table: table.to_owned(),
-            values,
+            row_id: row_id.to_owned(),
             base_version,
+            values: Some(values),
+            changed_fields: Some(changed_fields),
         }])
     }
 
@@ -3356,6 +3387,31 @@ impl SyncClient {
             pushed: meta.pushed_ids.len() as u32,
             ..SyncReport::default()
         };
+        let mut rejection_details_by_commit: HashMap<String, BTreeMap<i32, RejectionDetails>> =
+            HashMap::new();
+        for frame in &response.frames {
+            if let Frame::PushResultDetails {
+                client_commit_id,
+                entries,
+            } = frame
+            {
+                let details = rejection_details_by_commit
+                    .entry(client_commit_id.clone())
+                    .or_default();
+                for entry in entries {
+                    let parsed = match RejectionDetails::parse(&entry.details.0) {
+                        Ok(value) => value,
+                        Err(message) => {
+                            return SyncOutcome::Failed {
+                                error_code: "sync.invalid_request".to_owned(),
+                                message,
+                            };
+                        }
+                    };
+                    details.insert(entry.op_index, parsed);
+                }
+            }
+        }
         let mut frames = response.frames.into_iter();
         match frames.next() {
             Some(Frame::RespHeader {
@@ -3391,8 +3447,15 @@ impl SyncClient {
                     commit_seq: _,
                     results,
                 } => {
-                    self.handle_push_result(&client_commit_id, status, &results, &mut report);
+                    self.handle_push_result(
+                        &client_commit_id,
+                        status,
+                        &results,
+                        rejection_details_by_commit.get(&client_commit_id),
+                        &mut report,
+                    );
                 }
+                Frame::PushResultDetails { .. } => {}
                 Frame::SubStart {
                     id,
                     status,
@@ -3505,6 +3568,7 @@ impl SyncClient {
         client_commit_id: &str,
         status: PushStatus,
         results: &[OpResult],
+        rejection_details: Option<&BTreeMap<i32, RejectionDetails>>,
         report: &mut SyncReport,
     ) {
         let Some(index) = self
@@ -3648,6 +3712,9 @@ impl SyncClient {
                                 code: code.clone(),
                                 message: message.clone(),
                                 retryable: *retryable,
+                                details: rejection_details
+                                    .and_then(|details| details.get(op_index))
+                                    .cloned(),
                                 operation: operations
                                     .get(*op_index as usize)
                                     .map(CommitOperation::from),
@@ -4515,6 +4582,7 @@ impl SyncClient {
                         message: "the commit was dropped because its effective scope was revoked"
                             .to_owned(),
                         retryable: false,
+                        details: None,
                         operation: Some(CommitOperation::from(operation)),
                     };
                     rejections.push(rejection.clone());

--- a/rust/crates/ssp2/src/decode.rs
+++ b/rust/crates/ssp2/src/decode.rs
@@ -189,6 +189,8 @@ fn decode_response_frames(r: &mut Reader<'_>) -> Result<Vec<Frame>> {
     let mut sub_seen_commit = false;
     let mut sub_seen_segment = false;
     let mut error_seen = false;
+    let mut last_push_result: Option<(String, bool, Vec<i32>)> = None;
+    let mut last_push_result_has_details = false;
 
     while let Some((ty, payload)) = next_frame(r)? {
         if error_seen {
@@ -243,7 +245,70 @@ fn decode_response_frames(r: &mut Reader<'_>) -> Result<Vec<Frame>> {
                         "PUSH_RESULT after a SUB_START (out of grammar order)",
                     ));
                 }
-                frames.push(decode_push_result(payload)?);
+                let frame = decode_push_result(payload)?;
+                if let Frame::PushResult {
+                    client_commit_id,
+                    status,
+                    results,
+                    ..
+                } = &frame
+                {
+                    let error_indexes = results
+                        .iter()
+                        .filter_map(|result| match result {
+                            OpResult::Error { op_index, .. } => Some(*op_index),
+                            _ => None,
+                        })
+                        .collect();
+                    last_push_result = Some((
+                        client_commit_id.clone(),
+                        *status == PushStatus::Rejected,
+                        error_indexes,
+                    ));
+                    last_push_result_has_details = false;
+                }
+                frames.push(frame);
+                seen_body = true;
+            }
+            ft::PUSH_RESULT_DETAILS => {
+                if past_results {
+                    return Err(DecodeError::invalid(
+                        "PUSH_RESULT_DETAILS after a SUB_START (out of grammar order)",
+                    ));
+                }
+                let frame = decode_push_result_details(payload)?;
+                let Some((result_commit_id, result_rejected, error_indexes)) = &last_push_result
+                else {
+                    return Err(DecodeError::invalid(
+                        "PUSH_RESULT_DETAILS without a preceding PUSH_RESULT",
+                    ));
+                };
+                if last_push_result_has_details {
+                    return Err(DecodeError::invalid(
+                        "duplicate PUSH_RESULT_DETAILS companion",
+                    ));
+                }
+                if let Frame::PushResultDetails {
+                    client_commit_id,
+                    entries,
+                } = &frame
+                {
+                    if !*result_rejected || client_commit_id != result_commit_id {
+                        return Err(DecodeError::invalid(
+                            "PUSH_RESULT_DETAILS does not match its rejected PUSH_RESULT",
+                        ));
+                    }
+                    if entries
+                        .iter()
+                        .any(|entry| !error_indexes.contains(&entry.op_index))
+                    {
+                        return Err(DecodeError::invalid(
+                            "PUSH_RESULT_DETAILS entry does not match an error result",
+                        ));
+                    }
+                }
+                last_push_result_has_details = true;
+                frames.push(frame);
                 seen_body = true;
             }
             ft::SUB_START => {
@@ -572,6 +637,41 @@ fn decode_push_result(payload: &[u8]) -> Result<Frame> {
             status,
             commit_seq,
             results,
+        })
+    })
+}
+
+fn decode_push_result_details(payload: &[u8]) -> Result<Frame> {
+    frame_payload(payload, "PUSH_RESULT_DETAILS", |r| {
+        let client_commit_id = r.str("clientCommitId")?;
+        if client_commit_id.is_empty() {
+            return Err(DecodeError::invalid(
+                "PUSH_RESULT_DETAILS.clientCommitId must be non-empty",
+            ));
+        }
+        let count = r.u32("entries count")? as usize;
+        if count == 0 {
+            return Err(DecodeError::invalid(
+                "PUSH_RESULT_DETAILS must carry at least one entry",
+            ));
+        }
+        let mut entries = Vec::with_capacity(count.min(64));
+        let mut seen = std::collections::BTreeSet::new();
+        for _ in 0..count {
+            let op_index = r.i32("opIndex")?;
+            if op_index < 0 || !seen.insert(op_index) {
+                return Err(DecodeError::invalid(
+                    "PUSH_RESULT_DETAILS opIndex values must be unique and non-negative",
+                ));
+            }
+            entries.push(crate::model::PushResultDetail {
+                op_index,
+                details: r.json("details")?,
+            });
+        }
+        Ok(Frame::PushResultDetails {
+            client_commit_id,
+            entries,
         })
     })
 }

--- a/rust/crates/ssp2/src/encode.rs
+++ b/rust/crates/ssp2/src/encode.rs
@@ -160,6 +160,18 @@ fn encode_frame(frame: &Frame) -> (u8, Vec<u8>) {
             }
             ft::PUSH_RESULT
         }
+        Frame::PushResultDetails {
+            client_commit_id,
+            entries,
+        } => {
+            w.str(client_commit_id);
+            w.u32(entries.len() as u32);
+            for entry in entries {
+                w.i32(entry.op_index);
+                w.str(&entry.details.0);
+            }
+            ft::PUSH_RESULT_DETAILS
+        }
         Frame::SubStart {
             id,
             status,

--- a/rust/crates/ssp2/src/model.rs
+++ b/rust/crates/ssp2/src/model.rs
@@ -35,6 +35,7 @@ pub mod frame_type {
     pub const SEGMENT_INLINE: u8 = 0x15;
     pub const SUB_END: u8 = 0x16;
     pub const LEASE: u8 = 0x19;
+    pub const PUSH_RESULT_DETAILS: u8 = 0x1B;
     pub const ERROR: u8 = 0x1F;
 
     pub const REQUEST_TYPES: &[u8] = &[REQ_HEADER, PUSH_COMMIT, PULL_HEADER, SUBSCRIPTION];
@@ -47,6 +48,7 @@ pub mod frame_type {
         SEGMENT_INLINE,
         SUB_END,
         LEASE,
+        PUSH_RESULT_DETAILS,
         ERROR,
     ];
 }
@@ -159,6 +161,12 @@ pub enum OpResult {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushResultDetail {
+    pub op_index: i32,
+    pub details: RawJson,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Frame {
     ReqHeader {
@@ -197,6 +205,12 @@ pub enum Frame {
         status: PushStatus,
         commit_seq: Option<i64>,
         results: Vec<OpResult>,
+    },
+    /// Additive host-safe metadata for rejection records. Older clients skip
+    /// this frame under the unknown-frame rule and still process PUSH_RESULT.
+    PushResultDetails {
+        client_commit_id: String,
+        entries: Vec<PushResultDetail>,
     },
     SubStart {
         id: String,

--- a/rust/crates/ssp2/src/render.rs
+++ b/rust/crates/ssp2/src/render.rs
@@ -157,6 +157,27 @@ fn render_frame(frame: &Frame) -> Value {
                 Value::Array(results.iter().map(render_result).collect()),
             ));
         }
+        Frame::PushResultDetails {
+            client_commit_id,
+            entries: details_entries,
+        } => {
+            entries.push(("type", Value::from("PUSH_RESULT_DETAILS")));
+            entries.push(("clientCommitId", Value::from(client_commit_id.clone())));
+            entries.push((
+                "entries",
+                Value::Array(
+                    details_entries
+                        .iter()
+                        .map(|entry| {
+                            obj(vec![
+                                ("opIndex", Value::from(entry.op_index)),
+                                ("details", entry.details.parse()),
+                            ])
+                        })
+                        .collect(),
+                ),
+            ));
+        }
         Frame::SubStart {
             id,
             status,

--- a/rust/crates/ssp2/tests/push_result_details.rs
+++ b/rust/crates/ssp2/tests/push_result_details.rs
@@ -1,0 +1,74 @@
+use ssp2::model::{OpResult, PushResultDetail, PushStatus};
+use ssp2::primitives::RawJson;
+use ssp2::{decode_message, encode_message, Frame, Message, MsgKind};
+
+fn header() -> Frame {
+    Frame::RespHeader {
+        required_schema_version: None,
+        latest_schema_version: Some(1),
+    }
+}
+
+fn rejected() -> Frame {
+    Frame::PushResult {
+        client_commit_id: "commit-1".to_owned(),
+        status: PushStatus::Rejected,
+        commit_seq: None,
+        results: vec![OpResult::Error {
+            op_index: 0,
+            code: "app.invalid".to_owned(),
+            message: "diagnostic only".to_owned(),
+            retryable: false,
+        }],
+    }
+}
+
+fn details(commit_id: &str, op_index: i32) -> Frame {
+    Frame::PushResultDetails {
+        client_commit_id: commit_id.to_owned(),
+        entries: vec![PushResultDetail {
+            op_index,
+            details: RawJson(r#"{"reason":"invalid_value"}"#.to_owned()),
+        }],
+    }
+}
+
+#[test]
+fn valid_companion_round_trips() {
+    let message = Message {
+        msg_kind: MsgKind::Response,
+        frames: vec![header(), rejected(), details("commit-1", 0)],
+    };
+    let decoded = decode_message(&encode_message(&message)).expect("valid companion");
+    assert_eq!(decoded, message);
+}
+
+#[test]
+fn rejects_orphan_and_mismatched_companions() {
+    let orphan = Message {
+        msg_kind: MsgKind::Response,
+        frames: vec![header(), details("commit-1", 0)],
+    };
+    assert!(decode_message(&encode_message(&orphan))
+        .expect_err("orphan details must fail")
+        .to_string()
+        .contains("without a preceding PUSH_RESULT"));
+
+    let mismatched = Message {
+        msg_kind: MsgKind::Response,
+        frames: vec![header(), rejected(), details("other-commit", 0)],
+    };
+    assert!(decode_message(&encode_message(&mismatched))
+        .expect_err("mismatched details must fail")
+        .to_string()
+        .contains("does not match its rejected PUSH_RESULT"));
+
+    let wrong_operation = Message {
+        msg_kind: MsgKind::Response,
+        frames: vec![header(), rejected(), details("commit-1", 1)],
+    };
+    assert!(decode_message(&encode_message(&wrong_operation))
+        .expect_err("wrong operation details must fail")
+        .to_string()
+        .contains("does not match an error result"));
+}


### PR DESCRIPTION
## What changed

- add bounded, privacy-safe structured details for deliberate validation rejections through an additive SSP2 companion frame
- persist those details in server idempotency outcomes and TypeScript/Rust client outcome journals
- retain local-only changed-field intent for patch operations through conflicts, rejections, and restarts
- carry validators through WebSocket sync rounds and expose them in the published test kit
- document correction UX, concurrency testing, compatibility, and the 0.9.0 release

## Why

Offline-first applications need enough durable, machine-readable context to guide a user back to the fields they should correct. They also need to know which fields a local patch intended to change without trusting that metadata on the server or leaking arbitrary diagnostic data.

The companion frame keeps the legacy PUSH_RESULT layout stable: 0.8 clients skip frame 0x1B as unknown, while 0.9 clients accept older servers that omit it.

## Validation

- bun run check
- bun run build:packages
- bun run build:sites
- TypeScript-client × TypeScript-server conformance: 94 scenarios
- Rust-client × TypeScript-server conformance: 92 scenarios
- cargo fmt --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- Tauri and React Native binding gates
- Swift binding gate
- Kotlin and Flutter generated-schema checks; full toolchain gates skipped locally because JDK/Dart are unavailable
- 0.9.0 materialization, package build, and packed internal dependency pin audit in a disposable checkout
