### PR TITLE
fix(client): restore rows after rejected optimistic writes

### DIFF
--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -93,11 +93,17 @@ const WORKLOAD = {
  * - `propagationP95CeilingMs` 20 ms: local in-process p95 is 0.2 ms. A
  *   100× allowance absorbs runner noise; breaching 20 ms in-process means
  *   a sleep/poll crept into the sync/realtime loop.
- * - `ownJsRawCeilingBytes` 95 KB: syncular's own JS (core + codec) is
- *   89.4 KB raw today. Bundle bytes are deterministic — no runner noise —
- *   so this stays tight (~6% headroom: enough that a one-KB innocent
+ * - `ownJsRawCeilingBytes` 102 KB: syncular's own JS (core + codec) is
+ *   96.8 KB raw today. Bundle bytes are deterministic — no runner noise —
+ *   so this stays tight (~5% headroom: enough that a one-KB innocent
  *   change doesn't trip, small enough to catch real bloat). RAISED from
- *   88 KB
+ *   95 KB (2026-07-15, SPEC §7.2): restart-safe rejection rollback added
+ *   protected per-outbox before-images, exact update/delete/aggregate
+ *   restoration, and downstream overlay rebasing. This is correctness state
+ *   the TypeScript client needs because it materializes optimistic rows in
+ *   the visible tables; the Rust base-plus-overlay client already carried the
+ *   equivalent behavior. The total-gzip payload gate remains unchanged.
+ *   RAISED from 88 KB
  *   (2026-07-15, SPEC §7.2.1): durable final commit outcomes added 6,542
  *   raw bytes (85,010 → 91,552) for the atomic local journal, exact
  *   conflict/rejection evidence, restart restoration, protected retention,
@@ -143,7 +149,7 @@ const BUDGETS = {
   bootstrapRowsPerSecFloor: 90_000,
   imageBootstrapRowsPerSecFloor: 300_000,
   propagationP95CeilingMs: 20,
-  ownJsRawCeilingBytes: 95 * 1024,
+  ownJsRawCeilingBytes: 102 * 1024,
   totalGzipCeilingBytes: 600 * 1024,
 } as const;
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,32 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.12.0** (`v0.12.0`). All artifacts use Apache-2.0, except
+current release is **0.13.0** (`v0.13.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.13.0 release notes
+
+0.13.0 makes TypeScript optimistic rollback truthful immediately after a
+server rejection, including when no server row is delivered in the pull half.
+
+The release includes:
+
+- protected per-commit before-images captured atomically with every TypeScript
+  outbox append and retained across process restarts;
+- immediate restoration of rejected updates, inserts, deletes, and atomic
+  sibling operations, followed by FIFO replay of later pending edits;
+- rebased before-images for downstream commits touching the same rows, so a
+  later rejection still restores the correct confirmed base;
+- an explicit privacy boundary: rollback images never enter protocol frames,
+  public pending/outcome envelopes, preferences, telemetry, or generic
+  diagnostics;
+- additive local-schema migration and restart/aggregate regression coverage,
+  matching the Rust client's existing durable base-plus-overlay behavior.
+
+Upgrade note: pending TypeScript outbox entries created before 0.13.0 do not
+contain reconstructible before-images. They retain the prior fail-closed
+rollback behavior and converge on the next server delivery or re-bootstrap;
+every mutation recorded after the upgrade uses immediate durable restoration.
 
 ## 0.12.0 release notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2801,21 +2801,23 @@ write. Those remain explicit server-authoritative functions.
   Mechanically, "stop optimistic display" is: the commit leaves the
   outbox (exception: the `sync.idempotency_cache_miss` result of §6.3
   is a serving failure, not an outcome — the commit stays queued and
-  retries); rows its upserts targeted that exist **only optimistically**
-  (created by local writes, never confirmed by any server-delivered row
-  or segment) MUST be deleted — the §7.1 replay re-establishes any that
-  later pending commits still write. Rows the commit merely overwrote
-  SHOULD keep their stale-optimistic content until the pull half
-  delivers the server row; a client whose optimistic overlay is
-  **rebuilt from the last server-delivered base** (base plus replay of
-  still-pending commits, so the rejected commit's effect disappears
-  immediately) is equally conformant — both models converge identically
-  once the server row arrives, and the difference is unobservable to
-  the protocol. For a conflict, the record's `serverRow` (§6.3) lets the
-  app resolve without waiting. A rejected `delete` leaves the row
-  locally absent until the server re-delivers it (a later change or a
-  re-bootstrap): surfacing the rejection is the client's job; restoring
-  the row is app policy.
+  retries). The visible state MUST then be rebuilt from the last
+  server-delivered base plus every later still-pending commit, in FIFO order,
+  so the rejected commit's effect disappears immediately while independent
+  later offline work remains visible. Consequently a rejected optimistic
+  insert disappears, a rejected update restores the last confirmed row, and a
+  rejected delete restores the last confirmed row. For a conflict, the
+  record's `serverRow` (§6.3) remains the authoritative resolution input.
+
+  A client that materializes optimistic values directly into its visible
+  tables MUST durably retain enough protected base state to perform that
+  rebuild after a process restart. Per-commit before-images are sufficient:
+  capture them atomically with the outbox append, remove them atomically with
+  the outbox drain, restore the failed commit's images, rebase the images of
+  later commits that touch the same rows, and replay those later operations.
+  These images are client-internal protected data. They MUST NOT enter
+  `PUSH_COMMIT`, durable public outcome envelopes, ordinary application
+  preferences, telemetry, or generic diagnostics.
 - Push and pull SHOULD ride the same combined request (§1.5): a replaying
   client gets its own changes back in the pull half, converging in one
   round-trip.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/conformance/src/catalog/validators.ts
+++ b/packages/conformance/src/catalog/validators.ts
@@ -71,14 +71,23 @@ export const validatorScenarios: readonly Scenario[] = [
       ]);
       const a = await bootstrapped(ctx, 'actor-a', 'client-a');
 
-      // One commit: a too-long title (rejected by the validator) plus a
-      // sibling insert. §6.4 rolls the WHOLE commit back.
+      await a.api.mutate([
+        {
+          op: 'upsert',
+          table: 'tasks',
+          values: task('existing', 'p1', 'accepted'),
+        },
+      ]);
+      await syncOk(a);
+
+      // One commit: a too-long update of a confirmed row (rejected by the
+      // validator) plus a sibling insert. §6.4 rolls the WHOLE commit back.
       const commit = await a.api.mutate([
         {
           op: 'upsert',
           table: 'tasks',
           values: task(
-            'too-long',
+            'existing',
             'p1',
             'this title is definitely over ten chars',
           ),
@@ -115,11 +124,22 @@ export const validatorScenarios: readonly Scenario[] = [
       );
 
       // §6.4: NOTHING from the commit reached storage — the sibling insert
-      // rolled back with the rejected operation.
+      // rolled back and the prior row stayed accepted.
       checkEqual(
-        (await ctx.server.readRows('tasks')).length,
-        0,
-        'the whole commit rolled back atomically — sibling insert did not land',
+        (await ctx.server.readRows('tasks')).map((row) => ({
+          rowId: row.rowId,
+          title: row.values.title,
+        })),
+        [{ rowId: 'existing', title: 'accepted' }],
+        'the whole commit rolled back atomically on the server',
+      );
+      checkEqual(
+        (await a.api.readRows('tasks')).map((row) => ({
+          rowId: row.rowId,
+          title: row.values.title,
+        })),
+        [{ rowId: 'existing', title: 'accepted' }],
+        'the rejected optimistic update and sibling disappear locally immediately (§7.2)',
       );
     },
   },

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -123,6 +123,14 @@ that rolled back with the terminating operation. It stays in the protected
 client database and is never added to the wire protocol, preferences, or
 telemetry; successful and historical outcomes may omit it.
 
+Rejected optimistic state is removed immediately, even when a validator emits
+no server row in the pull half. The TypeScript client stores protected,
+restart-safe before-images beside each pending outbox commit, restores the last
+confirmed rows (including rejected deletes and atomic siblings), and then
+replays later pending edits. These before-images are internal rollback state:
+they are never encoded on the wire or exposed through pending commits, outcome
+envelopes, diagnostics, preferences, or telemetry.
+
 Use `patch(table, rowId, partial, { baseVersion? })` for editor-style partial
 updates. The wire still carries a full row, but the durable local operation
 records a sorted `changedFields` list so conflict and rejection UI knows which

--- a/packages/web-client/src/client.ts
+++ b/packages/web-client/src/client.ts
@@ -86,9 +86,12 @@ import {
   dropOutboxCommitsInScope,
   encodeOutboxCommit,
   listOutbox,
+  listOutboxBeforeImages,
+  type OutboxBeforeImage,
   type OutboxCommit,
   OutboxEncodeError,
   type OutboxOperation,
+  replaceOutboxBeforeImages,
 } from './outbox';
 import {
   activeFailureRecords,
@@ -1551,7 +1554,13 @@ export class SyncClient {
     });
     this.#applyBatch((batch) => {
       this.#db.transaction(() => {
-        appendOutboxCommit(this.#db, clientCommitId, operations, this.#now());
+        appendOutboxCommit(
+          this.#db,
+          clientCommitId,
+          operations,
+          this.#now(),
+          this.#captureBeforeImages(operations),
+        );
         this.#applyOperationsLocally(operations, batch);
         batch.status();
       });
@@ -1705,22 +1714,7 @@ export class SyncClient {
    */
   #dropIncompatibleCommit(commit: OutboxCommit, message: string): void {
     this.#applyBatch((batch) => {
-      deleteOutboxCommit(this.#db, commit.clientCommitId);
-      for (const operation of commit.operations) {
-        if (operation.op !== 'upsert') continue;
-        const table = this.#schema.tables.get(operation.table);
-        if (table === undefined) continue;
-        const row = this.#db.query(
-          `SELECT ${quoteIdent(SYNC_VERSION_COLUMN)} AS v FROM ${quoteIdent(table.name)} WHERE ${quoteIdent(table.primaryKey)} = ?`,
-          [operation.rowId],
-        )[0];
-        if (row !== undefined && row.v === OPTIMISTIC_VERSION) {
-          if (!this.#recordStoredRowScopes(batch, table, operation.rowId)) {
-            batch.table(table.name);
-          }
-          deleteLocalRow(this.#db, table, operation.rowId);
-        }
-      }
+      this.#rollbackFailedCommit(commit, batch);
       const rejection: RejectionRecord = {
         clientCommitId: commit.clientCommitId,
         opIndex: 0,
@@ -2548,27 +2542,11 @@ export class SyncClient {
     });
     pruneCommitOutcomes(this.#db, this.#outcomeRetentionMaxEntries);
     batch.outcomes();
-    // §7.2: stop optimistic display and decide about dependents — the
-    // commit leaves the outbox; rows it created that the server never
-    // confirmed are undone here, rows it overwrote reconcile via the pull
-    // half (the conflict record carries the server row for the app).
+    // §7.2: remove the rejected optimistic layer. Before-images restore
+    // validator-rejected updates even when the server emitted no new COMMIT;
+    // later pending overlays are then replayed with rebased before-images.
     this.#db.transaction(() => {
-      deleteOutboxCommit(this.#db, frame.clientCommitId);
-      for (const operation of commit.operations) {
-        if (operation.op !== 'upsert') continue;
-        const table = this.#schema.tables.get(operation.table);
-        if (table === undefined) continue;
-        const row = this.#db.query(
-          `SELECT ${quoteIdent(SYNC_VERSION_COLUMN)} AS v FROM ${quoteIdent(table.name)} WHERE ${quoteIdent(table.primaryKey)} = ?`,
-          [operation.rowId],
-        )[0];
-        if (row !== undefined && row.v === OPTIMISTIC_VERSION) {
-          if (!this.#recordStoredRowScopes(batch, table, operation.rowId)) {
-            batch.table(table.name);
-          }
-          deleteLocalRow(this.#db, table, operation.rowId);
-        }
-      }
+      this.#rollbackFailedCommit(commit, batch);
     });
     batch.status();
     summary.rejected.push(frame.clientCommitId);
@@ -2944,6 +2922,134 @@ export class SyncClient {
   }
 
   // -- optimistic state ----------------------------------------------------------
+
+  #captureBeforeImage(
+    operation: OutboxOperation,
+    opIndex: number,
+  ): OutboxBeforeImage {
+    const table = this.#schema.tables.get(operation.table);
+    if (table === undefined) return { opIndex, existed: false };
+    const columns = [
+      ...table.columns.map((column) => quoteIdent(column.name)),
+      quoteIdent(SYNC_VERSION_COLUMN),
+    ];
+    const row = this.#db.query(
+      `SELECT ${columns.join(', ')} FROM ${quoteIdent(table.name)} WHERE ${quoteIdent(table.primaryKey)} = ?`,
+      [operation.rowId],
+    )[0];
+    if (row === undefined) return { opIndex, existed: false };
+    const values: Record<string, ReturnType<typeof rowValueToJson>> = {};
+    for (const column of table.columns) {
+      values[column.name] = rowValueToJson(
+        fromSqlValue(column, row[column.name] ?? null),
+      );
+    }
+    const syncVersion = row[SYNC_VERSION_COLUMN];
+    if (typeof syncVersion !== 'number') {
+      throw new ClientSyncError(
+        'sync.local_corrupt',
+        `local row ${operation.table}/${operation.rowId} has no sync version`,
+      );
+    }
+    return { opIndex, existed: true, syncVersion, values };
+  }
+
+  #captureBeforeImages(
+    operations: readonly OutboxOperation[],
+    onlyKeys?: ReadonlySet<string>,
+  ): OutboxBeforeImage[] {
+    return operations.flatMap((operation, opIndex) =>
+      onlyKeys && !onlyKeys.has(`${operation.table}\u0000${operation.rowId}`)
+        ? []
+        : [this.#captureBeforeImage(operation, opIndex)],
+    );
+  }
+
+  #restoreBeforeImage(
+    operation: OutboxOperation,
+    image: OutboxBeforeImage,
+    batch: ChangeAccumulator,
+  ): void {
+    const table = this.#schema.tables.get(operation.table);
+    if (table === undefined) return;
+    batch.table(table.name);
+    if (!image.existed) {
+      deleteLocalRow(this.#db, table, operation.rowId);
+      return;
+    }
+    if (image.values === undefined || image.syncVersion === undefined) {
+      throw new ClientSyncError(
+        'sync.local_corrupt',
+        `rollback image for ${operation.table}/${operation.rowId} is incomplete`,
+      );
+    }
+    const values = table.columns.map((column) =>
+      jsonToRowValue(image.values?.[column.name] ?? null),
+    );
+    upsertLocalRow(this.#db, table, values, image.syncVersion);
+  }
+
+  #legacyUndoOptimisticRows(
+    commit: OutboxCommit,
+    batch: ChangeAccumulator,
+  ): void {
+    for (const operation of commit.operations) {
+      if (operation.op !== 'upsert') continue;
+      const table = this.#schema.tables.get(operation.table);
+      if (table === undefined) continue;
+      const row = this.#db.query(
+        `SELECT ${quoteIdent(SYNC_VERSION_COLUMN)} AS v FROM ${quoteIdent(table.name)} WHERE ${quoteIdent(table.primaryKey)} = ?`,
+        [operation.rowId],
+      )[0];
+      if (row !== undefined && row.v === OPTIMISTIC_VERSION) {
+        batch.table(table.name);
+        deleteLocalRow(this.#db, table, operation.rowId);
+      }
+    }
+  }
+
+  #rollbackFailedCommit(commit: OutboxCommit, batch: ChangeAccumulator): void {
+    const images = listOutboxBeforeImages(this.#db, commit.clientCommitId);
+    const imageByIndex = new Map(images.map((image) => [image.opIndex, image]));
+    const complete = commit.operations.every((_, index) =>
+      imageByIndex.has(index),
+    );
+    const affectedKeys = new Set(
+      commit.operations.map(
+        (operation) => `${operation.table}\u0000${operation.rowId}`,
+      ),
+    );
+    if (complete) {
+      const restored = new Set<string>();
+      commit.operations.forEach((operation, index) => {
+        const key = `${operation.table}\u0000${operation.rowId}`;
+        if (restored.has(key)) return;
+        const image = imageByIndex.get(index);
+        if (image) this.#restoreBeforeImage(operation, image, batch);
+        restored.add(key);
+      });
+    } else {
+      // Pending commits written by older clients have no before-images.
+      // Preserve the old fail-closed behavior rather than guessing a base.
+      this.#legacyUndoOptimisticRows(commit, batch);
+    }
+    deleteOutboxCommit(this.#db, commit.clientCommitId);
+
+    if (!complete) return;
+    for (const later of listOutbox(this.#db)) {
+      if (later.seq <= commit.seq) continue;
+      const affectedOperations = later.operations.filter((operation) =>
+        affectedKeys.has(`${operation.table}\u0000${operation.rowId}`),
+      );
+      if (affectedOperations.length === 0) continue;
+      replaceOutboxBeforeImages(
+        this.#db,
+        later.clientCommitId,
+        this.#captureBeforeImages(later.operations, affectedKeys),
+      );
+      this.#applyOperationsLocally(affectedOperations, batch);
+    }
+  }
 
   #applyOperationsLocally(
     operations: readonly OutboxOperation[],

--- a/packages/web-client/src/outbox.ts
+++ b/packages/web-client/src/outbox.ts
@@ -43,11 +43,20 @@ export interface OutboxCommit {
   readonly operations: readonly OutboxOperation[];
 }
 
+/** Protected local rollback image; never encoded or exposed in outcomes. */
+export interface OutboxBeforeImage {
+  readonly opIndex: number;
+  readonly existed: boolean;
+  readonly syncVersion?: number;
+  readonly values?: Readonly<Record<string, JsonRowValue>>;
+}
+
 export function appendOutboxCommit(
   db: ClientDatabase,
   clientCommitId: string,
   operations: readonly OutboxOperation[],
   nowMs: number,
+  beforeImages: readonly OutboxBeforeImage[] = [],
 ): void {
   if (operations.length === 0) {
     throw new ClientSyncError(
@@ -60,6 +69,20 @@ export function appendOutboxCommit(
      VALUES (?, ?, ?)`,
     [clientCommitId, nowMs, JSON.stringify(operations)],
   );
+  for (const image of beforeImages) {
+    db.exec(
+      `INSERT INTO _syncular_outbox_before_images(
+         client_commit_id, op_index, existed, sync_version, values_json
+       ) VALUES (?, ?, ?, ?, ?)`,
+      [
+        clientCommitId,
+        image.opIndex,
+        image.existed ? 1 : 0,
+        image.syncVersion ?? null,
+        image.values === undefined ? null : JSON.stringify(image.values),
+      ],
+    );
+  }
 }
 
 /** Pending commits in FIFO creation order (§7.1). */
@@ -81,9 +104,66 @@ export function deleteOutboxCommit(
   db: ClientDatabase,
   clientCommitId: string,
 ): void {
+  db.exec(
+    'DELETE FROM _syncular_outbox_before_images WHERE client_commit_id = ?',
+    [clientCommitId],
+  );
   db.exec('DELETE FROM _syncular_outbox WHERE client_commit_id = ?', [
     clientCommitId,
   ]);
+}
+
+export function listOutboxBeforeImages(
+  db: ClientDatabase,
+  clientCommitId: string,
+): OutboxBeforeImage[] {
+  return db
+    .query(
+      `SELECT op_index, existed, sync_version, values_json
+         FROM _syncular_outbox_before_images
+        WHERE client_commit_id = ? ORDER BY op_index`,
+      [clientCommitId],
+    )
+    .map((row) => ({
+      opIndex: row.op_index as number,
+      existed: row.existed === 1,
+      ...(typeof row.sync_version === 'number'
+        ? { syncVersion: row.sync_version }
+        : {}),
+      ...(typeof row.values_json === 'string'
+        ? {
+            values: JSON.parse(row.values_json) as Readonly<
+              Record<string, JsonRowValue>
+            >,
+          }
+        : {}),
+    }));
+}
+
+export function replaceOutboxBeforeImages(
+  db: ClientDatabase,
+  clientCommitId: string,
+  replacements: readonly OutboxBeforeImage[],
+): void {
+  for (const image of replacements) {
+    db.exec(
+      `DELETE FROM _syncular_outbox_before_images
+        WHERE client_commit_id = ? AND op_index = ?`,
+      [clientCommitId, image.opIndex],
+    );
+    db.exec(
+      `INSERT INTO _syncular_outbox_before_images(
+         client_commit_id, op_index, existed, sync_version, values_json
+       ) VALUES (?, ?, ?, ?, ?)`,
+      [
+        clientCommitId,
+        image.opIndex,
+        image.existed ? 1 : 0,
+        image.syncVersion ?? null,
+        image.values === undefined ? null : JSON.stringify(image.values),
+      ],
+    );
+  }
 }
 
 /**

--- a/packages/web-client/src/schema.ts
+++ b/packages/web-client/src/schema.ts
@@ -288,6 +288,13 @@ export function ensureLocalSchema(
       client_commit_id TEXT NOT NULL UNIQUE,
       created_at_ms INTEGER NOT NULL,
       operations TEXT NOT NULL)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS _syncular_outbox_before_images(
+      client_commit_id TEXT NOT NULL,
+      op_index INTEGER NOT NULL,
+      existed INTEGER NOT NULL CHECK(existed IN (0, 1)),
+      sync_version INTEGER,
+      values_json TEXT,
+      PRIMARY KEY(client_commit_id, op_index))`);
     db.exec(`CREATE TABLE IF NOT EXISTS _syncular_commit_outcomes(
       seq INTEGER PRIMARY KEY AUTOINCREMENT,
       client_commit_id TEXT NOT NULL UNIQUE,

--- a/packages/web-client/test/client.test.ts
+++ b/packages/web-client/test/client.test.ts
@@ -667,6 +667,180 @@ describe('durable commit outcomes', () => {
       rmSync(directory, { recursive: true, force: true });
     }
   });
+
+  test('validator rejection restores updates, deletes, aggregate siblings, and downstream overlays', async () => {
+    const server = makeServer(CLIENT_SCHEMA, {
+      validators: {
+        tasks: (operation) => {
+          if (
+            operation.op === 'delete' ||
+            String(operation.row?.title ?? '').startsWith('invalid')
+          ) {
+            throw new ValidationRejection(
+              'app.invalid_change',
+              'diagnostic only',
+            );
+          }
+        },
+      },
+    });
+    const client = await makeClient(server, { clientId: 'rollback-client' });
+    client.client.subscribe({
+      id: 'rollback-tasks',
+      table: 'tasks',
+      scopes: { project_id: ['rollback'] },
+    });
+    client.client.mutate([
+      {
+        table: 'tasks',
+        op: 'upsert',
+        values: taskValues('rollback-root', 'rollback', 'accepted'),
+      },
+    ]);
+    await client.client.syncUntilIdle();
+
+    const firstRejected = client.client.patch(
+      'tasks',
+      'rollback-root',
+      { title: 'invalid-first' },
+      { baseVersion: 1 },
+    );
+    const secondRejected = client.client.patch(
+      'tasks',
+      'rollback-root',
+      { title: 'invalid-second' },
+      { baseVersion: 1 },
+    );
+    expect(tableRows(client.db, 'tasks')[0]?.title).toBe('invalid-second');
+    await client.client.syncUntilIdle();
+    expect(client.client.commitOutcome(firstRejected)?.status).toBe('rejected');
+    expect(client.client.commitOutcome(secondRejected)?.status).toBe(
+      'rejected',
+    );
+    expect(tableRows(client.db, 'tasks')[0]).toMatchObject({
+      title: 'accepted',
+      _sync_version: 1,
+    });
+
+    const aggregateRejected = client.client.mutate([
+      {
+        table: 'tasks',
+        op: 'upsert',
+        values: taskValues('rollback-sibling', 'rollback', 'sibling'),
+        baseVersion: 0,
+      },
+      {
+        table: 'tasks',
+        op: 'upsert',
+        values: taskValues('rollback-root', 'rollback', 'invalid-aggregate'),
+        baseVersion: 1,
+      },
+    ]);
+    await client.client.syncUntilIdle();
+    expect(client.client.commitOutcome(aggregateRejected)).toMatchObject({
+      status: 'rejected',
+      operations: [{ rowId: 'rollback-sibling' }, { rowId: 'rollback-root' }],
+    });
+    expect(tableRows(client.db, 'tasks').map((row) => row.id)).toEqual([
+      'rollback-root',
+    ]);
+    expect(tableRows(client.db, 'tasks')[0]?.title).toBe('accepted');
+
+    const deleteRejected = client.client.mutate([
+      {
+        table: 'tasks',
+        op: 'delete',
+        rowId: 'rollback-root',
+        baseVersion: 1,
+      },
+    ]);
+    expect(tableRows(client.db, 'tasks')).toHaveLength(0);
+    await client.client.syncUntilIdle();
+    expect(client.client.commitOutcome(deleteRejected)?.status).toBe(
+      'rejected',
+    );
+    expect(tableRows(client.db, 'tasks')[0]).toMatchObject({
+      id: 'rollback-root',
+      title: 'accepted',
+      _sync_version: 1,
+    });
+    expect(
+      client.db.query('SELECT * FROM _syncular_outbox_before_images'),
+    ).toHaveLength(0);
+  });
+
+  test('rollback before-images survive restart without entering the public failed envelope', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'syncular-rollback-image-'));
+    const databasePath = join(directory, 'client.db');
+    const server = makeServer(CLIENT_SCHEMA, {
+      validators: {
+        tasks: (operation) => {
+          if (operation.row?.title === 'invalid-after-restart') {
+            throw new ValidationRejection(
+              'app.invalid_change',
+              'diagnostic only',
+            );
+          }
+        },
+      },
+    });
+    try {
+      const first = await makeClient(server, {
+        clientId: 'restart-rollback-client',
+        databasePath,
+      });
+      first.client.subscribe({
+        id: 'restart-rollback-tasks',
+        table: 'tasks',
+        scopes: { project_id: ['restart-rollback'] },
+      });
+      first.client.mutate([
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: taskValues('restart-root', 'restart-rollback', 'accepted'),
+        },
+      ]);
+      await first.client.syncUntilIdle();
+      const rejectedId = first.client.patch(
+        'tasks',
+        'restart-root',
+        { title: 'invalid-after-restart' },
+        { baseVersion: 1 },
+      );
+      expect(
+        first.db.query('SELECT * FROM _syncular_outbox_before_images'),
+      ).toHaveLength(1);
+      await first.client.close();
+      first.db.close();
+
+      const reopened = await makeClient(server, {
+        clientId: 'restart-rollback-client',
+        databasePath,
+      });
+      await reopened.client.syncUntilIdle();
+      expect(tableRows(reopened.db, 'tasks')[0]).toMatchObject({
+        title: 'accepted',
+        _sync_version: 1,
+      });
+      expect(reopened.client.commitOutcome(rejectedId)).toMatchObject({
+        status: 'rejected',
+        operations: [
+          {
+            rowId: 'restart-root',
+            values: { title: 'invalid-after-restart' },
+          },
+        ],
+      });
+      expect(
+        JSON.stringify(reopened.client.commitOutcome(rejectedId)),
+      ).not.toContain('values_json');
+      await reopened.client.close();
+      reopened.db.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('offline outbox (§7)', () => {

--- a/packages/web-client/test/outbox.test.ts
+++ b/packages/web-client/test/outbox.test.ts
@@ -30,7 +30,7 @@ import {
 const compiled = compileClientSchema(CLIENT_SCHEMA);
 
 describe('schema-agnostic persistence (§0 outbox rule)', () => {
-  test('migrates a pre-envelope outcome journal additively', () => {
+  test('migrates protected outcome and rollback bookkeeping additively', () => {
     const db = new BunClientDatabase();
     db.exec(`CREATE TABLE _syncular_commit_outcomes(
       seq INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -47,6 +47,17 @@ describe('schema-agnostic persistence (§0 outbox rule)', () => {
         .query('PRAGMA table_info(_syncular_commit_outcomes)')
         .map((column) => column.name),
     ).toContain('operations');
+    expect(
+      db
+        .query('PRAGMA table_info(_syncular_outbox_before_images)')
+        .map((column) => column.name),
+    ).toEqual([
+      'client_commit_id',
+      'op_index',
+      'existed',
+      'sync_version',
+      'values_json',
+    ]);
     db.close();
   });
 


### PR DESCRIPTION
## Summary\n- capture protected restart-safe before-images with TypeScript outbox commits\n- restore rejected inserts, updates, deletes, and aggregate siblings before replaying later pending edits\n- tighten SPEC §7.2, add TS/Rust conformance coverage, and prepare 0.13.0\n\n## Verification\n- bun run check (1,216 pass, 6 skip; 3,846 assertions)\n- isolated multi-tab suite (8 pass; 39 assertions)\n- focused TypeScript + Rust validator rollback conformance (2 pass)\n- bun install --frozen-lockfile\n- git diff --check