### PR TITLE
feat(typegen): support safe table retirement

### DIFF
--- a/apps/docs/src/content/guide-schema.md
+++ b/apps/docs/src/content/guide-schema.md
@@ -11,10 +11,11 @@ The authoritative contract for the manifest, the IR, and the SQL subset is the
 ## The two inputs
 
 **Migrations** (`migrations/NNNN_name/up.sql`) declare table shape. typegen
-parses a strict SQL subset (`CREATE TABLE` / `ALTER TABLE ADD COLUMN`, the
-six column types, one single-column primary key per table) and reads only
-the table shape. It never runs your migrations: your host does that, and
-the server manages its own internal tables.
+parses a strict SQL subset (`CREATE TABLE`, `ALTER TABLE ADD COLUMN`,
+`CREATE INDEX`, and `DROP TABLE`, plus the supported column types and one
+single-column primary key per table) and reads only the head table shape. It
+never runs your migrations: your host does that, and the server manages its
+own internal tables.
 
 **The manifest** (`syncular.json`) names the synced tables, their scope
 patterns, subscription templates, and the schema-version history:
@@ -32,8 +33,16 @@ patterns, subscription templates, and the schema-version history:
 }
 ```
 
-Table array order is the bootstrap order (parents before children). Every
-migrated table must be listed; unknown manifest keys are hard errors.
+Table array order is the bootstrap order (parents before children). Every table
+present at the head of migration history must be listed; a table retired by
+`DROP TABLE` is omitted. Unknown manifest keys are hard errors.
+
+`DROP TABLE IF EXISTS name` is also accepted. A dropped table name cannot be
+reused later: the generated head schema cannot safely distinguish that from an
+incompatible in-place rewrite on an upgrading server. The reference server
+drops the retired relational current-row table and its live scope index during
+the schema bump. Historical commit-log rows remain subject to normal retention,
+so table retirement is not a compliance erasure operation.
 
 ## Generate
 
@@ -112,11 +121,11 @@ in schema-agnostic form and encoded at send time with the current codec
 The server never accepts a retired encoding, and pending offline writes stay
 visible across the bump.
 
-### Dropped columns
+### Dropped columns and tables
 
-Re-encoding fails when a pending commit references a column the new schema no
-longer has: the value has nowhere to go, and there is no migration to fill or
-drop it. This surfaces as a rejection with the client-local code
+Re-encoding fails when a pending commit references a column or table the new
+schema no longer has: the value or operation has nowhere to go. This surfaces
+as a rejection with the client-local code
 `sync.outbox_incompatible` (§7.4.4). The un-encodable commit leaves the outbox
 and its purely-optimistic rows are undone, exactly like a server rejection.
 Later outbox commits that *do* encode keep replaying, so the queue keeps

--- a/docs/DESIGN-relational-server-storage.md
+++ b/docs/DESIGN-relational-server-storage.md
@@ -70,7 +70,8 @@ bounds the motivation and the bench-harness expectations.
 6. **Two dialects, three backends**: sqlite + d1 share `sqlite-dialect`;
    postgres is its own.
 7. **The migration subset is small**: CREATE TABLE / ADD COLUMN /
-   CREATE INDEX. Note: this subset exists **client-side only** today —
+   CREATE INDEX / DROP TABLE. Note: this subset existed **client-side only**
+   before relational server storage —
    v2 has no server-side DDL-application machinery at all
    (web-client/test/indexes.test.ts states this explicitly). P3 is
    greenfield, bounded by the subset, not a revival of existing code.
@@ -160,12 +161,17 @@ for incremental deltas — both hand the wire the same bytes as today.
 
 ### Server-side schema migration (the genuinely new burden)
 
-The server must create tables on first use and `ALTER` on a schemaVersion
-bump (add column, add index — exactly the migration subset). This is
+The server must create tables on first use and evolve them on a schemaVersion
+bump (add column, add index, retire table — exactly the migration subset). This is
 **new code** (v2 has no server DDL machinery; see constraint 7), bounded
-by the subset: CREATE TABLE / ADD COLUMN / CREATE INDEX only. The
+by the subset: CREATE TABLE / ADD COLUMN / CREATE INDEX / DROP TABLE only. The
 schema-floor response (§1.6) already gates unsupported client versions;
 server migration runs at schema load / version bump.
+
+A retired table is detected from the persisted prior layouts and removed from
+the relational current-row store together with its `sync_row_scopes` entries.
+The append-only commit log remains under the ordinary retention policy; schema
+retirement is deliberately not presented as a compliance erasure primitive.
 
 On D1 (stateless Workers, per-request instantiation) a schema-version
 marker table gates the DDL check so cold starts don't re-run `CREATE TABLE
@@ -340,7 +346,7 @@ P3 grew slightly (honest greenfield framing); net unchanged.
   written in the same statement/transaction from the same source bytes,
   and the contract tests assert agreement.
 - **Migration correctness under version bump** — bounded by the migration
-  subset (CREATE TABLE / ADD COLUMN / CREATE INDEX); server migration
+  subset (CREATE TABLE / ADD COLUMN / CREATE INDEX / DROP TABLE); server migration
   mirrors the client's DDL derivation. Genuinely new code — the largest
   unknown in the plan.
 - **D1 projection fidelity** — i64 > 2⁵³ imprecise in typed columns

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,26 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.11.0** (`v0.11.0`). All artifacts use Apache-2.0, except
+current release is **0.12.0** (`v0.12.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.12.0 release notes
+
+0.12.0 adds safe table retirement to SQL migration type generation and the
+relational server schema-bump path.
+
+The release includes:
+
+- strict `DROP TABLE name` and `DROP TABLE IF EXISTS name` parsing, with
+  unknown tables, trailing clauses, and dropped-name reuse rejected;
+- head-schema generation that permits historically created, subsequently
+  retired tables to be omitted from the manifest and generated APIs;
+- SQLite, PostgreSQL, and D1 schema bumps that remove retired relational
+  current-row tables and their live scope-index entries;
+- an explicit retention boundary: append-only commit history remains governed
+  by ordinary retention, so schema retirement is not an erasure API;
+- generator, manifest, and three-dialect server migration coverage plus
+  updated schema documentation.
 
 ## 0.11.0 release notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/server/src/d1-storage.ts
+++ b/packages/server/src/d1-storage.ts
@@ -43,9 +43,11 @@ import { syncError } from './errors';
 import {
   commitWindowPageSql,
   deleteRowSql,
+  dropTableDdl,
   layoutsOf,
   migratePayload,
   parseLayouts,
+  retiredTableNames,
   rewritePlan,
   rewriteRowSql,
   rewriteValues,
@@ -489,6 +491,7 @@ export class D1ServerStorage implements ServerStorage {
     if (marker === null || marker.schema_version < schema.version) {
       await this.migrate();
       const layouts = parseLayouts(marker?.layouts);
+      const retiredTables = retiredTableNames(schema, layouts);
       const existing = new Map<string, ReadonlySet<string>>();
       for (const table of schema.tables.values()) {
         const { results } = await this.#db
@@ -511,6 +514,20 @@ export class D1ServerStorage implements ServerStorage {
         const plan = rewritePlan(table, oldLayout, existing.get(table.name));
         if (!plan.migrate && !plan.backfill) continue;
         await this.#rewriteRows(table, plan.migrate ? oldLayout : undefined);
+      }
+      // Retire tables only after the additive DDL and rewrites succeed. D1
+      // cannot wrap the whole bump in an interactive transaction, but this
+      // ordering avoids destructive work before every fallible preparatory
+      // step and the batch keeps table + live-scope cleanup atomic.
+      if (retiredTables.length > 0) {
+        await this.#db.batch(
+          retiredTables.flatMap((tableName) => [
+            this.#db
+              .prepare('DELETE FROM sync_row_scopes WHERE tbl=?')
+              .bind(tableName),
+            this.#db.prepare(dropTableDdl(tableName)),
+          ]),
+        );
       }
       await this.#db
         .prepare(

--- a/packages/server/src/postgres-storage.ts
+++ b/packages/server/src/postgres-storage.ts
@@ -46,9 +46,11 @@ import {
 import {
   commitWindowPageSql,
   deleteRowSql,
+  dropTableDdl,
   layoutsOf,
   migratePayload,
   parseLayouts,
+  retiredTableNames,
   rewritePlan,
   rewriteRowSql,
   rewriteValues,
@@ -721,6 +723,7 @@ export class PostgresServerStorage implements ServerStorage {
           ? marker.rows[0].layouts
           : undefined,
       );
+      const retiredTables = retiredTableNames(schema, layouts);
       await this.#exec.transaction(async (client) => {
         const existing = new Map<string, ReadonlySet<string>>();
         for (const table of schema.tables.values()) {
@@ -732,6 +735,12 @@ export class PostgresServerStorage implements ServerStorage {
           if (rows.length > 0) {
             existing.set(table.name, new Set(rows.map((r) => r.column_name)));
           }
+        }
+        for (const tableName of retiredTables) {
+          await client.query('DELETE FROM sync_row_scopes WHERE tbl=$1', [
+            tableName,
+          ]);
+          await client.query(dropTableDdl(tableName));
         }
         for (const statement of schemaDdl(schema, existing, 'postgres')) {
           await client.query(statement);

--- a/packages/server/src/relational-rows.ts
+++ b/packages/server/src/relational-rows.ts
@@ -454,6 +454,25 @@ export function parseLayouts(json: string | null | undefined): StoredLayouts {
 }
 
 /**
+ * Tables present in the stored layout but absent from the configured head
+ * schema. A schema-version bump retires their relational current-row tables;
+ * append-only commit history remains governed by the normal retention policy.
+ */
+export function retiredTableNames(
+  schema: CompiledSchema,
+  storedLayouts: StoredLayouts,
+): string[] {
+  return Object.keys(storedLayouts)
+    .filter((name) => !schema.tables.has(name))
+    .sort();
+}
+
+/** Idempotent DDL for one retired relational current-row table. */
+export function dropTableDdl(tableName: string): string {
+  return `DROP TABLE IF EXISTS ${quoteIdent(tableName)}`;
+}
+
+/**
  * Enforce the migration subset on a table's column list: the old layout
  * must be an exact prefix (same name, type, nullability) of the new one,
  * and appended columns must be nullable (there is no default to backfill).

--- a/packages/server/src/sqlite-storage.ts
+++ b/packages/server/src/sqlite-storage.ts
@@ -11,9 +11,11 @@ import { syncError } from './errors';
 import {
   commitWindowPageSql,
   deleteRowSql,
+  dropTableDdl,
   layoutsOf,
   migratePayload,
   parseLayouts,
+  retiredTableNames,
   rewritePlan,
   rewriteRowSql,
   rewriteValues,
@@ -273,6 +275,7 @@ export class SqliteServerStorage implements ServerStorage {
       // projection backfill for flipped-on materialization). One
       // transaction: a failed bump leaves no half-state.
       const layouts = parseLayouts(marker?.layouts);
+      const retiredTables = retiredTableNames(schema, layouts);
       const existing = new Map<string, ReadonlySet<string>>();
       for (const table of schema.tables.values()) {
         const columns = this.db
@@ -286,6 +289,12 @@ export class SqliteServerStorage implements ServerStorage {
       }
       this.db.exec('BEGIN IMMEDIATE');
       try {
+        for (const tableName of retiredTables) {
+          this.db
+            .query('DELETE FROM sync_row_scopes WHERE tbl=?')
+            .run(tableName);
+          this.db.exec(dropTableDdl(tableName));
+        }
         for (const statement of schemaDdl(schema, existing, 'sqlite')) {
           this.db.exec(statement);
         }

--- a/packages/server/test/relational-rows.test.ts
+++ b/packages/server/test/relational-rows.test.ts
@@ -9,7 +9,7 @@
  *   4. the serve path is byte-verbatim (`_sync_payload` round-trips), with
  *      the row-codec round-trip invariant asserted per column type;
  *   5. schema version bumps apply the migration subset (ADD COLUMN /
- *      CREATE INDEX) and the version marker gates re-runs;
+ *      CREATE INDEX / DROP TABLE) and the version marker gates re-runs;
  *   6. reserved identifiers are rejected at schema compile.
  */
 import { describe, expect, test } from 'bun:test';
@@ -343,6 +343,76 @@ describe('server-side schema migration (the subset)', () => {
     const decoded = decodeRow(v2Columns, stored!.payload);
     expect(decoded[2]).toBe('v1 row');
     expect(decoded[v2Columns.length - 1]).toBeNull();
+  });
+
+  test('a version bump retires current rows and scope indexes for a removed table', async () => {
+    const storage = new SqliteServerStorage();
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'retired'));
+    await upsert(storage, PARTITION, 'projects', projectRow('p1', 'kept'));
+
+    const v2: ServerSchema = {
+      version: 2,
+      tables: [SCHEMA.tables[1]!],
+    };
+    await storage.ensureSchema(compileSchema(v2));
+
+    const retired = storage.db
+      .query<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='tasks'",
+      )
+      .get();
+    expect(retired).toBeNull();
+    const staleScopes = storage.db
+      .query<{ n: number }, [string]>(
+        'SELECT count(*) AS n FROM sync_row_scopes WHERE tbl=?',
+      )
+      .get('tasks');
+    expect(staleScopes?.n).toBe(0);
+    expect(await storage.getRow(PARTITION, 'projects', 'p1')).toBeDefined();
+  });
+
+  test('postgres retires the relational current-row table atomically', async () => {
+    const db = await PGlite.create();
+    const storage = new PostgresServerStorage(pgliteExecutor(db));
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'retired'));
+    await storage.ensureSchema(
+      compileSchema({ version: 2, tables: [SCHEMA.tables[1]!] }),
+    );
+
+    const table = await db.query<{ name: string | null }>(
+      "SELECT to_regclass('tasks')::text AS name",
+    );
+    expect(table.rows[0]?.name).toBeNull();
+    const scopes = await db.query<{ n: number | string }>(
+      "SELECT count(*) AS n FROM sync_row_scopes WHERE tbl='tasks'",
+    );
+    expect(Number(scopes.rows[0]?.n)).toBe(0);
+  });
+
+  test('D1 retires the relational current-row table idempotently', async () => {
+    const db = new D1DatabaseDouble();
+    const storage = new D1ServerStorage(db);
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    const tx = await storage.begin(PARTITION);
+    await tx.upsertRow('tasks', taskRow('t1', 'p1', 'retired'));
+    await tx.commit();
+    await storage.ensureSchema(
+      compileSchema({ version: 2, tables: [SCHEMA.tables[1]!] }),
+    );
+
+    const table = await db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='tasks'",
+      )
+      .first<{ name: string }>();
+    expect(table).toBeNull();
+    const scopes = await db
+      .prepare('SELECT count(*) AS n FROM sync_row_scopes WHERE tbl=?')
+      .bind('tasks')
+      .first<{ n: number }>();
+    expect(scopes?.n).toBe(0);
   });
 
   test('an older server refuses a newer database', async () => {

--- a/packages/typegen/README.md
+++ b/packages/typegen/README.md
@@ -184,6 +184,7 @@ duplicate ordinals are errors). The parser accepts exactly:
 - `CREATE TABLE [IF NOT EXISTS] name ( column-defs…, [PRIMARY KEY (col)] ) [WITHOUT ROWID]`
 - `ALTER TABLE name ADD [COLUMN] column-def`
 - `CREATE [UNIQUE] INDEX [IF NOT EXISTS] name ON table ( col [, col…] )`
+- `DROP TABLE [IF EXISTS] name`
 - column-def: `name TYPE [PRIMARY KEY] [NOT NULL] [NULL] [DEFAULT literal]`
 - `--` line comments and `/* … */` block comments
 
@@ -206,21 +207,27 @@ inline or table-level.
 secondary indexes on an already-created table: `CREATE INDEX name ON table
 (col)`, a compound `… (a, b)` (order preserved), the `UNIQUE` variant, and
 `IF NOT EXISTS`. Each index becomes an `Ir​Table.indexes` entry
-(`{ name, columns, unique }`, declaration order) and is materialized as a real
-SQLite index by the **clients** (the TS web-client mirror + the Rust core's
-base/visible table pair) and by typegen's own named-query type-check DB. Index
-columns must exist on the table; index names must be unique across the schema;
-a column must not repeat within one index. **Indexes are client-side only**:
-the server stores rows in a generic `sync_rows` table with an opaque payload
-(no per-user-table SQL columns exist server-side), so a user-column index has
-nothing to attach to there — the scope inverted-index already covers server
-reads. The column list is bare column names: **ASC/DESC**, **expression**
-columns (`lower(a)`), and **partial** (`WHERE …`) indexes are hard errors (the
-IR models column names only, so accepting a direction/expression would silently
-drop it).
+(`{ name, columns, unique }`, declaration order) and is materialized by the
+clients (the TS web-client mirror + the Rust core's base/visible table pair),
+typegen's named-query type-check DB, and the server's relational app-table
+projection. Index columns must exist on the table; index names must be unique
+across the schema; a column must not repeat within one index. The column list
+is bare column names: **ASC/DESC**, **expression** columns (`lower(a)`), and
+**partial** (`WHERE …`) indexes are hard errors (the IR models column names
+only, so accepting a direction/expression would silently drop it).
+
+**Table retirement** (`DROP TABLE`). A table created earlier in migration
+history and dropped before the head version is absent from the IR and must be
+omitted from the manifest's `tables` list. `IF EXISTS` is supported. Reusing a
+dropped table name is rejected: the head-only IR cannot distinguish a new
+table from an incompatible in-place rewrite on an upgrading server. On a
+schema-version bump, clients wipe and re-bootstrap their synced tables; the
+reference relational server drops the retired current-row table and its live
+scope index. Append-only commit history follows the configured retention
+policy—`DROP TABLE` is schema retirement, not a compliance erasure API.
 
 **Hard errors** (each names the construct and source file): any other
-statement (`CREATE TRIGGER/VIEW`, `DROP`, DML, `ALTER … RENAME`, …); unknown
+statement (`CREATE TRIGGER/VIEW`, `DROP INDEX`, DML, `ALTER … RENAME`, …); unknown
 or parameterized types (`VARCHAR(36)`); quoted identifiers
 (`"t"`, `` `t` ``, `[t]`); table constraints (`FOREIGN KEY`, `UNIQUE`,
 `CHECK`, `CONSTRAINT`); column constraints beyond the list above

--- a/packages/typegen/src/generate.ts
+++ b/packages/typegen/src/generate.ts
@@ -263,8 +263,14 @@ export function buildIr(
     throw new TypegenError(MANIFEST_FILENAME, 'no migrations found');
   }
   const parsedTables = new Map<string, ParsedTable>();
+  const droppedTables = new Set<string>();
   for (const migration of migrations) {
-    applyMigrationSql(parsedTables, migration.sql, `${migration.name}/up.sql`);
+    applyMigrationSql(
+      parsedTables,
+      migration.sql,
+      `${migration.name}/up.sql`,
+      droppedTables,
+    );
   }
   const schemaVersions = buildSchemaVersions(manifest, migrations);
   const tables = manifest.tables.map((manifestTable) => {

--- a/packages/typegen/src/sql.ts
+++ b/packages/typegen/src/sql.ts
@@ -7,6 +7,7 @@
  *   [WITHOUT ROWID]`
  * - `ALTER TABLE name ADD [COLUMN] coldef`
  * - `CREATE [UNIQUE] INDEX [IF NOT EXISTS] name ON table (col [, col…])`
+ * - `DROP TABLE [IF EXISTS] name`
  * - column defs: `name TYPE [PRIMARY KEY] [NOT NULL] [NULL]
  *   [DEFAULT literal]`
  * - `--` and C-style comments
@@ -290,10 +291,11 @@ function parseColumnDef(cursor: Cursor, allowPrimaryKey: boolean): ColumnDef {
 function parseCreate(
   cursor: Cursor,
   tables: Map<string, ParsedTable>,
+  droppedTables: ReadonlySet<string>,
   source: string,
 ): void {
   if (cursor.eatWord('TABLE')) {
-    parseCreateTable(cursor, tables, source);
+    parseCreateTable(cursor, tables, droppedTables, source);
     return;
   }
   if (cursor.eatWord('UNIQUE')) {
@@ -314,6 +316,7 @@ function parseCreate(
 function parseCreateTable(
   cursor: Cursor,
   tables: Map<string, ParsedTable>,
+  droppedTables: ReadonlySet<string>,
   source: string,
 ): void {
   if (cursor.eatWord('IF')) {
@@ -321,6 +324,11 @@ function parseCreateTable(
     cursor.expectWord('EXISTS', 'after IF NOT');
   }
   const name = cursor.identifier('a table name');
+  if (droppedTables.has(name)) {
+    cursor.fail(
+      `table ${name} cannot be re-created after DROP TABLE — table-name reuse is unsupported`,
+    );
+  }
   if (tables.has(name)) {
     cursor.fail(`table ${name} is created twice`);
   }
@@ -506,6 +514,28 @@ function parseAlterTable(
   table.columns.push(def.column);
 }
 
+/** `DROP TABLE [IF EXISTS] name`; table-name reuse remains unsupported. */
+function parseDropTable(
+  cursor: Cursor,
+  tables: Map<string, ParsedTable>,
+  droppedTables: Set<string>,
+): void {
+  cursor.expectWord('TABLE', 'after DROP');
+  let ifExists = false;
+  if (cursor.eatWord('IF')) {
+    cursor.expectWord('EXISTS', 'after IF');
+    ifExists = true;
+  }
+  const name = cursor.identifier('a table name');
+  cursor.expectEnd();
+  if (!tables.has(name)) {
+    if (ifExists) return;
+    cursor.fail(`DROP TABLE ${name}: table does not exist at this point`);
+  }
+  tables.delete(name);
+  droppedTables.add(name);
+}
+
 /**
  * Apply one migration file's SQL to the accumulated table map. Columns
  * accumulate in declaration order — the §2.4 row-codec positional order.
@@ -514,19 +544,22 @@ export function applyMigrationSql(
   tables: Map<string, ParsedTable>,
   sql: string,
   source: string,
+  droppedTables: Set<string> = new Set<string>(),
 ): void {
   for (const tokens of tokenizeStatements(sql, source)) {
     const cursor = new Cursor(tokens, source);
     const head = cursor.next();
     const word = head.kind === 'word' ? head.text.toUpperCase() : '';
     if (word === 'CREATE') {
-      parseCreate(cursor, tables, source);
+      parseCreate(cursor, tables, droppedTables, source);
     } else if (word === 'ALTER') {
       parseAlterTable(cursor, tables);
+    } else if (word === 'DROP') {
+      parseDropTable(cursor, tables, droppedTables);
     } else {
       throw new TypegenError(
         source,
-        `unsupported SQL statement starting with ${JSON.stringify(head.text)} (only CREATE TABLE, CREATE [UNIQUE] INDEX, and ALTER TABLE … ADD COLUMN)`,
+        `unsupported SQL statement starting with ${JSON.stringify(head.text)} (only CREATE TABLE, CREATE [UNIQUE] INDEX, ALTER TABLE … ADD COLUMN, and DROP TABLE)`,
       );
     }
   }

--- a/packages/typegen/test/manifest-errors.test.ts
+++ b/packages/typegen/test/manifest-errors.test.ts
@@ -147,6 +147,48 @@ describe('buildIr cross-checks', () => {
     );
   });
 
+  test('a table retired by the head migration is omitted from the manifest and IR', () => {
+    const ir = buildIr(
+      manifest({
+        schemaVersions: [
+          { version: 1, through: '0001_initial' },
+          { version: 2, through: '0002_retire_hidden' },
+        ],
+      }),
+      [
+        {
+          name: '0001_initial',
+          sql: `${MIGRATIONS[0]?.sql}; CREATE TABLE hidden (id TEXT PRIMARY KEY)`,
+        },
+        { name: '0002_retire_hidden', sql: 'DROP TABLE hidden' },
+      ],
+    );
+    expect(ir.schemaVersion).toBe(2);
+    expect(ir.tables.map((table) => table.name)).toEqual(['tasks']);
+  });
+
+  test('a dropped table name cannot be reused by a later migration', () => {
+    expectFail(
+      () =>
+        buildIr(
+          manifest({
+            schemaVersions: [
+              { version: 1, through: '0001_initial' },
+              { version: 2, through: '0002_recreate' },
+            ],
+          }),
+          [
+            MIGRATIONS[0]!,
+            {
+              name: '0002_recreate',
+              sql: 'DROP TABLE tasks; CREATE TABLE tasks (id TEXT PRIMARY KEY, project_id TEXT NOT NULL)',
+            },
+          ],
+        ),
+      /cannot be re-created after DROP TABLE/,
+    );
+  });
+
   test('scope pattern must reference an existing column', () => {
     expectFail(
       () =>

--- a/packages/typegen/test/sql-errors.test.ts
+++ b/packages/typegen/test/sql-errors.test.ts
@@ -1,7 +1,7 @@
 /**
  * The SQL subset is a fence: everything outside CREATE TABLE (typed
- * columns + single primary key) and ALTER TABLE ADD COLUMN is a hard
- * error naming the unsupported construct.
+ * columns + single primary key), ALTER TABLE ADD COLUMN, CREATE INDEX, and
+ * DROP TABLE is a hard error naming the unsupported construct.
  */
 import { describe, expect, test } from 'bun:test';
 import { applyMigrationSql, type ParsedTable, TypegenError } from '../src';
@@ -82,6 +82,24 @@ describe('supported subset', () => {
     const tables = parse('CREATE TABLE t (id TEXT PRIMARY KEY)');
     expect(tables.get('t')?.indexes).toEqual([]);
   });
+
+  test('DROP TABLE removes a table and its indexes from the head schema', () => {
+    const tables = parse(`
+      CREATE TABLE retired (id TEXT PRIMARY KEY, title TEXT);
+      CREATE INDEX retired_by_title ON retired (title);
+      CREATE TABLE kept (id TEXT PRIMARY KEY);
+      DROP TABLE retired;
+    `);
+    expect([...tables.keys()]).toEqual(['kept']);
+  });
+
+  test('DROP TABLE IF EXISTS is a no-op for an absent table', () => {
+    const tables = parse(`
+      DROP TABLE IF EXISTS absent;
+      CREATE TABLE kept (id TEXT PRIMARY KEY);
+    `);
+    expect([...tables.keys()]).toEqual(['kept']);
+  });
 });
 
 describe('CREATE INDEX subset — hard errors naming the construct', () => {
@@ -153,7 +171,7 @@ function expectError(sql: string, pattern: RegExp): void {
 
 describe('unsupported constructs are hard errors that name the construct', () => {
   test('other statements', () => {
-    expectError('DROP TABLE t', /unsupported SQL statement.*"DROP"/);
+    expectError('DROP INDEX idx', /expected TABLE after DROP/);
     expectError(
       'CREATE TRIGGER trg AFTER INSERT ON t BEGIN SELECT 1; END',
       /unsupported CREATE statement.*found "TRIGGER"/,
@@ -161,6 +179,21 @@ describe('unsupported constructs are hard errors that name the construct', () =>
     expectError(
       "INSERT INTO t VALUES ('x')",
       /unsupported SQL statement.*"INSERT"/,
+    );
+  });
+
+  test('DROP TABLE rejects unsafe or ambiguous evolution', () => {
+    expectError(
+      'DROP TABLE missing',
+      /DROP TABLE missing: table does not exist at this point/,
+    );
+    expectError(
+      'CREATE TABLE t (id TEXT PRIMARY KEY); DROP TABLE t CASCADE',
+      /unsupported trailing SQL "CASCADE"/,
+    );
+    expectError(
+      'CREATE TABLE t (id TEXT PRIMARY KEY); DROP TABLE t; CREATE TABLE t (id TEXT PRIMARY KEY)',
+      /cannot be re-created after DROP TABLE/,
     );
   });
 


### PR DESCRIPTION
## What changed

- accept strict `DROP TABLE` and `DROP TABLE IF EXISTS` migrations in typegen
- omit retired tables from the generated head schema and reject dropped-name reuse
- retire relational current-row tables and live scope indexes on SQLite, PostgreSQL, and D1 schema bumps
- document the retention boundary and prepare the lockstep 0.12.0 release

## Why

Applications could preserve immutable migration history, but typegen rejected the forward `DROP TABLE` migration needed to remove an obsolete synced table. Omitting the table from the manifest alone also left stale relational current-row storage on an upgrading server.

## Impact

Apps can now retire a synced table without deleting migration history. Clients wipe and re-bootstrap on the schema bump; reference servers remove current rows and live scope entries. Append-only commit history still follows normal retention and this is explicitly not a compliance-erasure API.

## Validation

- `bun run check` (1,214 main tests + 8 isolated multi-tab tests)
- `bun run build:packages`
- `bun run build:sites`
- Rust fmt, clippy, and workspace tests
- Tauri, React Native, and Swift binding gates
- strict worker/native performance gates
- Kotlin and Flutter gates reported missing local JDK 21+/Dart toolchains