### PR TITLE
Retain complete failed aggregate envelopes

### DIFF
--- a/apps/docs/src/content/concepts-conflicts.md
+++ b/apps/docs/src/content/concepts-conflicts.md
@@ -177,3 +177,9 @@ restore recovery UI after restart. Once the user keeps the server value or
 creates a corrected replacement commit, call `resolveCommitOutcome(...)`;
 resolution is explicit and one-way, so the app never silently loses evidence
 of an offline write that did not land.
+
+For a failed multi-operation commit, `outcome.operations` contains the complete
+ordered local envelope even though the server result names only the operation
+that terminated the atomic commit. Use it only in an authorized,
+domain-specific aggregate repair flow. The envelope is protected local payload,
+does not make full-row intent safe to infer, and never crosses the wire.

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -85,6 +85,9 @@ pump + disconnect realtime — call from `AppState` `'background'`) and
 Final commit outcomes use the same native SQLite journal as Tauri. Call
 `commitOutcome`, `commitOutcomes`, and `resolveCommitOutcome`; active
 conflicts/rejections and their losing operations survive app restarts.
+Failed aggregate outcomes also carry the complete ordered local operation
+envelope; it remains protected native SQLite payload and never enters the wire
+protocol or ordinary application preferences.
 
 ## Verification bar
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,26 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.10.0** (`v0.10.0`). All artifacts use Apache-2.0, except
+current release is **0.11.0** (`v0.11.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.11.0 release notes
+
+0.11.0 makes failed multi-operation commits recoverable as atomic aggregates
+after their outbox entry has drained.
+
+The release includes:
+
+- the complete schema-agnostic local operation envelope on conflict and
+  rejection outcomes, alongside the terminating operation result;
+- protected SQLite persistence in the same transaction that records the final
+  outcome and drains the outbox, including additive migration of 0.10 client
+  databases;
+- matching TypeScript and Rust/native APIs plus direct, restart, worker,
+  Tauri, and React Native compatibility;
+- an explicit privacy boundary: failed sibling values remain local-only in the
+  protected client database, never enter protocol frames, ordinary app
+  preferences, or telemetry, and follow existing outcome retention rules.
 
 ## 0.10.0 release notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2835,9 +2835,23 @@ newest-first local sequence, final status, and every operation result. A
 conflict retains its stable code and message, `serverVersion`, decoded
 `serverRow`, and the losing schema-agnostic local operation. An error retains
 its stable code, message, retryability, accepted §6.3.1 details when present,
-and local operation. The same rule
-applies to client-local terminal drops such as `sync.outbox_incompatible` and
-an outbox commit proven to be inside a revoked effective scope.
+and local operation. For a final `conflict` or `rejected` result, the entry also
+retains the complete ordered schema-agnostic local operation envelope from the
+failed commit. The envelope is required because the server reports only the
+terminating operation while every sibling rolled back; without it an
+application cannot safely reconstruct atomic aggregate intent after the
+outbox drains or the process restarts. Historical entries and successful
+outcomes MAY omit the envelope. The same rule applies to client-local terminal
+drops such as `sync.outbox_incompatible` and an outbox commit proven to be
+inside a revoked effective scope.
+
+The complete failed envelope is protected local payload. It MUST NOT be added
+to protocol frames, copied into ordinary application preferences or telemetry,
+or exposed in generic diagnostics. It follows the same active-failure-safe
+retention and explicit resolution lifecycle as the rest of the outcome entry.
+An application may inspect it only inside an authorized, domain-specific
+recovery surface; presence of the envelope does not make full-row edit intent
+known or authorize an automatic merge.
 
 The operation journal also preserves **local edit intent** for an upsert made
 through the client's partial-update API: `changedFields` is the normalized,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -16,7 +16,9 @@ the single mutable core owner.
 The bridge includes the native core's durable commit-outcome journal:
 `commitOutcome`, `commitOutcomes`, and `resolveCommitOutcome`. Final results
 and explicit conflict resolutions survive process restarts; active failures
-are never silently removed by retention.
+are never silently removed by retention. Failed outcomes retain their complete
+ordered local operation envelope for authorized aggregate recovery with the
+same protected-storage and retention contract as the core client.
 
 Part of [Syncular](https://syncular.dev) — an offline-first sync framework.
 See the [Syncular repository](https://github.com/syncular/syncular) for docs.

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -117,6 +117,11 @@ the same SQLite transaction that drains their outbox commit. Conflict entries
 retain the losing operation plus `serverVersion`/`serverRow`; active failures
 restore after restart and are never removed by retention. Configure the
 history cap with `limits.outcomeRetentionMaxEntries` (default 1,000).
+Failed outcomes additionally retain the complete ordered local commit envelope
+as `outcome.operations`, so a domain recovery flow can reconstruct siblings
+that rolled back with the terminating operation. It stays in the protected
+client database and is never added to the wire protocol, preferences, or
+telemetry; successful and historical outcomes may omit it.
 
 Use `patch(table, rowId, partial, { baseVersion? })` for editor-style partial
 updates. The wire still carries a full row, but the durable local operation

--- a/packages/web-client/src/client.ts
+++ b/packages/web-client/src/client.ts
@@ -1737,6 +1737,7 @@ export class SyncClient {
         status: 'rejected',
         recordedAtMs: this.#now(),
         results: [{ status: 'error', rejection }],
+        operations: commit.operations,
       });
       pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
       batch.status();
@@ -2543,6 +2544,7 @@ export class SyncClient {
         : 'rejected',
       recordedAtMs: this.#now(),
       results: outcomeResults,
+      operations: commit.operations,
     });
     pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
     batch.outcomes();
@@ -2900,6 +2902,7 @@ export class SyncClient {
                 status: 'rejected',
                 recordedAtMs: this.#now(),
                 results,
+                operations: commit.operations,
               });
             }
             pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);

--- a/packages/web-client/src/outcomes.ts
+++ b/packages/web-client/src/outcomes.ts
@@ -70,6 +70,12 @@ export interface CommitOutcome {
   readonly status: CommitOutcomeStatus;
   readonly recordedAtMs: number;
   readonly results: readonly CommitOperationOutcome[];
+  /**
+   * Complete local failed-commit envelope, retained after outbox drain so an
+   * authorized application can reconstruct atomic aggregate intent. Absent
+   * for successful and historical outcomes. Never sent over the wire.
+   */
+  readonly operations?: readonly OutboxOperation[];
   readonly resolution: CommitOutcomeResolution;
   readonly resolvedAtMs?: number;
   readonly replacementClientCommitId?: string;
@@ -142,6 +148,9 @@ function parseOutcome(row: Readonly<Record<string, unknown>>): CommitOutcome {
     status: row.status as CommitOutcomeStatus,
     recordedAtMs: row.recorded_at_ms as number,
     results: decodeResults(row.results as string),
+    ...(typeof row.operations === 'string'
+      ? { operations: JSON.parse(row.operations) as OutboxOperation[] }
+      : {}),
     resolution: row.resolution as CommitOutcomeResolution,
     ...(typeof row.resolved_at_ms === 'number'
       ? { resolvedAtMs: row.resolved_at_ms }
@@ -158,13 +167,16 @@ export function recordCommitOutcome(
 ): CommitOutcome {
   db.exec(
     `INSERT INTO _syncular_commit_outcomes(
-       client_commit_id, status, recorded_at_ms, results, resolution
-     ) VALUES (?, ?, ?, ?, 'active')`,
+       client_commit_id, status, recorded_at_ms, results, operations, resolution
+     ) VALUES (?, ?, ?, ?, ?, 'active')`,
     [
       outcome.clientCommitId,
       outcome.status,
       outcome.recordedAtMs,
       encodeResults(outcome.results),
+      outcome.operations === undefined
+        ? null
+        : JSON.stringify(outcome.operations),
     ],
   );
   return commitOutcome(db, outcome.clientCommitId) as CommitOutcome;
@@ -175,7 +187,7 @@ export function commitOutcome(
   clientCommitId: string,
 ): CommitOutcome | undefined {
   const row = db.query(
-    `SELECT seq, client_commit_id, status, recorded_at_ms, results,
+    `SELECT seq, client_commit_id, status, recorded_at_ms, results, operations,
             resolution, resolved_at_ms, replacement_client_commit_id
        FROM _syncular_commit_outcomes WHERE client_commit_id = ?`,
     [clientCommitId],
@@ -198,7 +210,7 @@ export function listCommitOutcomes(
     ? "WHERE resolution = 'active' AND status IN ('conflict', 'rejected')"
     : '';
   const rows = db.query(
-    `SELECT seq, client_commit_id, status, recorded_at_ms, results,
+    `SELECT seq, client_commit_id, status, recorded_at_ms, results, operations,
             resolution, resolved_at_ms, replacement_client_commit_id
        FROM _syncular_commit_outcomes ${where}
       ORDER BY seq DESC${limit === undefined ? '' : ' LIMIT ?'}`,

--- a/packages/web-client/src/schema.ts
+++ b/packages/web-client/src/schema.ts
@@ -294,10 +294,20 @@ export function ensureLocalSchema(
       status TEXT NOT NULL CHECK(status IN ('applied', 'cached', 'conflict', 'rejected')),
       recorded_at_ms INTEGER NOT NULL,
       results TEXT NOT NULL,
+      operations TEXT,
       resolution TEXT NOT NULL DEFAULT 'active'
         CHECK(resolution IN ('active', 'resolved_keep_server', 'superseded', 'dismissed')),
       resolved_at_ms INTEGER,
       replacement_client_commit_id TEXT)`);
+    // Outcomes created before durable aggregate recovery retain no commit
+    // envelope. New failed outcomes store it in the protected client DB.
+    try {
+      db.exec(
+        'ALTER TABLE _syncular_commit_outcomes ADD COLUMN operations TEXT',
+      );
+    } catch {
+      // column already exists — the CREATE above included it
+    }
     db.exec(`CREATE INDEX IF NOT EXISTS _syncular_commit_outcomes_resolution_seq
       ON _syncular_commit_outcomes(resolution, seq)`);
     db.exec(`CREATE TABLE IF NOT EXISTS _syncular_subscriptions(

--- a/packages/web-client/test/client.test.ts
+++ b/packages/web-client/test/client.test.ts
@@ -500,6 +500,89 @@ describe('durable commit outcomes', () => {
     loser.db.close();
   });
 
+  test('retains the complete failed aggregate envelope across restart', async () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), 'syncular-aggregate-outcome-'),
+    );
+    const databasePath = join(directory, 'loser.db');
+    const server = makeServer();
+    try {
+      const winner = await makeClient(server, { clientId: 'aggregate-winner' });
+      const loser = await makeClient(server, {
+        clientId: 'aggregate-loser',
+        databasePath,
+      });
+      for (const entry of [winner, loser]) {
+        entry.client.subscribe({
+          id: 's1',
+          table: 'tasks',
+          scopes: { project_id: ['aggregate'] },
+        });
+      }
+      winner.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('aggregate-root', 'aggregate', 'base'),
+        },
+      ]);
+      await winner.client.syncUntilIdle();
+      await loser.client.syncUntilIdle();
+      winner.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('aggregate-root', 'aggregate', 'winner'),
+          baseVersion: 1,
+        },
+      ]);
+      await winner.client.syncUntilIdle();
+
+      const losingCommitId = loser.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('aggregate-root', 'aggregate', 'loser'),
+          baseVersion: 1,
+        },
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('aggregate-child', 'aggregate', 'sibling intent'),
+          baseVersion: 0,
+        },
+      ]);
+      await loser.client.syncUntilIdle();
+      expect(loser.client.commitOutcome(losingCommitId)).toMatchObject({
+        status: 'conflict',
+        results: [{ status: 'conflict' }],
+        operations: [
+          { rowId: 'aggregate-root', baseVersion: 1 },
+          { rowId: 'aggregate-child', baseVersion: 0 },
+        ],
+      });
+      await loser.client.close();
+      loser.db.close();
+
+      const reopened = await makeClient(server, {
+        clientId: 'aggregate-loser',
+        databasePath,
+      });
+      expect(
+        reopened.client.commitOutcome(losingCommitId)?.operations,
+      ).toMatchObject([
+        { table: 'tasks', rowId: 'aggregate-root', op: 'upsert' },
+        { table: 'tasks', rowId: 'aggregate-child', op: 'upsert' },
+      ]);
+      await reopened.client.close();
+      reopened.db.close();
+      await winner.client.close();
+      winner.db.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test('structured rejection details and patch intent survive restart', async () => {
     const directory = mkdtempSync(
       join(tmpdir(), 'syncular-rejection-details-'),

--- a/packages/web-client/test/outbox.test.ts
+++ b/packages/web-client/test/outbox.test.ts
@@ -30,6 +30,26 @@ import {
 const compiled = compileClientSchema(CLIENT_SCHEMA);
 
 describe('schema-agnostic persistence (§0 outbox rule)', () => {
+  test('migrates a pre-envelope outcome journal additively', () => {
+    const db = new BunClientDatabase();
+    db.exec(`CREATE TABLE _syncular_commit_outcomes(
+      seq INTEGER PRIMARY KEY AUTOINCREMENT,
+      client_commit_id TEXT NOT NULL UNIQUE,
+      status TEXT NOT NULL,
+      recorded_at_ms INTEGER NOT NULL,
+      results TEXT NOT NULL,
+      resolution TEXT NOT NULL DEFAULT 'active',
+      resolved_at_ms INTEGER,
+      replacement_client_commit_id TEXT)`);
+    ensureLocalSchema(db, compiled);
+    expect(
+      db
+        .query('PRAGMA table_info(_syncular_commit_outcomes)')
+        .map((column) => column.name),
+    ).toContain('operations');
+    db.close();
+  });
+
   test('mutations are stored as JSON values, not encoded bytes', async () => {
     const server = makeServer();
     const a = await makeClient(server, { clientId: 'client-a' });

--- a/rust/crates/client/src/api.rs
+++ b/rust/crates/client/src/api.rs
@@ -434,6 +434,10 @@ pub struct CommitOutcome {
     pub status: CommitOutcomeStatus,
     pub recorded_at_ms: i64,
     pub results: Vec<CommitOperationOutcome>,
+    /// Complete local failed-commit envelope retained after outbox drain.
+    /// Absent for successful and historical outcomes; never sent over wire.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operations: Option<Vec<CommitOperation>>,
     pub resolution: CommitOutcomeResolution,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolved_at_ms: Option<i64>,

--- a/rust/crates/client/src/client.rs
+++ b/rust/crates/client/src/client.rs
@@ -168,6 +168,58 @@ mod observation_tests {
     }
 
     #[test]
+    fn migrates_pre_envelope_outcome_journal_additively() {
+        let path = std::env::temp_dir().join(format!(
+            "syncular-outcome-migration-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let conn = Connection::open(&path).expect("open legacy database");
+        conn.execute_batch(
+            "CREATE TABLE _syncular_commit_outcomes (
+               seq INTEGER PRIMARY KEY AUTOINCREMENT,
+               client_commit_id TEXT NOT NULL UNIQUE,
+               status TEXT NOT NULL,
+               recorded_at_ms INTEGER NOT NULL,
+               results_json TEXT NOT NULL,
+               resolution TEXT NOT NULL DEFAULT 'active',
+               resolved_at_ms INTEGER,
+               replacement_client_commit_id TEXT);",
+        )
+        .expect("create legacy outcome journal");
+        drop(conn);
+        let schema = json!({
+            "version": 1,
+            "tables": [{
+                "name": "tasks",
+                "primaryKey": "id",
+                "columns": [
+                    { "name": "id", "type": "string", "nullable": false },
+                    { "name": "project_id", "type": "string", "nullable": false }
+                ],
+                "scopes": [{ "pattern": "project:{project_id}" }]
+            }]
+        });
+        let client = SyncClient::open_path(
+            "migration-native".to_owned(),
+            &schema,
+            ClientLimits::default(),
+            path.to_str().expect("UTF-8 temp path"),
+        )
+        .expect("migrate database");
+        let has_operations = client
+            .conn
+            .prepare("PRAGMA table_info(_syncular_commit_outcomes)")
+            .expect("prepare table info")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query table info")
+            .filter_map(Result::ok)
+            .any(|column| column == "operations_json");
+        assert!(has_operations);
+        drop(client);
+        std::fs::remove_file(path).expect("remove temp database");
+    }
+
+    #[test]
     fn durable_conflict_outcome_and_resolution_survive_reopen() {
         let path = std::env::temp_dir().join(format!(
             "syncular-durable-outcome-{}.db",
@@ -203,6 +255,24 @@ mod observation_tests {
                 changed_fields: None,
             }),
         };
+        let failed_operations = vec![
+            OutboxOp {
+                upsert: true,
+                table: "tasks".to_owned(),
+                row_id: "t1".to_owned(),
+                base_version: Some(1),
+                values: None,
+                changed_fields: None,
+            },
+            OutboxOp {
+                upsert: true,
+                table: "tasks".to_owned(),
+                row_id: "status-event-1".to_owned(),
+                base_version: Some(0),
+                values: None,
+                changed_fields: None,
+            },
+        ];
 
         {
             let mut first = SyncClient::open_path(
@@ -222,6 +292,7 @@ mod observation_tests {
                     &[CommitOperationOutcome::Conflict {
                         conflict: conflict.clone(),
                     }],
+                    Some(&failed_operations),
                 )
                 .expect("persist outcome");
             first.conflicts.push(conflict);
@@ -246,14 +317,14 @@ mod observation_tests {
             )
             .expect("reopen");
             assert_eq!(reopened.conflicts().len(), 1);
-            assert_eq!(
-                reopened
-                    .commit_outcome("losing-commit")
-                    .expect("read outcome")
-                    .expect("outcome")
-                    .status,
-                CommitOutcomeStatus::Conflict
-            );
+            let outcome = reopened
+                .commit_outcome("losing-commit")
+                .expect("read outcome")
+                .expect("outcome");
+            assert_eq!(outcome.status, CommitOutcomeStatus::Conflict);
+            let operations = outcome.operations.expect("aggregate envelope");
+            assert_eq!(operations.len(), 2);
+            assert_eq!(operations[1].row_id, "status-event-1");
             let resolved = reopened
                 .resolve_commit_outcome(ResolveCommitOutcomeInput {
                     client_commit_id: "losing-commit".to_owned(),
@@ -434,6 +505,18 @@ impl From<&OutboxOp> for CommitOperation {
 struct OutboxCommit {
     client_commit_id: String,
     ops: Vec<OutboxOp>,
+}
+
+struct StoredCommitOutcomeRow {
+    sequence: i64,
+    client_commit_id: String,
+    status: String,
+    recorded_at_ms: i64,
+    results_json: String,
+    operations_json: Option<String>,
+    resolution: String,
+    resolved_at_ms: Option<i64>,
+    replacement_client_commit_id: Option<String>,
 }
 
 /// Section outcome distinguishing the §5.6 subscription-local fail-closed
@@ -1151,6 +1234,7 @@ impl SyncClient {
                    status TEXT NOT NULL CHECK(status IN ('applied', 'cached', 'conflict', 'rejected')),
                    recorded_at_ms INTEGER NOT NULL,
                    results_json TEXT NOT NULL,
+                   operations_json TEXT,
                    resolution TEXT NOT NULL DEFAULT 'active'
                      CHECK(resolution IN ('active', 'resolved_keep_server', 'superseded', 'dismissed')),
                    resolved_at_ms INTEGER,
@@ -1169,6 +1253,11 @@ impl SyncClient {
                    effective_scopes TEXT NOT NULL);",
             )
             .map_err(|e| e.to_string())?;
+        // Migrate an outcome journal created before failed aggregate
+        // envelopes were retained. Historical rows intentionally stay NULL.
+        let _ = self
+            .conn
+            .execute_batch("ALTER TABLE _syncular_commit_outcomes ADD COLUMN operations_json TEXT");
         // §7.4.1: seed the persisted local schema-version marker on first
         // create (a fresh install is already at its generated version).
         if self.get_meta(LOCAL_SCHEMA_VERSION_KEY).is_none() {
@@ -1832,6 +1921,7 @@ impl SyncClient {
                 &commit.client_commit_id,
                 CommitOutcomeStatus::Rejected,
                 &results,
+                Some(&commit.ops),
             )?;
             self.delete_outbox_persisted(&commit.client_commit_id)?;
         }
@@ -1985,46 +2075,45 @@ impl SyncClient {
         client_commit_id: &str,
         status: CommitOutcomeStatus,
         results: &[CommitOperationOutcome],
+        operations: Option<&[OutboxOp]>,
     ) -> Result<(), String> {
         let results_json = serde_json::to_string(results).map_err(|error| error.to_string())?;
+        let operations_json = operations
+            .map(|items| {
+                serde_json::to_string(&items.iter().map(CommitOperation::from).collect::<Vec<_>>())
+            })
+            .transpose()
+            .map_err(|error| error.to_string())?;
         self.conn
             .execute(
                 "INSERT INTO _syncular_commit_outcomes (
-                   client_commit_id, status, recorded_at_ms, results_json, resolution
-                 ) VALUES (?1, ?2, ?3, ?4, 'active')",
+                   client_commit_id, status, recorded_at_ms, results_json,
+                   operations_json, resolution
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'active')",
                 rusqlite::params![
                     client_commit_id,
                     Self::outcome_status_name(status),
                     self.clock_now_ms(),
-                    results_json
+                    results_json,
+                    operations_json
                 ],
             )
             .map(|_| ())
             .map_err(|error| error.to_string())
     }
 
-    fn outcome_from_tuple(
-        row: (
-            i64,
-            String,
-            String,
-            i64,
-            String,
-            String,
-            Option<i64>,
-            Option<String>,
-        ),
-    ) -> Result<CommitOutcome, String> {
-        let (
+    fn outcome_from_row(row: StoredCommitOutcomeRow) -> Result<CommitOutcome, String> {
+        let StoredCommitOutcomeRow {
             sequence,
             client_commit_id,
             status,
             recorded_at_ms,
             results_json,
+            operations_json,
             resolution,
             resolved_at_ms,
             replacement_client_commit_id,
-        ) = row;
+        } = row;
         Ok(CommitOutcome {
             sequence,
             client_commit_id,
@@ -2032,6 +2121,13 @@ impl SyncClient {
             recorded_at_ms,
             results: serde_json::from_str(&results_json)
                 .map_err(|error| format!("invalid persisted commit outcome results: {error}"))?,
+            operations: operations_json
+                .map(|value| {
+                    serde_json::from_str(&value).map_err(|error| {
+                        format!("invalid persisted commit outcome operations: {error}")
+                    })
+                })
+                .transpose()?,
             resolution: Self::parse_outcome_resolution(&resolution)?,
             resolved_at_ms,
             replacement_client_commit_id,
@@ -2042,26 +2138,27 @@ impl SyncClient {
         let row = self
             .conn
             .query_row(
-                "SELECT seq, client_commit_id, status, recorded_at_ms, results_json,
+                "SELECT seq, client_commit_id, status, recorded_at_ms, results_json, operations_json,
                         resolution, resolved_at_ms, replacement_client_commit_id
                    FROM _syncular_commit_outcomes WHERE client_commit_id = ?1",
                 rusqlite::params![client_commit_id],
                 |row| {
-                    Ok((
-                        row.get(0)?,
-                        row.get(1)?,
-                        row.get(2)?,
-                        row.get(3)?,
-                        row.get(4)?,
-                        row.get(5)?,
-                        row.get(6)?,
-                        row.get(7)?,
-                    ))
+                    Ok(StoredCommitOutcomeRow {
+                        sequence: row.get(0)?,
+                        client_commit_id: row.get(1)?,
+                        status: row.get(2)?,
+                        recorded_at_ms: row.get(3)?,
+                        results_json: row.get(4)?,
+                        operations_json: row.get(5)?,
+                        resolution: row.get(6)?,
+                        resolved_at_ms: row.get(7)?,
+                        replacement_client_commit_id: row.get(8)?,
+                    })
                 },
             )
             .optional()
             .map_err(|error| error.to_string())?;
-        row.map(Self::outcome_from_tuple).transpose()
+        row.map(Self::outcome_from_row).transpose()
     }
 
     pub fn commit_outcomes(&self, query: CommitOutcomeQuery) -> Result<Vec<CommitOutcome>, String> {
@@ -2069,7 +2166,7 @@ impl SyncClient {
             return Err("sync.invalid_request: commit outcome limit must be positive".to_owned());
         }
         let mut sql = String::from(
-            "SELECT seq, client_commit_id, status, recorded_at_ms, results_json,
+            "SELECT seq, client_commit_id, status, recorded_at_ms, results_json, operations_json,
                     resolution, resolved_at_ms, replacement_client_commit_id
                FROM _syncular_commit_outcomes",
         );
@@ -2083,21 +2180,22 @@ impl SyncClient {
         let mut stmt = self.conn.prepare(&sql).map_err(|error| error.to_string())?;
         let rows = stmt
             .query_map([], |row| {
-                Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                    row.get(4)?,
-                    row.get(5)?,
-                    row.get(6)?,
-                    row.get(7)?,
-                ))
+                Ok(StoredCommitOutcomeRow {
+                    sequence: row.get(0)?,
+                    client_commit_id: row.get(1)?,
+                    status: row.get(2)?,
+                    recorded_at_ms: row.get(3)?,
+                    results_json: row.get(4)?,
+                    operations_json: row.get(5)?,
+                    resolution: row.get(6)?,
+                    resolved_at_ms: row.get(7)?,
+                    replacement_client_commit_id: row.get(8)?,
+                })
             })
             .map_err(|error| error.to_string())?;
         let mut outcomes = Vec::new();
         for row in rows {
-            outcomes.push(Self::outcome_from_tuple(
+            outcomes.push(Self::outcome_from_row(
                 row.map_err(|error| error.to_string())?,
             )?);
         }
@@ -3604,7 +3702,12 @@ impl SyncClient {
                     CommitOutcomeStatus::Cached
                 };
                 if self
-                    .persist_commit_outcome(client_commit_id, outcome_status, &journal_results)
+                    .persist_commit_outcome(
+                        client_commit_id,
+                        outcome_status,
+                        &journal_results,
+                        None,
+                    )
                     .and_then(|()| self.delete_outbox_persisted(client_commit_id))
                     .and_then(|()| self.prune_commit_outcomes())
                     .is_err()
@@ -3732,7 +3835,12 @@ impl SyncClient {
                     CommitOutcomeStatus::Conflict
                 };
                 if self
-                    .persist_commit_outcome(client_commit_id, outcome_status, &journal_results)
+                    .persist_commit_outcome(
+                        client_commit_id,
+                        outcome_status,
+                        &journal_results,
+                        Some(&operations),
+                    )
                     .and_then(|()| self.delete_outbox_persisted(client_commit_id))
                     .and_then(|()| self.prune_commit_outcomes())
                     .is_err()
@@ -4593,6 +4701,7 @@ impl SyncClient {
                 &commit.client_commit_id,
                 CommitOutcomeStatus::Rejected,
                 &results,
+                Some(&commit.ops),
             )?;
             self.delete_outbox_persisted(&commit.client_commit_id)?;
         }


### PR DESCRIPTION
## Summary
- retain the complete ordered local operation envelope on failed commit outcomes
- migrate TypeScript and Rust/native protected outcome journals additively
- document privacy, retention, and authorized recovery boundaries

## Verification
- bun run check (1,206 pass, 6 environment skips, 8 isolated multi-tab)
- bun run build:packages && bun run build:sites
- bun run bench:ci
- cargo fmt/clippy/test plus native transport and Rust conformance (93/93)
- Tauri workspace + native bridge
- Swift and React Native binding gates
- Kotlin/Flutter generated output fresh; runtime checks delegated to provisioned CI lanes