### PR TITLE
Fix application-row upsert integrity

### DIFF
--- a/docs/DESIGN-relational-server-storage.md
+++ b/docs/DESIGN-relational-server-storage.md
@@ -126,7 +126,9 @@ for long enough, dropping `_sync_payload` is a cheap follow-up migration
 - `upsertRow`: `decodeRow(columns, payload)` → typed values →
   `INSERT … ON CONFLICT(_sync_partition, pk) DO UPDATE`, writing the typed
   columns, `_sync_server_version`, `_sync_scopes`, and `_sync_payload` in
-  one statement.
+  one statement. The conflict target is the row primary key only: a
+  secondary unique-index collision fails the statement and preserves the
+  existing row; replace-style writes are forbidden for application rows.
 - `getRow` / `scanRows` / `readCommitWindow`'s current-row reads: `SELECT
   _sync_payload, _sync_server_version, _sync_scopes …` — byte-verbatim,
   same as today. Typed columns are never read on the sync serve path.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,30 @@
 # Syncular release runbook
 
 Syncular publishes every public npm package and Rust crate in lockstep. The
-current release is **0.13.0** (`v0.13.0`). All artifacts use Apache-2.0, except
+current release is **0.14.0** (`v0.14.0`). All artifacts use Apache-2.0, except
 private examples and test harnesses that are never published.
+
+## 0.14.0 release notes
+
+0.14.0 makes application-row upserts safe in the presence of secondary
+unique indexes on SQLite-family clients and servers.
+
+The release includes:
+
+- primary-key-targeted `ON CONFLICT ... DO UPDATE` writes for the TypeScript
+  SQLite client, SQLite-image bootstrap path, Rust client, SQLite server, and
+  D1 server;
+- removal of application-row `INSERT OR REPLACE` behavior that could delete
+  an existing row when a different row collided with a secondary unique
+  index;
+- atomic failure semantics matching PostgreSQL: the colliding write fails and
+  the previously stored row remains intact;
+- direct regression coverage for ordinary client apply, SQLite-image apply,
+  native apply, SQLite server storage, and D1 storage.
+
+No wire or schema change is required. Existing databases and generated code
+remain compatible; applications using unique indexes should upgrade every
+SQLite-family client and server runtime together.
 
 ## 0.13.0 release notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1497,8 +1497,12 @@ for clients without signed-URL support.
 
 ### 5.6 Segment application contract (client)
 
-- Segments for a table replace-or-upsert: the client applies rows by
-  primary key (`INSERT OR REPLACE` semantics). On the **first page** of
+- Segments for a table upsert by primary key: an existing row with the same
+  primary key is updated and an absent row is inserted. Constraints outside
+  the primary key retain their ordinary database semantics. In particular, a
+  client MUST NOT use replace-style conflict handling that can delete a
+  different row after a secondary unique-index collision; the colliding
+  segment application aborts and preserves the existing row. On the **first page** of
   a table in a **fresh** bootstrap, the client MUST first delete local
   rows for the subscription's scope (same matching rule as the purge
   contract, §3.3, against the `SUB_START` effective-scope echo) so

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncular",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/server/src/relational-rows.ts
+++ b/packages/server/src/relational-rows.ts
@@ -261,13 +261,9 @@ export function upsertSql(
   const names = tableColumnNames(table);
   const quoted = names.map((name) => quoteIdent(name)).join(', ');
   const values = placeholderList(names.length, dialect);
-  if (dialect === 'sqlite') {
-    // INSERT OR REPLACE keys on the (_sync_partition, _sync_row_id) PK.
-    return `INSERT OR REPLACE INTO ${quoteIdent(table.name)} (${quoted}) VALUES (${values})`;
-  }
   const updates = names
     .slice(2) // partition + row id are the conflict key
-    .map((name) => `${quoteIdent(name)}=EXCLUDED.${quoteIdent(name)}`)
+    .map((name) => `${quoteIdent(name)}=excluded.${quoteIdent(name)}`)
     .join(', ');
   return `INSERT INTO ${quoteIdent(table.name)} (${quoted}) VALUES (${values})
      ON CONFLICT (${quoteIdent(SYNC_PARTITION_COLUMN)}, ${quoteIdent(SYNC_ROW_ID_COLUMN)}) DO UPDATE SET ${updates}`;

--- a/packages/server/src/sqlite-dialect.ts
+++ b/packages/server/src/sqlite-dialect.ts
@@ -2,8 +2,8 @@
  * Shared SQLite dialect for the two SQLite-family storages: `bun:sqlite`
  * (synchronous, `SqliteServerStorage`) and Cloudflare D1 (async,
  * `D1ServerStorage`). D1 *is* SQLite — same DDL, same statement grammar,
- * same `?` positional placeholders, same `INSERT OR REPLACE` / `INSERT OR
- * IGNORE` upsert idioms — so the schema and the value (de)serialization are
+ * same `?` positional placeholders, same `INSERT ... ON CONFLICT` / `INSERT
+ * OR IGNORE` upsert idioms — so the schema and the value (de)serialization are
  * genuinely common ground and live here.
  *
  * What is NOT shared: statement *execution*. `bun:sqlite` is sync

--- a/packages/server/test/relational-rows.test.ts
+++ b/packages/server/test/relational-rows.test.ts
@@ -59,7 +59,14 @@ const SCHEMA: ServerSchema = {
       columns: TASK_COLUMNS,
       primaryKey: 'id',
       scopes: ['project:{project_id}'],
-      indexes: [{ name: 'tasks_by_title', columns: ['title'] }],
+      indexes: [
+        { name: 'tasks_by_title', columns: ['title'] },
+        {
+          name: 'tasks_by_project_title',
+          columns: ['project_id', 'title'],
+          unique: true,
+        },
+      ],
     },
     {
       name: 'projects',
@@ -115,7 +122,7 @@ async function sqliteStorage(): Promise<SqliteServerStorage> {
 }
 
 async function upsert(
-  storage: SqliteServerStorage | PostgresServerStorage,
+  storage: SqliteServerStorage | PostgresServerStorage | D1ServerStorage,
   partition: string,
   table: string,
   row: StoredRow,
@@ -241,6 +248,48 @@ describe('relational tables (sqlite)', () => {
       )
       .all('tasks');
     expect(indexes.map((i) => i.name)).toContain('tasks_by_title');
+  });
+
+  test('a secondary unique collision never replaces the existing server row', async () => {
+    const storage = await sqliteStorage();
+    await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'original'));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'updated'));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t2', 'p1', 'original'));
+
+    await expect(
+      upsert(storage, PARTITION, 'tasks', taskRow('t3', 'p1', 'original')),
+    ).rejects.toThrow();
+    const rows = storage.db
+      .query<{ id: string; title: string }, []>(
+        'SELECT id, title FROM tasks ORDER BY id',
+      )
+      .all();
+    expect(rows).toEqual([
+      { id: 't1', title: 'updated' },
+      { id: 't2', title: 'original' },
+    ]);
+  });
+});
+
+describe('relational tables (D1)', () => {
+  test('a secondary unique collision never replaces the existing server row', async () => {
+    const db = new D1DatabaseDouble();
+    const storage = new D1ServerStorage(db);
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'original'));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'updated'));
+    await upsert(storage, PARTITION, 'tasks', taskRow('t2', 'p1', 'original'));
+
+    await expect(
+      upsert(storage, PARTITION, 'tasks', taskRow('t3', 'p1', 'original')),
+    ).rejects.toThrow();
+    const { results } = await db
+      .prepare('SELECT id, title FROM tasks ORDER BY id')
+      .all<{ id: string; title: string }>();
+    expect(results).toEqual([
+      { id: 't1', title: 'updated' },
+      { id: 't2', title: 'original' },
+    ]);
   });
 });
 

--- a/packages/web-client/src/apply.ts
+++ b/packages/web-client/src/apply.ts
@@ -31,7 +31,12 @@ function upsertSql(table: CompiledClientTable): string {
     quoteIdent(SYNC_VERSION_COLUMN),
   ];
   const placeholders = names.map(() => '?').join(', ');
-  return `INSERT OR REPLACE INTO ${quoteIdent(table.name)} (${names.join(', ')}) VALUES (${placeholders})`;
+  const updates = names
+    .filter((name) => name !== quoteIdent(table.primaryKey))
+    .map((name) => `${name}=excluded.${name}`)
+    .join(', ');
+  return `INSERT INTO ${quoteIdent(table.name)} (${names.join(', ')}) VALUES (${placeholders})
+    ON CONFLICT (${quoteIdent(table.primaryKey)}) DO UPDATE SET ${updates}`;
 }
 
 export function upsertLocalRow(
@@ -285,7 +290,7 @@ function imageInvalid(detail: string): never {
  * the in-file metadata against the descriptor, validate the data table's
  * column names/order against the generated schema, run the §5.6
  * first-page clear when fresh, then copy every row with a single
- * `INSERT OR REPLACE … SELECT` — `_syncular_version` lands in
+ * one primary-key upsert — `_syncular_version` lands in
  * `_sync_version` exactly like a rows segment's per-row `serverVersion`.
  */
 export function applySqliteSegment(
@@ -365,17 +370,24 @@ export function applySqliteSegment(
       );
     }
 
-    // 3. One transaction: fresh-bootstrap clear, then replace-or-upsert.
+    // 3. One transaction: fresh-bootstrap clear, then primary-key upsert.
     const names = table.columns.map((column) => quoteIdent(column.name));
+    const insertNames = [...names, quoteIdent(SYNC_VERSION_COLUMN)];
+    const updates = insertNames
+      .filter((name) => name !== quoteIdent(table.primaryKey))
+      .map((name) => `${name}=excluded.${name}`)
+      .join(', ');
     return (options.transaction ?? ((fn) => db.transaction(fn)))(() => {
       if (options.clearFirst) {
         deleteScopedRows(db, table, options.effective);
       }
       db.exec(
-        `INSERT OR REPLACE INTO ${quoteIdent(table.name)}
-           (${[...names, quoteIdent(SYNC_VERSION_COLUMN)].join(', ')})
+        `INSERT INTO ${quoteIdent(table.name)}
+           (${insertNames.join(', ')})
          SELECT ${[...names, quoteIdent('_syncular_version')].join(', ')}
-         FROM ${IMAGE_ALIAS}.${quoteIdent(table.name)}`,
+         FROM ${IMAGE_ALIAS}.${quoteIdent(table.name)}
+         WHERE true
+         ON CONFLICT (${quoteIdent(table.primaryKey)}) DO UPDATE SET ${updates}`,
       );
       const counted = db.query(
         `SELECT count(*) AS n FROM ${IMAGE_ALIAS}.${quoteIdent(table.name)}`,

--- a/packages/web-client/test/indexes.test.ts
+++ b/packages/web-client/test/indexes.test.ts
@@ -6,6 +6,8 @@
  * the same declared indexes created on the relational per-app row tables —
  * is covered by packages/server/test/relational-rows.test.ts.
  */
+
+import { Database } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
 import {
   type ClientSchema,
@@ -14,6 +16,7 @@ import {
   ensureLocalSchema,
 } from '@syncular/client';
 import { BunClientDatabase } from '@syncular/client/bun';
+import { applySqliteSegment, upsertLocalRow } from '../src/apply';
 
 const SCHEMA: ClientSchema = {
   version: 1,
@@ -56,6 +59,45 @@ function indexNames(db: BunClientDatabase): string[] {
     )
     .map((r) => String(r.name))
     .sort();
+}
+
+function sqliteImageBytes(
+  rows: ReadonlyArray<{
+    id: string;
+    projectId: string;
+    title: string;
+    version: number;
+  }>,
+): Uint8Array {
+  const image = new Database(':memory:');
+  try {
+    image.exec(`
+      CREATE TABLE tasks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        _syncular_version INTEGER NOT NULL
+      );
+      CREATE TABLE _syncular_segment (
+        format INTEGER NOT NULL,
+        "table" TEXT NOT NULL,
+        "schemaVersion" INTEGER NOT NULL,
+        "asOfCommitSeq" INTEGER NOT NULL,
+        "scopeDigest" TEXT NOT NULL,
+        "rowCount" INTEGER NOT NULL
+      );
+    `);
+    image
+      .query('INSERT INTO _syncular_segment VALUES (1, ?, 1, 7, ?, ?)')
+      .run('tasks', 'digest', rows.length);
+    const insert = image.query('INSERT INTO tasks VALUES (?, ?, ?, ?)');
+    for (const row of rows) {
+      insert.run(row.id, row.projectId, row.title, row.version);
+    }
+    return new Uint8Array(image.serialize());
+  } finally {
+    image.close();
+  }
 }
 
 describe('CREATE INDEX subset — client local DDL', () => {
@@ -104,6 +146,89 @@ describe('CREATE INDEX subset — client local DDL', () => {
         `INSERT INTO "tasks" ("id","project_id","title") VALUES ('t3','p1','b')`,
       ),
     ).not.toThrow();
+  });
+
+  test('a secondary unique collision never replaces the existing synced row', () => {
+    const db = new BunClientDatabase();
+    const compiled = compileClientSchema(SCHEMA);
+    const table = compiled.tables.get('tasks');
+    if (table === undefined) throw new Error('compiled tasks table missing');
+    ensureLocalSchema(db, compiled);
+
+    upsertLocalRow(db, table, ['t1', 'p1', 'a'], 1);
+    upsertLocalRow(db, table, ['t1', 'p1', 'renamed'], 2);
+    expect(db.query('SELECT * FROM tasks')).toEqual([
+      { id: 't1', project_id: 'p1', title: 'renamed', _sync_version: 2 },
+    ]);
+
+    upsertLocalRow(db, table, ['t2', 'p1', 'a'], 1);
+    expect(() => upsertLocalRow(db, table, ['t3', 'p1', 'a'], 2)).toThrow();
+    expect(
+      db.query(
+        'SELECT id, project_id, title, _sync_version FROM tasks ORDER BY id',
+      ),
+    ).toEqual([
+      { id: 't1', project_id: 'p1', title: 'renamed', _sync_version: 2 },
+      { id: 't2', project_id: 'p1', title: 'a', _sync_version: 1 },
+    ]);
+  });
+
+  test('sqlite-image primary-key upserts preserve rows on a secondary unique collision', () => {
+    const db = new BunClientDatabase();
+    const compiled = compileClientSchema(SCHEMA);
+    const table = compiled.tables.get('tasks');
+    if (table === undefined) throw new Error('compiled tasks table missing');
+    ensureLocalSchema(db, compiled);
+    upsertLocalRow(db, table, ['t1', 'p1', 'original'], 1);
+
+    const descriptor = {
+      table: 'tasks',
+      rowCount: 1,
+      asOfCommitSeq: 7,
+      scopeDigest: 'digest',
+    } as const;
+    expect(
+      applySqliteSegment(
+        db,
+        compiled,
+        table,
+        sqliteImageBytes([
+          {
+            id: 't1',
+            projectId: 'p1',
+            title: 'updated',
+            version: 2,
+          },
+        ]),
+        descriptor,
+        { clearFirst: false, effective: { project_id: ['p1'] } },
+      ),
+    ).toBe(1);
+    upsertLocalRow(db, table, ['t2', 'p1', 'original'], 1);
+
+    expect(() =>
+      applySqliteSegment(
+        db,
+        compiled,
+        table,
+        sqliteImageBytes([
+          {
+            id: 't3',
+            projectId: 'p1',
+            title: 'original',
+            version: 3,
+          },
+        ]),
+        descriptor,
+        { clearFirst: false, effective: { project_id: ['p1'] } },
+      ),
+    ).toThrow();
+    expect(
+      db.query('SELECT id, title, _sync_version FROM tasks ORDER BY id'),
+    ).toEqual([
+      { id: 't1', title: 'updated', _sync_version: 2 },
+      { id: 't2', title: 'original', _sync_version: 1 },
+    ]);
   });
 
   test('the §7.4.3 drop-and-recreate reset restores the indexes', () => {

--- a/rust/crates/client/src/client.rs
+++ b/rust/crates/client/src/client.rs
@@ -112,6 +112,70 @@ mod observation_tests {
     }
 
     #[test]
+    fn secondary_unique_collision_preserves_existing_synced_row() {
+        let client = SyncClient::new(
+            "unique-upsert-test".to_owned(),
+            &json!({
+                "version": 1,
+                "tables": [{
+                    "name": "tasks",
+                    "primaryKey": "id",
+                    "columns": [
+                        { "name": "id", "type": "string", "nullable": false },
+                        { "name": "project_id", "type": "string", "nullable": false },
+                        { "name": "title", "type": "string", "nullable": false }
+                    ],
+                    "scopes": [{ "pattern": "project:{project_id}" }],
+                    "indexes": [{
+                        "name": "tasks_by_project_title",
+                        "columns": ["project_id", "title"],
+                        "unique": true
+                    }]
+                }]
+            }),
+            ClientLimits::default(),
+        )
+        .expect("test client");
+        let table = client.schema.table("tasks").expect("tasks table");
+        let sql = client.insert_row_sql(&base_table("tasks"), table);
+
+        client
+            .conn
+            .execute(&sql, rusqlite::params!["t1", "p1", "original", 1])
+            .expect("insert first row");
+        client
+            .conn
+            .execute(&sql, rusqlite::params!["t1", "p1", "updated", 2])
+            .expect("update same primary key");
+        client
+            .conn
+            .execute(&sql, rusqlite::params!["t2", "p1", "original", 1])
+            .expect("insert second row");
+        assert!(client
+            .conn
+            .execute(&sql, rusqlite::params!["t3", "p1", "original", 2])
+            .is_err());
+
+        let rows = client
+            .conn
+            .prepare("SELECT id, title FROM _syncular_base_tasks ORDER BY id")
+            .expect("prepare rows")
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("query rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect rows");
+        assert_eq!(
+            rows,
+            vec![
+                ("t1".to_owned(), "updated".to_owned()),
+                ("t2".to_owned(), "original".to_owned())
+            ]
+        );
+    }
+
+    #[test]
     fn reopening_active_subscriptions_emits_a_catch_up_intent() {
         let path = std::env::temp_dir().join(format!(
             "syncular-startup-intent-{}.db",
@@ -619,7 +683,7 @@ pub struct SyncClient {
     /// off. The encrypt/decrypt seam (`values.rs`) is compiled only under the
     /// `e2ee` feature; without it, a schema with encrypted columns fails loud.
     encryption: crate::values::EncryptionConfig,
-    /// Per-table `INSERT OR REPLACE` SQL, built once per (full table name) —
+    /// Per-table primary-key upsert SQL, built once per (full table name) —
     /// the row write path runs per row during bootstrap (§5.6), so the SQL
     /// string (and, via `prepare_cached`, its compiled statement) is reused
     /// instead of being rebuilt and re-prepared per row. Cleared on a §7.4.3
@@ -4500,14 +4564,15 @@ impl SyncClient {
         // image side; every cell is validated against the declared column
         // type and bound BORROWED (no per-cell allocation, no per-row
         // statement re-preparation) — the Rust analogue of the TS client's
-        // single `INSERT OR REPLACE … SELECT` bulk copy.
+        // one prepared primary-key upsert per imported row.
         self.overlay_dirty.set(true);
         // A fresh whole-table load pays secondary-index maintenance per row;
         // dropping the base half's NON-unique indexes for the load and
         // recreating them after replaces that with one bulk sort per index.
-        // Unique indexes stay in place — `INSERT OR REPLACE` clobbers
-        // through them, so they are semantics, not just speed. The DDL rides
-        // the open section savepoint (§1.4): an abort rolls the drop back.
+        // Unique indexes stay in place because they are semantics, not just
+        // speed. A collision outside the primary key aborts the section and
+        // preserves the existing row. The DDL rides the open section
+        // savepoint (§1.4): an abort rolls the drop back.
         let bulk_indexes: Vec<&crate::schema::IndexSchema> = if first_fresh_page {
             table.indexes.iter().filter(|i| !i.unique).collect()
         } else {
@@ -5036,7 +5101,7 @@ impl SyncClient {
 
     // -- local row storage ----------------------------------------------------------
 
-    /// The cached per-table `INSERT OR REPLACE` SQL for `full_table` (see
+    /// The cached per-table primary-key upsert SQL for `full_table` (see
     /// the `insert_sql` field: built once, reused per row).
     fn insert_row_sql(&self, full_table: &str, table: &crate::schema::TableSchema) -> String {
         if let Some(sql) = self.insert_sql.borrow().get(full_table) {
@@ -5045,8 +5110,15 @@ impl SyncClient {
         let mut columns: Vec<String> = table.columns.iter().map(|c| quote_ident(&c.name)).collect();
         columns.push(quote_ident("_syncular_version"));
         let placeholders: Vec<&str> = columns.iter().map(|_| "?").collect();
+        let primary_key = quote_ident(&table.primary_key);
+        let updates = columns
+            .iter()
+            .filter(|column| **column != primary_key)
+            .map(|column| format!("{column}=excluded.{column}"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let sql = format!(
-            "INSERT OR REPLACE INTO {full_table} ({}) VALUES ({})",
+            "INSERT INTO {full_table} ({}) VALUES ({}) ON CONFLICT ({primary_key}) DO UPDATE SET {updates}",
             columns.join(", "),
             placeholders.join(", ")
         );


### PR DESCRIPTION
## What changed

- replace application-row `INSERT OR REPLACE` writes with primary-key-targeted upserts in the TypeScript client, SQLite-image path, Rust client, SQLite server, and D1 server
- preserve normal primary-key update behavior while allowing secondary unique-index collisions to fail atomically
- prepare the lockstep 0.14.0 release and clarify the normative segment-application contract

## Why

`INSERT OR REPLACE` deletes the row that owns a conflicting secondary unique value before inserting the incoming row. A rejected Syncular write could therefore silently remove valid local or server data. Targeted `ON CONFLICT(primary key) DO UPDATE` matches PostgreSQL behavior and leaves the existing row intact.

## Validation

- `bun run check` — 1220 passed, 6 environment-gated skipped; isolated multi-tab 8 passed
- `cargo test --workspace`
- native-transport FFI round tests
- Tauri plugin native-transport tests
- focused regressions for TypeScript row apply, SQLite-image apply, Rust apply, SQLite server, and D1 server