### PR TITLE
feat(server): add durable reactions and remote application clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ checked by the server when it syncs.
 The browser client runs SQLite on OPFS. Native integrations share the Rust core
 and native SQLite across Rust, Swift, Kotlin, Flutter, React Native, and Tauri.
 Servers run on Bun, Node, or Cloudflare Workers with SQLite, Postgres, or D1.
-Backend processes can run the same SQLite client headlessly, or use the
-database-less remote client for push-only commits and registered server
-operations.
+Backend services and workers can run a
+[server-side `SyncClient`](https://syncular.dev/guide-server-clients/) with
+persistent SQLite (often called a headless client). A
+[database-less `SyncRemoteClient`](https://syncular.dev/guide-remote-operations/)
+submits commits and calls registered server operations. Applications can store
+[domain actions as event rows](https://syncular.dev/guide-domain-events/)
+alongside their related writes.
 
 **[Documentation](https://syncular.dev)** ·
 [Quickstart](https://syncular.dev/quickstart/) ·

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ checked by the server when it syncs.
 The browser client runs SQLite on OPFS. Native integrations share the Rust core
 and native SQLite across Rust, Swift, Kotlin, Flutter, React Native, and Tauri.
 Servers run on Bun, Node, or Cloudflare Workers with SQLite, Postgres, or D1.
+Backend processes can run the same SQLite client headlessly, or use the
+database-less remote client for push-only commits and registered server
+operations.
 
 **[Documentation](https://syncular.dev)** ·
 [Quickstart](https://syncular.dev/quickstart/) ·
@@ -43,7 +46,8 @@ can still change before 1.0. Changes are recorded in
 
 ## How behavior is checked
 
-[`docs/SPEC.md`](docs/SPEC.md) defines the wire protocol, and
+[`docs/SPEC.md`](docs/SPEC.md) defines the sync wire protocol,
+[`docs/REMOTE.md`](docs/REMOTE.md) defines registered remote operations, and
 [`spec/vectors/`](spec/vectors) contains its byte-level fixtures. The
 TypeScript and Rust cores run the same implementation-independent conformance
 catalog. A behavior change that affects both cores has to update the spec and

--- a/apps/demo-react/src/syncular.queries.ts
+++ b/apps/demo-react/src/syncular.queries.ts
@@ -71,6 +71,7 @@ export interface NamedQuery<Row, Params = undefined> {
   readonly sql: string;
   readonly mapRow: (row: Readonly<Record<string, unknown>>) => Row;
   readonly tables: readonly string[];
+  readonly resultColumns: readonly QueryResultColumn[];
   readonly bind: (params: Params) => readonly QueryValue[];
   readonly sqlFor?: (params: Params) => string;
   readonly dependencies: (params: Params) => readonly QueryDependency[];
@@ -83,6 +84,12 @@ export interface NamedQuery<Row, Params = undefined> {
 export interface QueryDependency {
   readonly table: string;
   readonly scopeKeys?: readonly string[];
+}
+
+export interface QueryResultColumn {
+  readonly name: string;
+  readonly type: 'string' | 'integer' | 'float' | 'boolean' | 'json' | 'bytes' | 'blob_ref' | 'crdt';
+  readonly nullable: boolean;
 }
 
 export interface WindowCoverage {
@@ -163,6 +170,7 @@ export const listTodosQuery: NamedQuery<ListTodosRow, ListTodosParams> = {
   mapRow: listTodosMapRow,
   sqlFor: (params: ListTodosParams) => listTodosSelect(params).sql,
   tables: listTodosTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'listId', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }, { name: 'position', type: 'integer', nullable: false }, { name: 'updatedAtMs', type: 'integer', nullable: false }, { name: 'attachment', type: 'blob_ref', nullable: true }],
   dependencies: (params) => [
     { table: 'todos', scopeKeys: ['list:' + String(params.listId) + ''] },
   ],

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -13,7 +13,7 @@
     "@syncular/server": "workspace:*",
     "@syncular/server-hono": "workspace:*",
     "@syncular/client": "workspace:*",
-    "hono": "^4.11.0"
+    "hono": "^4.12.34"
   },
   "devDependencies": {
     "@syncular/typegen": "workspace:*",

--- a/apps/docs/src/content/blog/offline-first-writes.md
+++ b/apps/docs/src/content/blog/offline-first-writes.md
@@ -524,7 +524,7 @@ The web core is TypeScript. The native core is Rust, exposed through thin Swift,
 
 Both implement the written [SSP2 protocol](https://github.com/syncular/syncular/blob/main/docs/SPEC.md). Both consume the same generated schema contract. Both run the same implementation-agnostic [conformance scenarios and golden byte vectors](/guide-conformance/).
 
-The catalog contains 95 scenarios covering convergence, offline replay, lost acknowledgements, conflicts, scopes, revocation, bootstrap interruption, blobs, encryption, CRDTs, schema upgrades, realtime, presence, windowing, validation, and pruning. The repository gate passes more than 1,200 tests across the TypeScript and Rust paths.
+The catalog contains 96 scenarios covering convergence, offline replay, lost acknowledgements, conflicts, scopes, revocation, bootstrap interruption, blobs, encryption, CRDTs, schema upgrades, realtime, presence, windowing, validation, and pruning. The repository gate passes more than 1,200 tests across the TypeScript and Rust paths.
 
 Writing down a protocol is valuable because it removes implementation language as an excuse. If behavior can only be explained by pointing at a TypeScript object, it is not yet a portable protocol.
 

--- a/apps/docs/src/content/blog/offline-first-writes.md
+++ b/apps/docs/src/content/blog/offline-first-writes.md
@@ -524,7 +524,7 @@ The web core is TypeScript. The native core is Rust, exposed through thin Swift,
 
 Both implement the written [SSP2 protocol](https://github.com/syncular/syncular/blob/main/docs/SPEC.md). Both consume the same generated schema contract. Both run the same implementation-agnostic [conformance scenarios and golden byte vectors](/guide-conformance/).
 
-The catalog contains 96 scenarios covering convergence, offline replay, lost acknowledgements, conflicts, scopes, revocation, bootstrap interruption, blobs, encryption, CRDTs, schema upgrades, realtime, presence, windowing, validation, and pruning. The repository gate passes more than 1,200 tests across the TypeScript and Rust paths.
+The catalog contains 97 scenarios covering convergence, offline replay, lost acknowledgements, conflicts, scopes, revocation, bootstrap interruption, blobs, encryption, CRDTs, schema upgrades, realtime, presence, windowing, validation, and pruning. The repository gate passes more than 1,200 tests across the TypeScript and Rust paths.
 
 Writing down a protocol is valuable because it removes implementation language as an excuse. If behavior can only be explained by pointing at a TypeScript object, it is not yet a portable protocol.
 

--- a/apps/docs/src/content/guide-domain-events.md
+++ b/apps/docs/src/content/guide-domain-events.md
@@ -1,0 +1,208 @@
+# Domain actions and event rows
+
+Row changes describe state. They do not reliably describe why the state
+changed. A reservation time can move because a patient rescheduled, a clinician
+changed availability, or an operator repaired bad data. Consumers that infer
+the action from the changed columns will eventually misclassify one of those
+cases.
+
+Store the action as ordinary relational data. Update the affected domain rows
+and insert one immutable event row in the same `mutate([...])` call.
+
+## Schema
+
+This example keeps appointments, reservations, and domain events in the same
+clinic scope:
+
+```sql
+CREATE TABLE appointments (
+  id TEXT PRIMARY KEY,
+  clinic_id TEXT NOT NULL,
+  reservation_id TEXT NOT NULL,
+  starts_at_ms BIGINT NOT NULL,
+  updated_at_ms BIGINT NOT NULL
+);
+
+CREATE TABLE reservations (
+  id TEXT PRIMARY KEY,
+  clinic_id TEXT NOT NULL,
+  starts_at_ms BIGINT NOT NULL,
+  updated_at_ms BIGINT NOT NULL
+);
+
+CREATE TABLE domain_events (
+  id TEXT PRIMARY KEY,
+  clinic_id TEXT NOT NULL,
+  aggregate_type TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  occurred_at_ms BIGINT NOT NULL,
+  payload JSON NOT NULL
+);
+```
+
+Declare the same `clinic:{clinic_id}` scope for all three tables. Event rows
+then follow the same authorization boundary as the state they describe.
+
+## Write the state and action together
+
+Generate the event ID once and keep it with the logical action. The local
+outbox retains the commit across retries.
+
+```ts
+const occurredAtMs = Date.now();
+const eventId = crypto.randomUUID();
+
+const commitId = client.mutate([
+  {
+    table: 'appointments',
+    op: 'upsert',
+    values: {
+      id: appointment.id,
+      clinic_id: appointment.clinicId,
+      reservation_id: appointment.reservationId,
+      starts_at_ms: newStartsAtMs,
+      updated_at_ms: occurredAtMs,
+    },
+  },
+  {
+    table: 'reservations',
+    op: 'upsert',
+    values: {
+      id: appointment.reservationId,
+      clinic_id: appointment.clinicId,
+      starts_at_ms: newStartsAtMs,
+      updated_at_ms: occurredAtMs,
+    },
+  },
+  {
+    table: 'domain_events',
+    op: 'upsert',
+    values: {
+      id: eventId,
+      clinic_id: appointment.clinicId,
+      aggregate_type: 'appointment',
+      aggregate_id: appointment.id,
+      event_type: 'appointment_rescheduled',
+      occurred_at_ms: occurredAtMs,
+      payload: JSON.stringify({
+        reservationId: appointment.reservationId,
+        previousStartsAtMs: appointment.startsAtMs,
+        startsAtMs: newStartsAtMs,
+      }),
+    },
+  },
+]);
+```
+
+The three operations form one Syncular commit. The server applies every row,
+the commit-log entry, and the idempotency result in one storage transaction.
+A rejection or conflict rolls the complete commit back.
+
+## Require the event with `commitValidator`
+
+A client bug could update the appointment without inserting its event. A
+whole-commit validator can reject that shape before the transaction commits:
+
+```ts
+import {
+  CommitValidationRejection,
+  type CommitValidator,
+} from '@syncular/server';
+
+export const requireAppointmentEvents: CommitValidator = ({ operations }) => {
+  const appointments = operations.filter(
+    (operation) =>
+      operation.table === 'appointments' &&
+      operation.stored !== undefined &&
+      operation.row?.starts_at_ms !== operation.stored.starts_at_ms,
+  );
+  for (const appointment of appointments) {
+    const reservationId = appointment.row?.reservation_id;
+    const reservation = operations.find(
+      (operation) =>
+        operation.table === 'reservations' &&
+        operation.rowId === reservationId &&
+        operation.row?.starts_at_ms === appointment.row?.starts_at_ms,
+    );
+    const event = operations.find(
+      (operation) =>
+        operation.table === 'domain_events' &&
+        operation.row?.aggregate_id === appointment.rowId &&
+        operation.row?.event_type === 'appointment_rescheduled',
+    );
+
+    if (reservation === undefined || event === undefined) {
+      throw new CommitValidationRejection(
+        appointment.opIndex,
+        'app.incomplete_appointment_reschedule',
+        'appointment reschedule requires its reservation and event rows',
+      );
+    }
+  }
+};
+```
+
+Pass it as `SyncServerConfig.commitValidator`. The callback observes the final
+candidate state inside the open commit transaction.
+
+Also reject updates of existing `domain_events` rows with a table validator.
+Allow deletes only for a dedicated retention actor:
+
+```ts
+import { ValidationRejection, type Validator } from '@syncular/server';
+
+export const immutableDomainEvents: Validator = (operation, context) => {
+  if (
+    operation.stored !== undefined &&
+    !(operation.op === 'delete' && context.actorId === 'event-retention-worker')
+  ) {
+    throw new ValidationRejection(
+      'app.domain_event_immutable',
+      'existing domain events are immutable',
+    );
+  }
+};
+```
+
+Corrections to an event that already landed should insert another event, such
+as `appointment_reschedule_corrected`, with its own stable ID and a reference
+to the event it corrects.
+
+## Consumption and retention
+
+Treat the event primary key as the consumer idempotency key. A worker should
+record processed IDs or pass the ID to an idempotent downstream API. Delivery
+can repeat after a lost acknowledgement or a process crash.
+
+Event rows remain queryable until the retention worker deletes them.
+Commit-log pruning does not delete current rows. Define an application
+retention policy, then let the dedicated actor delete expired rows through
+normal mutations so replicas converge. Keep events required for audit or
+replay in storage appropriate for that retention period.
+
+If a reschedule conflicts, the complete state-and-event commit is rejected.
+Resolve against the returned server row and submit a new commit identity. The
+event ID can remain stable when it still identifies the same business action
+and no event row landed. If an earlier event already landed, preserve it and
+insert a correction event with a new ID. Exact retries of one prepared commit
+keep both the commit identity and event ID unchanged.
+
+## Related mechanisms
+
+- `SyncularServerEvents` reports protocol and operational activity such as a
+  rejected push, a segment download, or a resolver failure. It is an
+  observability sink. Domain event rows are application data and sync to
+  authorized replicas.
+- A CRDT or Yjs column defines how concurrent values merge. It does not record
+  the business action that caused an edit. A row may contain a CRDT column and
+  still have a sibling domain event.
+- A normal client mutation is appropriate when the caller may write the rows
+  under its resolved scopes. Use a [server-authoritative command](/guide-remote-operations/#server-authoritative-commands)
+  when the operation needs privileged reads, secret material, a server-owned
+  invariant, or custom command authorization.
+
+## Find this guide
+
+Search terms: domain action, domain event, event row, immutable event,
+transactional outbox.

--- a/apps/docs/src/content/guide-domain-events.md
+++ b/apps/docs/src/content/guide-domain-events.md
@@ -95,6 +95,10 @@ const commitId = client.mutate([
 ]);
 ```
 
+`crypto.randomUUID()` is stable for retries of this durable local commit. If
+the action originates from a retried webhook or job, derive the event ID from
+that upstream request ID or persist the generated ID with the job.
+
 The three operations form one Syncular commit. The server applies every row,
 the commit-log entry, and the idempotency result in one storage transaction.
 A rejection or conflict rolls the complete commit back.
@@ -114,6 +118,7 @@ export const requireAppointmentEvents: CommitValidator = ({ operations }) => {
   const appointments = operations.filter(
     (operation) =>
       operation.table === 'appointments' &&
+      operation.op === 'upsert' &&
       operation.stored !== undefined &&
       operation.row?.starts_at_ms !== operation.stored.starts_at_ms,
   );
@@ -122,12 +127,18 @@ export const requireAppointmentEvents: CommitValidator = ({ operations }) => {
     const reservation = operations.find(
       (operation) =>
         operation.table === 'reservations' &&
+        operation.op === 'upsert' &&
         operation.rowId === reservationId &&
+        operation.row?.clinic_id === appointment.row?.clinic_id &&
         operation.row?.starts_at_ms === appointment.row?.starts_at_ms,
     );
     const event = operations.find(
       (operation) =>
         operation.table === 'domain_events' &&
+        operation.op === 'upsert' &&
+        operation.stored === undefined &&
+        operation.row?.clinic_id === appointment.row?.clinic_id &&
+        operation.row?.aggregate_type === 'appointment' &&
         operation.row?.aggregate_id === appointment.rowId &&
         operation.row?.event_type === 'appointment_rescheduled',
     );
@@ -169,6 +180,62 @@ Corrections to an event that already landed should insert another event, such
 as `appointment_reschedule_corrected`, with its own stable ID and a reference
 to the event it corrects.
 
+## Plan durable reactions from event rows
+
+When [durable server reactions](/server-reactions/) are enabled, use the event
+row as the planner input. The planner runs after validation while the source
+transaction is still open. Its reaction records commit atomically with the
+appointment, reservation, event row, commit log, and idempotency result.
+
+```ts
+import type { ReactionPlanner } from '@syncular/server';
+
+type AppointmentReactions = {
+  'appointment.notify_rescheduled': {
+    readonly eventId: string;
+    readonly appointmentId: string;
+    readonly payload: string;
+  };
+};
+
+export const appointmentReactionPlanner: ReactionPlanner<
+  AppointmentReactions
+> = ({ operations }) =>
+  operations.flatMap((operation) => {
+    if (
+      operation.table !== 'domain_events' ||
+      operation.op !== 'upsert' ||
+      operation.row?.event_type !== 'appointment_rescheduled'
+    ) {
+      return [];
+    }
+
+    const eventId = operation.row.id;
+    const appointmentId = operation.row.aggregate_id;
+    const payload = operation.row.payload;
+    if (
+      typeof eventId !== 'string' ||
+      typeof appointmentId !== 'string' ||
+      typeof payload !== 'string'
+    ) {
+      throw new Error('invalid appointment_rescheduled event');
+    }
+
+    return [
+      {
+        key: `notify:${eventId}`,
+        type: 'appointment.notify_rescheduled',
+        version: 1,
+        payload: { eventId, appointmentId, payload },
+      },
+    ];
+  });
+```
+
+Pass the planner as `SyncServerConfig.reactionPlanner`. A runner handles the
+reaction after commit and receives a stable reaction idempotency key. Keep
+external calls out of both `mutate()` validation and the planner.
+
 ## Consumption and retention
 
 Treat the event primary key as the consumer idempotency key. A worker should
@@ -201,8 +268,3 @@ keep both the commit identity and event ID unchanged.
   under its resolved scopes. Use a [server-authoritative command](/guide-remote-operations/#server-authoritative-commands)
   when the operation needs privileged reads, secret material, a server-owned
   invariant, or custom command authorization.
-
-## Find this guide
-
-Search terms: domain action, domain event, event row, immutable event,
-transactional outbox.

--- a/apps/docs/src/content/guide-headless-clients.md
+++ b/apps/docs/src/content/guide-headless-clients.md
@@ -1,0 +1,198 @@
+# Headless Node and Bun clients
+
+`SyncClient` is the server client for a process that needs a local synchronized
+read model. The same client used in a browser runs in a CLI, background worker,
+or long-running Node or Bun service. It has no DOM dependency when supplied a
+native SQLite backend.
+
+Use a persistent database path. An in-memory database loses rows, subscription
+cursors, client identity, and the outbox on restart.
+
+## Open the local replica
+
+```ts
+import {
+  httpSegmentDownloader,
+  httpSyncTransport,
+  SyncClient,
+  webSocketRealtimeConnector,
+  type SyncIntent,
+} from '@syncular/client';
+import { openBunDatabase } from '@syncular/client/bun';
+// Node: import { openNodeDatabase } from '@syncular/client/node';
+import { schema } from './syncular.generated';
+
+const database = openBunDatabase('./data/appointment-worker.sqlite');
+// const database = openNodeDatabase('./data/appointment-worker.sqlite');
+
+const serviceToken = process.env.SYNCULAR_SERVICE_TOKEN;
+if (serviceToken === undefined) throw new Error('missing service token');
+
+let client: SyncClient;
+let timer: ReturnType<typeof setTimeout> | undefined;
+let closed = false;
+let running = Promise.resolve();
+
+function schedule(intent: SyncIntent): void {
+  if (closed || intent.kind === 'none') return;
+  if (timer !== undefined) clearTimeout(timer);
+  const delay = intent.kind === 'background' ? intent.delayMs : 0;
+  timer = setTimeout(() => {
+    running = running
+      .then(() => client.syncUntilIdle())
+      .then(() => undefined)
+      .catch((error) => console.error('sync failed', error));
+  }, delay);
+}
+
+client = new SyncClient({
+  database,
+  schema,
+  clientId: 'appointment-worker-eu-1',
+  transport: httpSyncTransport('https://api.example.com/sync', {
+    headers: { Authorization: `Bearer ${serviceToken}` },
+  }),
+  segments: httpSegmentDownloader('https://api.example.com/segments', {
+    headers: { Authorization: `Bearer ${serviceToken}` },
+  }),
+  realtime: webSocketRealtimeConnector(
+    `wss://api.example.com/realtime?access_token=${encodeURIComponent(serviceToken)}`,
+  ),
+  onSyncNeeded: () => schedule({ kind: 'interactive' }),
+  onSyncIntent: schedule,
+});
+
+await client.start();
+client.subscribe({
+  id: 'clinic-42-appointments',
+  table: 'appointments',
+  scopes: { clinic_id: ['clinic-42'] },
+});
+await client.syncUntilIdle();
+await client.connectRealtime();
+```
+
+The HTTP and WebSocket credentials are application auth. The server's
+`authenticate` callback maps them to an actor and partition. The example uses a
+query parameter for WebSocket authentication because the built-in connector
+uses the standard `WebSocket` constructor. Configure the server to accept that
+credential, or provide a custom `RealtimeConnector` for a runtime that supports
+headers. Bun and current Node runtimes provide `fetch`; the WebSocket connector
+also requires a global `WebSocket` implementation.
+
+`openNodeDatabase()` uses the optional `better-sqlite3` peer. Install it in a
+Node service. Bun should use `openBunDatabase()` and `bun:sqlite`.
+
+## Query and mutate
+
+Reads use the local SQLite replica and do not wait for the network:
+
+```ts
+const rows = client.query(
+  `SELECT id, starts_at_ms, status
+     FROM appointments
+    WHERE clinic_id = ?
+    ORDER BY starts_at_ms`,
+  ['clinic-42'],
+);
+```
+
+Writes enter the same durable outbox as browser writes:
+
+```ts
+const commitId = client.mutate([
+  {
+    table: 'appointments',
+    op: 'upsert',
+    values: updatedAppointment,
+  },
+]);
+
+await client.syncUntilIdle();
+console.log({ commitId });
+```
+
+Keep one live client per database file. The leader lock fails if another
+process tries to own the same replica concurrently.
+
+## Idempotent event consumption
+
+Use immutable [domain event rows](/guide-domain-events/) as the work source.
+Keep consumer receipts in a worker-local table. Direct database writes are
+appropriate for this local-only table; never write a synced table through
+`client.database`.
+
+```ts
+client.database.exec(`
+  CREATE TABLE IF NOT EXISTS worker_receipts (
+    event_id TEXT PRIMARY KEY,
+    processed_at_ms INTEGER NOT NULL
+  )
+`);
+
+const pending = client.query(`
+  SELECT e.id, e.event_type, e.payload
+    FROM domain_events AS e
+    LEFT JOIN worker_receipts AS r ON r.event_id = e.id
+   WHERE r.event_id IS NULL
+   ORDER BY e.occurred_at_ms, e.id
+   LIMIT 100
+`);
+
+for (const event of pending) {
+  const eventId = String(event.id);
+  await fetch('https://jobs.example.com/appointment-events', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': eventId,
+    },
+    body: String(event.payload),
+  });
+  client.database.exec(
+    'INSERT OR IGNORE INTO worker_receipts(event_id, processed_at_ms) VALUES (?, ?)',
+    [eventId, Date.now()],
+  );
+}
+```
+
+The downstream idempotency key covers a crash after the external call and
+before the local receipt insert. The local receipt avoids repeated calls in
+normal operation.
+
+## Clean shutdown
+
+Stop scheduling new rounds, close realtime, wait for the current round, then
+close SQLite:
+
+```ts
+async function shutdown(): Promise<void> {
+  closed = true;
+  if (timer !== undefined) clearTimeout(timer);
+  await running;
+  await client.close();
+  database.close();
+}
+
+process.once('SIGINT', () => void shutdown());
+process.once('SIGTERM', () => void shutdown());
+```
+
+## Choose the correct server-side surface
+
+- Headless `SyncClient`: persistent local SQLite, local SQL reads, scoped or
+  wildcard access from `resolveScopes`, durable outbox, subscriptions, and
+  realtime convergence.
+- [`SyncRemoteClient`](/guide-remote-operations/): no SQLite. It submits
+  ordinary commits and calls registered remote queries or commands.
+- Direct authoritative database access: trusted code located with the server
+  database. It bypasses the Syncular client protocol and should remain inside
+  the server trust boundary.
+- `SyncularServerEvents`: operational telemetry. It is not a durable work
+  queue or an application subscription.
+- Durable server reactions: durable post-commit work scheduling. They are
+  separate from a headless replica and from live query watches.
+
+Search terms: server client, headless client, Node client, Bun client,
+background worker, CLI sync.
+

--- a/apps/docs/src/content/guide-remote-operations.md
+++ b/apps/docs/src/content/guide-remote-operations.md
@@ -1,0 +1,310 @@
+# Remote server operations
+
+Server processes do not all need a local replica. `SyncRemoteClient` is the
+database-less client for ordinary commits, registered authoritative queries,
+server-authoritative commands, and live query snapshots.
+
+## Capability matrix
+
+| Need | Surface | Local SQLite | Authorization | Durable retry |
+|---|---|---:|---|---|
+| Local SQL read model and offline outbox | Headless `SyncClient` | Required | Resolved scopes or wildcard access | Outbox owned by client |
+| Ordinary commit from a job or webhook | `SyncRemoteClient.commit()` | None | Normal write scopes | Caller retains prepared bytes |
+| Predefined typed server SQL | `SyncRemoteClient.query()` | None | Generated scope coverage or privileged callback | Read-only request |
+| Privileged transactional operation | `SyncRemoteClient.command()` | None | Command callback plus normal write scopes | Stable request ID |
+| Live predefined query | `SyncRemoteClient.watch()` | None | Same rule as the query | Replacement snapshots while connected |
+| Operator SQL next to the database | Storage or driver directly | None | Server trust boundary | Application-owned |
+| Protocol telemetry | `SyncularServerEvents` | None | Operator access | Sink-owned |
+| Durable post-commit work | Durable server reactions | None | Server configuration | Reaction store |
+
+## Database-less ordinary commits
+
+The client uses the existing `/sync` push path. It does not create a local
+database, subscription cursor, or outbox.
+
+```ts
+import {
+  httpRemoteOperationTransport,
+  httpSyncTransport,
+  SyncRemoteClient,
+} from '@syncular/client';
+import { schema } from './syncular.generated';
+
+const headers = { Authorization: `Bearer ${process.env.SERVICE_TOKEN}` };
+const client = new SyncRemoteClient({
+  schema,
+  clientId: 'billing-webhooks',
+  transport: httpSyncTransport('https://api.example.com/sync', { headers }),
+  operations: httpRemoteOperationTransport(
+    'https://api.example.com/operations',
+    { headers },
+  ),
+});
+
+const prepared = await client.prepareCommit({
+  requestId: 'stripe-event-evt_123',
+  mutations: [
+    {
+      table: 'invoices',
+      op: 'upsert',
+      values: invoice,
+    },
+  ],
+});
+
+const result = await client.sendCommit(prepared);
+```
+
+Persist `prepared.bytes` with the job when a retry must survive process
+restart. Send the exact bytes again after a lost response. This also preserves
+random encryption nonces. The server returns `cached` after the first applied
+delivery.
+
+## Registered typed queries
+
+Typegen already emits a typed `NamedQuery` descriptor for SQL and SYQL. The
+server registers that descriptor; the remote client sends its generated ID and
+parameters. Query text never crosses the network.
+
+```ts
+import {
+  registerRemoteQuery,
+  RemoteOperationRegistry,
+} from '@syncular/server';
+import { tasksInProjectQuery } from './syncular.queries';
+
+export const operations = new RemoteOperationRegistry([
+  registerRemoteQuery(tasksInProjectQuery, {
+    maxRows: 500,
+    auth: { access: 'scoped' },
+  }),
+]);
+```
+
+A scoped registration requires complete generated coverage for every table in
+the query. The server resolves the caller's scopes and verifies every coverage
+unit before executing SQL. Queries without complete coverage fail with
+`operation.invalid_request`.
+
+An administrative query uses a mandatory privileged authorizer:
+
+```ts
+registerRemoteQuery(allInvoicesQuery, {
+  maxRows: 2_000,
+  auth: {
+    access: 'privileged',
+    authorize: ({ actorId }) => operatorIds.has(actorId),
+  },
+});
+```
+
+Mount the registry with Hono:
+
+```ts
+const app = createSyncularHono({
+  config,
+  operations,
+  authenticate,
+});
+```
+
+Call it with the same generated descriptor:
+
+```ts
+import {
+  httpRemoteOperationTransport,
+  SyncRemoteClient,
+} from '@syncular/client';
+import { tasksInProjectQuery } from './syncular.queries';
+
+const token = process.env.SYNCULAR_SERVICE_TOKEN;
+if (token === undefined) throw new Error('missing service token');
+const headers = { Authorization: `Bearer ${token}` };
+
+const queryClient = new SyncRemoteClient({
+  clientId: 'reporting-worker',
+  operations: httpRemoteOperationTransport(
+    'https://api.example.com/operations',
+    { headers },
+  ),
+});
+
+const snapshot = await queryClient.query(tasksInProjectQuery, {
+  projectId: 'project-42',
+});
+
+console.log(snapshot.rows, snapshot.maxCommitSeq);
+```
+
+The schema and `/sync` transport are optional when a process only calls
+registered queries or commands. Ordinary commits require both.
+
+The storage adapter rewrites every generated app-table relation into a
+partition-filtered relation. It executes the rows and `maxCommitSeq` reads in
+one database snapshot. SQLite, D1, and Postgres adapters implement this
+capability. The authored query still needs syntax supported by the selected
+server database. Typegen currently checks the SQLite form, so a Postgres
+deployment should keep remotely registered SQL within the common SQL subset or
+test it against Postgres in CI.
+
+## Server-authoritative commands
+
+Commands run custom code after the partition write lock and idempotency
+recheck. Their reads and returned mutations share the transaction used by the
+normal push validator, commit validator, commit log, and realtime notification.
+
+```ts
+import {
+  registerRemoteCommand,
+  RemoteOperationRegistry,
+} from '@syncular/server';
+import { captureInvoice } from './remote-operation-descriptors';
+
+const operations = new RemoteOperationRegistry([
+  registerRemoteCommand(captureInvoice, {
+    authorize: ({ actorId }) => billingServiceActors.has(actorId),
+    run: async (command, input) => {
+      const invoice = await command.getRow('invoices', input.invoiceId);
+      if (invoice === undefined) throw new Error('invoice is unavailable');
+      return [
+        {
+          table: 'invoices',
+          op: 'upsert',
+          values: { ...invoice, status: 'captured' },
+        },
+        {
+          table: 'domain_events',
+          op: 'upsert',
+          values: {
+            id: crypto.randomUUID(),
+            account_id: invoice.account_id,
+            aggregate_type: 'invoice',
+            aggregate_id: input.invoiceId,
+            event_type: 'invoice_captured',
+            occurred_at_ms: Date.now(),
+            payload: '{}',
+          },
+        },
+      ];
+    },
+  }),
+]);
+```
+
+Keep the shared descriptor in an import-safe module:
+
+```ts
+import {
+  remoteCommand,
+  type RemoteCommandDescriptor,
+} from '@syncular/client';
+
+export const captureInvoice: RemoteCommandDescriptor<{
+  invoiceId: string;
+}> = remoteCommand('commands/capture-invoice-v1');
+```
+
+The client supplies a stable request ID:
+
+```ts
+const result = await client.command(
+  captureInvoice,
+  'capture-request-018f',
+  { invoiceId: 'invoice-42' },
+);
+```
+
+The command authorizer is additional to normal write-scope authorization.
+Configure wildcard scopes only for actors that should have full write access.
+Command callbacks should restrict side effects to planning database mutations.
+External calls belong after the commit in an idempotent worker or durable
+reaction.
+
+## Live query watches
+
+`RemoteOperationWatchHub` reruns affected registered queries and sends full
+replacement snapshots. A commit touching unrelated tables does not rerun the
+query. If commits arrive during a query, the session coalesces them into one
+additional run.
+
+```ts
+import {
+  composeRealtimeNotifiers,
+  RemoteOperationWatchHub,
+} from '@syncular/server';
+
+const operationWatches = new RemoteOperationWatchHub(operations);
+const config = {
+  ...baseConfig,
+  realtime: composeRealtimeNotifiers(syncRealtimeHub, operationWatches),
+};
+```
+
+The host's WebSocket upgrade for `/operations/realtime` authenticates the
+request, builds a `SyncRequestContext`, and connects it:
+
+```ts
+const session = operationWatches.connect(context, (bytes) => socket.send(bytes));
+socket.onmessage = (bytes) => void session.receive(bytes);
+socket.onclose = () => session.close();
+```
+
+Client setup and subscription:
+
+```ts
+import {
+  httpRemoteOperationTransport,
+  httpSyncTransport,
+  SyncRemoteClient,
+  webSocketRemoteOperationConnector,
+} from '@syncular/client';
+
+const token = process.env.SYNCULAR_SERVICE_TOKEN;
+if (token === undefined) throw new Error('missing service token');
+const headers = { Authorization: `Bearer ${token}` };
+
+const client = new SyncRemoteClient({
+  schema,
+  clientId: 'reporting-worker',
+  transport: httpSyncTransport('https://api.example.com/sync', { headers }),
+  operations: httpRemoteOperationTransport(
+    'https://api.example.com/operations',
+    { headers },
+  ),
+  operationRealtime: webSocketRemoteOperationConnector(
+    `wss://api.example.com/operations/realtime?access_token=${encodeURIComponent(token)}`,
+  ),
+});
+
+const unwatch = await client.watch(
+  tasksInProjectQuery,
+  { projectId: 'project-42' },
+  {
+    onSnapshot: ({ rows }) => replaceReport(rows),
+    onError: (error) => reportWatchFailure(error),
+  },
+);
+
+unwatch();
+client.close();
+```
+
+Watches are live invalidations, not durable work delivery. After a connection
+loss, reconnect and register the watch again to receive a fresh snapshot.
+
+## Boundaries
+
+- Remote operation requests contain a registered ID and encoded values. They
+  never contain caller-supplied SQL.
+- Direct authoritative database access is for trusted code already inside the
+  database trust boundary. It does not create Syncular commits or realtime
+  notifications by itself.
+- `SyncularServerEvents` describes protocol operation. Domain event rows
+  describe application intent.
+- Durable server reactions schedule recoverable post-commit work. Query
+  watches provide replaceable live state and may repeat or disappear with the
+  connection.
+
+Search terms: database-less client, server client, M2M query, admin query,
+typed server query, predefined query, server-authoritative command,
+subscription.

--- a/apps/docs/src/content/guide-remote-operations.md
+++ b/apps/docs/src/content/guide-remote-operations.md
@@ -2,13 +2,15 @@
 
 Server processes do not all need a local replica. `SyncRemoteClient` is the
 database-less client for ordinary commits, registered authoritative queries,
-server-authoritative commands, and live query snapshots.
+server-authoritative commands, and live query snapshots. It fits
+machine-to-machine (M2M) integrations, admin queries, and workers without local
+SQLite.
 
 ## Capability matrix
 
 | Need | Surface | Local SQLite | Authorization | Durable retry |
 |---|---|---:|---|---|
-| Local SQL read model and offline outbox | Headless `SyncClient` | Required | Resolved scopes or wildcard access | Outbox owned by client |
+| Local SQL read model and offline outbox | Server-side `SyncClient` | Required | Resolved scopes or wildcard access | Outbox owned by client |
 | Ordinary commit from a job or webhook | `SyncRemoteClient.commit()` | None | Normal write scopes | Caller retains prepared bytes |
 | Predefined typed server SQL | `SyncRemoteClient.query()` | None | Generated scope coverage or privileged callback | Read-only request |
 | Privileged transactional operation | `SyncRemoteClient.command()` | None | Command callback plus normal write scopes | Stable request ID |
@@ -30,7 +32,9 @@ import {
 } from '@syncular/client';
 import { schema } from './syncular.generated';
 
-const headers = { Authorization: `Bearer ${process.env.SERVICE_TOKEN}` };
+const serviceToken = process.env.SERVICE_TOKEN;
+if (serviceToken === undefined) throw new Error('missing service token');
+const headers = { Authorization: `Bearer ${serviceToken}` };
 const client = new SyncRemoteClient({
   schema,
   clientId: 'billing-webhooks',
@@ -55,10 +59,10 @@ const prepared = await client.prepareCommit({
 const result = await client.sendCommit(prepared);
 ```
 
-Persist `prepared.bytes` with the job when a retry must survive process
-restart. Send the exact bytes again after a lost response. This also preserves
-random encryption nonces. The server returns `cached` after the first applied
-delivery.
+Persist `prepared.bytes` as binary data or base64 with the job when a retry
+must survive process restart. Send the exact decoded bytes again after a lost
+response. This also preserves random encryption nonces. The server returns
+`cached` after the first applied delivery.
 
 ## Registered typed queries
 
@@ -81,10 +85,13 @@ export const operations = new RemoteOperationRegistry([
 ]);
 ```
 
-A scoped registration requires complete generated coverage for every table in
-the query. The server resolves the caller's scopes and verifies every coverage
-unit before executing SQL. Queries without complete coverage fail with
-`operation.invalid_request`.
+A scoped registration requires generated coverage for every table and every
+declared scope in the query. In SYQL, declare it as a `sync query`; typegen then
+emits coverage only when every scope is constrained by required equality or
+`IN` predicates. The server resolves the caller's scopes and verifies every
+covered value before executing SQL. Ordinary queries and queries without a
+complete proof fail with `operation.invalid_request` when registered as
+scoped.
 
 An administrative query uses a mandatory privileged authorizer:
 
@@ -147,6 +154,10 @@ server database. Typegen currently checks the SQLite form, so a Postgres
 deployment should keep remotely registered SQL within the common SQL subset or
 test it against Postgres in CI.
 
+Registration requires generated result-column metadata. The server validates
+and returns only those columns, so driver-specific or undeclared fields do not
+cross the operation boundary.
+
 ## Server-authoritative commands
 
 Commands run custom code after the partition write lock and idempotency
@@ -176,7 +187,13 @@ const operations = new RemoteOperationRegistry([
           table: 'domain_events',
           op: 'upsert',
           values: {
-            id: crypto.randomUUID(),
+            id: JSON.stringify([
+              'invoice-captured',
+              command.actorId,
+              command.clientId,
+              command.operationId,
+              command.requestId,
+            ]),
             account_id: invoice.account_id,
             aggregate_type: 'invoice',
             aggregate_id: input.invoiceId,
@@ -216,6 +233,10 @@ const result = await client.command(
 
 The command authorizer is additional to normal write-scope authorization.
 Configure wildcard scopes only for actors that should have full write access.
+The command context exposes the request's identity-checked `clientId`, its
+`operationId`, and its `requestId` for stable event and application idempotency
+keys.
+The authorizer can run again on a retry, so it must not have side effects.
 Command callbacks should restrict side effects to planning database mutations.
 External calls belong after the commit in an idempotent worker or durable
 reaction.
@@ -241,13 +262,28 @@ const config = {
 ```
 
 The host's WebSocket upgrade for `/operations/realtime` authenticates the
-request, builds a `SyncRequestContext`, and connects it:
+request, builds a `SyncRequestContext`, and connects it. The Syncular portion
+of that runtime-specific adapter is:
 
 ```ts
-const session = operationWatches.connect(context, (bytes) => socket.send(bytes));
-socket.onmessage = (bytes) => void session.receive(bytes);
-socket.onclose = () => session.close();
+import type {
+  RemoteOperationWatchSession,
+  SyncRequestContext,
+} from '@syncular/server';
+
+export function connectOperationWatches(
+  context: SyncRequestContext,
+  send: (bytes: Uint8Array) => void,
+): RemoteOperationWatchSession {
+  return operationWatches.connect(context, send);
+}
 ```
+
+Forward each inbound binary WebSocket message to `session.receive(bytes)` and
+call `session.close()` when the socket closes. If `receive()` rejects, close
+the socket with an application protocol error. The Hono adapter mounts the
+HTTP `/operations` route; WebSocket upgrade wiring remains with the runtime
+host.
 
 Client setup and subscription:
 
@@ -261,6 +297,8 @@ import {
 
 const token = process.env.SYNCULAR_SERVICE_TOKEN;
 if (token === undefined) throw new Error('missing service token');
+const realtimeTicket = process.env.SYNCULAR_OPERATION_REALTIME_TICKET;
+if (realtimeTicket === undefined) throw new Error('missing realtime ticket');
 const headers = { Authorization: `Bearer ${token}` };
 
 const client = new SyncRemoteClient({
@@ -272,7 +310,7 @@ const client = new SyncRemoteClient({
     { headers },
   ),
   operationRealtime: webSocketRemoteOperationConnector(
-    `wss://api.example.com/operations/realtime?access_token=${encodeURIComponent(token)}`,
+    `wss://api.example.com/operations/realtime?ticket=${encodeURIComponent(realtimeTicket)}`,
   ),
 });
 
@@ -289,6 +327,10 @@ unwatch();
 client.close();
 ```
 
+Use a short-lived WebSocket ticket because proxy access logs can retain URLs.
+A custom `RemoteOperationRealtimeConnector` can obtain a new ticket for each
+connection attempt when the application rotates them.
+
 Watches are live invalidations, not durable work delivery. After a connection
 loss, reconnect and register the watch again to receive a fresh snapshot.
 
@@ -304,7 +346,3 @@ loss, reconnect and register the watch again to receive a fresh snapshot.
 - Durable server reactions schedule recoverable post-commit work. Query
   watches provide replaceable live state and may repeat or disappear with the
   connection.
-
-Search terms: database-less client, server client, M2M query, admin query,
-typed server query, predefined query, server-authoritative command,
-subscription.

--- a/apps/docs/src/content/guide-server-clients.md
+++ b/apps/docs/src/content/guide-server-clients.md
@@ -1,9 +1,9 @@
-# Headless Node and Bun clients
+# Server-side sync clients
 
-`SyncClient` is the server client for a process that needs a local synchronized
+`SyncClient` can run server-side when a process needs a local synchronized
 read model. The same client used in a browser runs in a CLI, background worker,
 or long-running Node or Bun service. It has no DOM dependency when supplied a
-native SQLite backend.
+native SQLite backend. This deployment is sometimes called a headless client.
 
 Use a persistent database path. An in-memory database loses rows, subscription
 cursors, client identity, and the outbox on restart.
@@ -14,6 +14,7 @@ cursors, client identity, and the outbox on restart.
 import {
   httpSegmentDownloader,
   httpSyncTransport,
+  installRealtimeSupervisor,
   SyncClient,
   webSocketRealtimeConnector,
   type SyncIntent,
@@ -27,6 +28,9 @@ const database = openBunDatabase('./data/appointment-worker.sqlite');
 
 const serviceToken = process.env.SYNCULAR_SERVICE_TOKEN;
 if (serviceToken === undefined) throw new Error('missing service token');
+const realtimeTicket = process.env.SYNCULAR_REALTIME_TICKET;
+if (realtimeTicket === undefined) throw new Error('missing realtime ticket');
+const clientId = 'appointment-worker-eu-1';
 
 let client: SyncClient;
 let timer: ReturnType<typeof setTimeout> | undefined;
@@ -34,10 +38,15 @@ let closed = false;
 let running = Promise.resolve();
 
 function schedule(intent: SyncIntent): void {
-  if (closed || intent.kind === 'none') return;
-  if (timer !== undefined) clearTimeout(timer);
+  if (closed) return;
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timer = undefined;
+  }
+  if (intent.kind === 'none') return;
   const delay = intent.kind === 'background' ? intent.delayMs : 0;
   timer = setTimeout(() => {
+    timer = undefined;
     running = running
       .then(() => client.syncUntilIdle())
       .then(() => undefined)
@@ -48,7 +57,7 @@ function schedule(intent: SyncIntent): void {
 client = new SyncClient({
   database,
   schema,
-  clientId: 'appointment-worker-eu-1',
+  clientId,
   transport: httpSyncTransport('https://api.example.com/sync', {
     headers: { Authorization: `Bearer ${serviceToken}` },
   }),
@@ -56,7 +65,7 @@ client = new SyncClient({
     headers: { Authorization: `Bearer ${serviceToken}` },
   }),
   realtime: webSocketRealtimeConnector(
-    `wss://api.example.com/realtime?access_token=${encodeURIComponent(serviceToken)}`,
+    `wss://api.example.com/realtime?clientId=${encodeURIComponent(clientId)}&ticket=${encodeURIComponent(realtimeTicket)}`,
   ),
   onSyncNeeded: () => schedule({ kind: 'interactive' }),
   onSyncIntent: schedule,
@@ -69,16 +78,24 @@ client.subscribe({
   scopes: { clinic_id: ['clinic-42'] },
 });
 await client.syncUntilIdle();
-await client.connectRealtime();
+installRealtimeSupervisor(client);
 ```
 
+The supervisor owns initial connection, reconnect with bounded backoff, and a
+catch-up sync after reconnect. A custom service loop can call
+`connectRealtime()` and `disconnectRealtime()` directly instead.
+
 The HTTP and WebSocket credentials are application auth. The server's
-`authenticate` callback maps them to an actor and partition. The example uses a
-query parameter for WebSocket authentication because the built-in connector
-uses the standard `WebSocket` constructor. Configure the server to accept that
-credential, or provide a custom `RealtimeConnector` for a runtime that supports
-headers. Bun and current Node runtimes provide `fetch`; the WebSocket connector
-also requires a global `WebSocket` implementation.
+`authenticate` callback maps them to an actor and partition. The realtime host
+passes `clientId` to `RealtimeHub.connect`; Syncular checks its actor binding.
+The client ID identifies the replica and is not an authentication credential.
+The example uses a query parameter for WebSocket authentication because the
+built-in connector uses the standard `WebSocket` constructor. Configure the
+server to accept that short-lived ticket. Do not put a long-lived service
+bearer in a URL that a proxy may log. A rotating ticket flow can provide a
+custom `RealtimeConnector` that obtains a ticket for each connection attempt.
+Bun and current Node runtimes provide `fetch`; the WebSocket connector also
+requires a global `WebSocket` implementation.
 
 `openNodeDatabase()` uses the optional `better-sqlite3` peer. Install it in a
 Node service. Bun should use `openBunDatabase()` and `bun:sqlite`.
@@ -112,8 +129,10 @@ await client.syncUntilIdle();
 console.log({ commitId });
 ```
 
-Keep one live client per database file. The leader lock fails if another
-process tries to own the same replica concurrently.
+Keep one live client per database file. The default server-side lock assumes a
+single owner and does not coordinate across processes. Enforce ownership with
+your service manager or supply a `LeaderLock` backed by a cross-process lock
+when several processes could open the same path.
 
 ## Idempotent event consumption
 
@@ -166,12 +185,20 @@ Stop scheduling new rounds, close realtime, wait for the current round, then
 close SQLite:
 
 ```ts
-async function shutdown(): Promise<void> {
-  closed = true;
-  if (timer !== undefined) clearTimeout(timer);
-  await running;
-  await client.close();
-  database.close();
+let shutdownPromise: Promise<void> | undefined;
+
+function shutdown(): Promise<void> {
+  shutdownPromise ??= (async () => {
+    closed = true;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    await running;
+    await client.close();
+    database.close();
+  })();
+  return shutdownPromise;
 }
 
 process.once('SIGINT', () => void shutdown());
@@ -180,8 +207,8 @@ process.once('SIGTERM', () => void shutdown());
 
 ## Choose the correct server-side surface
 
-- Headless `SyncClient`: persistent local SQLite, local SQL reads, scoped or
-  wildcard access from `resolveScopes`, durable outbox, subscriptions, and
+- Server-side `SyncClient`: persistent local SQLite, local SQL reads, scoped
+  or wildcard access from `resolveScopes`, durable outbox, subscriptions, and
   realtime convergence.
 - [`SyncRemoteClient`](/guide-remote-operations/): no SQLite. It submits
   ordinary commits and calls registered remote queries or commands.
@@ -190,9 +217,6 @@ process.once('SIGTERM', () => void shutdown());
   the server trust boundary.
 - `SyncularServerEvents`: operational telemetry. It is not a durable work
   queue or an application subscription.
-- Durable server reactions: durable post-commit work scheduling. They are
-  separate from a headless replica and from live query watches.
-
-Search terms: server client, headless client, Node client, Bun client,
-background worker, CLI sync.
-
+- [Durable server reactions](/server-reactions/): durable post-commit work
+  scheduling. They are separate from a server-side replica and from live
+  query watches.

--- a/apps/docs/src/content/guide-server.md
+++ b/apps/docs/src/content/guide-server.md
@@ -1,5 +1,11 @@
 # Server setup
 
+Looking for a server client or background worker? Use the normal
+[`SyncClient` headlessly](/guide-headless-clients/) when the process needs a
+local SQLite read model. Use [`SyncRemoteClient`](/guide-remote-operations/)
+when it needs database-less commits, predefined authoritative queries, or
+commands.
+
 The server is a framework-free protocol library:
 `handleSyncRequest(bytes, ctx) → bytes` over host-provided storage,
 scope-resolution, and segment/blob-store interfaces. A thin Hono adapter

--- a/apps/docs/src/content/guide-server.md
+++ b/apps/docs/src/content/guide-server.md
@@ -1,7 +1,7 @@
 # Server setup
 
 Looking for a server client or background worker? Use the normal
-[`SyncClient` headlessly](/guide-headless-clients/) when the process needs a
+[`SyncClient` on the server](/guide-server-clients/) when the process needs a
 local SQLite read model. Use [`SyncRemoteClient`](/guide-remote-operations/)
 when it needs database-less commits, predefined authoritative queries, or
 commands.
@@ -83,7 +83,7 @@ Two more surfaces attach outside the adapter:
 - `GET /realtime`: the WebSocket upgrade is runtime-specific and stays with
   your host process (below).
 - `GET /admin`: the optional operator console, mounted separately and
-  never open by default. See [Operations](/server-operations/).
+  never open by default. See [Operations and maintenance](/server-operations/).
 
 An HTTP-only deployment is fully conformant: clients that never open the
 socket sync over `POST /sync` with identical semantics. Realtime is simply
@@ -273,7 +273,8 @@ covers the same ground with virtual time.
   `@syncular/server-workers` covers Cloudflare Workers. See
   [Cloudflare Workers](/server-workers/).
 - **Day two**: structured events, the admin console, commit-log pruning,
-  blob GC, and load testing live in [Operations](/server-operations/).
+  blob GC, and load testing live in
+  [Operations and maintenance](/server-operations/).
 - **Post-commit application work**: configure planners, leased handlers,
   retries, and dead letters in
   [Durable server reactions](/server-reactions/).
@@ -285,7 +286,7 @@ covers the same ground with virtual time.
 - [Cloudflare Workers](/server-workers/): D1 + R2 + Durable Object realtime.
 - [Durable server reactions](/server-reactions/): email, webhooks,
   projections, and jobs after accepted commits.
-- [Operations](/server-operations/): events, admin console, pruning, GC,
+- [Operations and maintenance](/server-operations/): events, admin console, pruning, GC,
   load tests.
 - [Scopes & authorization](/concepts-scopes/): how `resolveScopes` gates
   every read and write.

--- a/apps/docs/src/content/guide-server.md
+++ b/apps/docs/src/content/guide-server.md
@@ -268,12 +268,17 @@ covers the same ground with virtual time.
   [Cloudflare Workers](/server-workers/).
 - **Day two**: structured events, the admin console, commit-log pruning,
   blob GC, and load testing live in [Operations](/server-operations/).
+- **Post-commit application work**: configure planners, leased handlers,
+  retries, and dead letters in
+  [Durable server reactions](/server-reactions/).
 
 ## Where to go next
 
 - [Storage backends](/server-storage/): SQLite, Postgres, D1, segment and
   blob stores, signed URLs and CDN.
 - [Cloudflare Workers](/server-workers/): D1 + R2 + Durable Object realtime.
+- [Durable server reactions](/server-reactions/): email, webhooks,
+  projections, and jobs after accepted commits.
 - [Operations](/server-operations/): events, admin console, pruning, GC,
   load tests.
 - [Scopes & authorization](/concepts-scopes/): how `resolveScopes` gates

--- a/apps/docs/src/content/platform-web.md
+++ b/apps/docs/src/content/platform-web.md
@@ -260,8 +260,8 @@ optional peer dependency, so browser-only apps skip the native build entirely;
 (`npm install better-sqlite3`). The [quickstart](/quickstart/) runs this exact
 shape in a terminal.
 
-See [Headless Node and Bun clients](/guide-headless-clients/) for the complete
-service lifecycle. A process that needs no local SQLite database can use
+See [Server-side sync clients](/guide-server-clients/) for the complete service
+lifecycle. A process that needs no local SQLite database can use
 [`SyncRemoteClient`](/guide-remote-operations/) instead.
 
 ## Browser support

--- a/apps/docs/src/content/platform-web.md
+++ b/apps/docs/src/content/platform-web.md
@@ -260,6 +260,10 @@ optional peer dependency, so browser-only apps skip the native build entirely;
 (`npm install better-sqlite3`). The [quickstart](/quickstart/) runs this exact
 shape in a terminal.
 
+See [Headless Node and Bun clients](/guide-headless-clients/) for the complete
+service lifecycle. A process that needs no local SQLite database can use
+[`SyncRemoteClient`](/guide-remote-operations/) instead.
+
 ## Browser support
 
 There is a single support floor and a single persistence path:

--- a/apps/docs/src/content/reference.md
+++ b/apps/docs/src/content/reference.md
@@ -18,6 +18,12 @@ when exact normative behavior matters.
 
 ## Task guides
 
+- [Server-side sync clients](/guide-server-clients/): run a persistent SQLite
+  replica in a Node or Bun service, CLI, or background worker.
+- [Remote server operations](/guide-remote-operations/): submit database-less
+  commits and call typed queries, commands, and live watches.
+- [Domain actions and event rows](/guide-domain-events/): store application
+  intent atomically with related domain writes.
 - [Durable server reactions](/server-reactions/): atomically plan application
   work from accepted commits, then deliver it with leases, retries, stable
   idempotency keys, and dead letters.
@@ -119,5 +125,5 @@ Each operational contract lives next to the code that enforces it:
 
 - [Quickstart](/quickstart/): the whole shape end to end in five minutes.
 - [Protocol & conformance](/guide-conformance/): how the spec is enforced across cores.
-- [Headless Node and Bun clients](/guide-headless-clients/): persistent server-side replicas.
+- [Server-side sync clients](/guide-server-clients/): persistent SQLite replicas in Node and Bun processes.
 - [Remote server operations](/guide-remote-operations/): database-less commits, typed authoritative queries, commands, and watches.

--- a/apps/docs/src/content/reference.md
+++ b/apps/docs/src/content/reference.md
@@ -15,6 +15,12 @@ Start with the dedicated [SYQL language guide](/syql/) for examples and the
 authoring model. Use the language specification when implementing tooling or
 when exact normative behavior matters.
 
+## Task guides
+
+- [Durable server reactions](/server-reactions/): atomically plan application
+  work from accepted commits, then deliver it with leases, retries, stable
+  idempotency keys, and dead letters.
+
 ## Protocol specification by section
 
 | Section | Topic |
@@ -42,7 +48,7 @@ All published under the `@syncular/*` scope (plus the unscoped scaffolder):
 | Package | What it is | Source |
 |---|---|---|
 | `@syncular/core` | Protocol codecs, shared types, the golden-vector round-trip | [packages/core](https://github.com/syncular/syncular/tree/main/packages/core) |
-| `@syncular/server` | `handleSyncRequest` + storage/auth/segment/blob interfaces, realtime hub, pruning, signed URLs, `SyncularAdmin` | [packages/server](https://github.com/syncular/syncular/tree/main/packages/server) |
+| `@syncular/server` | `handleSyncRequest` + storage/auth/segment/blob interfaces, durable reaction planning and delivery, realtime hub, pruning, signed URLs, `SyncularAdmin` | [packages/server](https://github.com/syncular/syncular/tree/main/packages/server) |
 | `@syncular/server-hono` | Thin Hono adapter mounting the §1.1 routes + the static admin page | [packages/server-hono](https://github.com/syncular/syncular/tree/main/packages/server-hono) |
 | `@syncular/server-workers` | Cloudflare Workers entry: fetch handler over D1 storage + R2 segments/blobs | [packages/server-workers](https://github.com/syncular/syncular/tree/main/packages/server-workers) |
 | `@syncular/client` | The TS client core on sqlite-wasm/OPFS, worker + transports, multi-tab | [packages/web-client](https://github.com/syncular/syncular/tree/main/packages/web-client) |

--- a/apps/docs/src/content/reference.md
+++ b/apps/docs/src/content/reference.md
@@ -10,6 +10,7 @@ and binding to where it lives.
 |---|---|
 | [Syncular protocol specification](https://github.com/syncular/syncular/blob/main/docs/SPEC.md) | Transport, data model, scopes, synchronization, storage-independent behavior, errors, and conformance |
 | [SYQL language specification](https://github.com/syncular/syncular/blob/main/docs/SYQL.md) | `.syql` lexical grammar, syntax, types, static semantics, SQLite profile, lowering, generated API contract, tooling, and conformance |
+| [Remote operation specification](https://github.com/syncular/syncular/blob/main/docs/REMOTE.md) | Registered authoritative queries, commands, operation value encoding, and live query watches |
 
 Start with the dedicated [SYQL language guide](/syql/) for examples and the
 authoring model. Use the language specification when implementing tooling or
@@ -48,10 +49,10 @@ All published under the `@syncular/*` scope (plus the unscoped scaffolder):
 | Package | What it is | Source |
 |---|---|---|
 | `@syncular/core` | Protocol codecs, shared types, the golden-vector round-trip | [packages/core](https://github.com/syncular/syncular/tree/main/packages/core) |
-| `@syncular/server` | `handleSyncRequest` + storage/auth/segment/blob interfaces, durable reaction planning and delivery, realtime hub, pruning, signed URLs, `SyncularAdmin` | [packages/server](https://github.com/syncular/syncular/tree/main/packages/server) |
+| `@syncular/server` | `handleSyncRequest`, registered queries and commands, durable reaction planning and delivery, storage/auth/segment/blob interfaces, realtime hubs, pruning, signed URLs, `SyncularAdmin` | [packages/server](https://github.com/syncular/syncular/tree/main/packages/server) |
 | `@syncular/server-hono` | Thin Hono adapter mounting the §1.1 routes + the static admin page | [packages/server-hono](https://github.com/syncular/syncular/tree/main/packages/server-hono) |
 | `@syncular/server-workers` | Cloudflare Workers entry: fetch handler over D1 storage + R2 segments/blobs | [packages/server-workers](https://github.com/syncular/syncular/tree/main/packages/server-workers) |
-| `@syncular/client` | The TS client core on sqlite-wasm/OPFS, worker + transports, multi-tab | [packages/web-client](https://github.com/syncular/syncular/tree/main/packages/web-client) |
+| `@syncular/client` | The TS replica client plus database-less `SyncRemoteClient`, native/browser database adapters, worker transports, and multi-tab support | [packages/web-client](https://github.com/syncular/syncular/tree/main/packages/web-client) |
 | `@syncular/react` | React bindings: `SyncProvider` + hooks over fine-grained invalidation | [packages/react](https://github.com/syncular/syncular/tree/main/packages/react) |
 | `@syncular/crypto` | Client-side E2EE primitives (symmetric + asymmetric); see [Encryption](/concepts-encryption/) | [packages/crypto](https://github.com/syncular/syncular/tree/main/packages/crypto) |
 | `@syncular/crdt-yjs` | The Yjs `crdt`-column merger (server) + `YjsColumn` client helper; see [CRDT columns](/concepts-crdt/) | [packages/crdt-yjs](https://github.com/syncular/syncular/tree/main/packages/crdt-yjs) |
@@ -118,3 +119,5 @@ Each operational contract lives next to the code that enforces it:
 
 - [Quickstart](/quickstart/): the whole shape end to end in five minutes.
 - [Protocol & conformance](/guide-conformance/): how the spec is enforced across cores.
+- [Headless Node and Bun clients](/guide-headless-clients/): persistent server-side replicas.
+- [Remote server operations](/guide-remote-operations/): database-less commits, typed authoritative queries, commands, and watches.

--- a/apps/docs/src/content/server-operations.md
+++ b/apps/docs/src/content/server-operations.md
@@ -4,6 +4,11 @@ Day-two concerns for a running sync server: the structured-events hook,
 the admin console, commit-log pruning, reaction retention, blob GC, and the
 load-test suite. Everything here is host-scheduled and opt-in.
 
+Application-level domain actions use immutable
+[domain event rows](/guide-domain-events/). Registered application queries and
+commands use [remote server operations](/guide-remote-operations/).
+`SyncularServerEvents` below remains operational telemetry.
+
 ## Structured events
 
 One optional interface, `SyncularServerEvents`, carries every
@@ -214,3 +219,7 @@ event stream, that segment *reuse* beats *build* under a storm. Full docs in
   the policies pruning and GC interact with.
 - [Cloudflare Workers](/server-workers/): running the sweep from a cron
   trigger.
+- [Domain actions and event rows](/guide-domain-events/): durable application
+  intent stored with domain writes.
+- [Remote server operations](/guide-remote-operations/): database-less typed
+  queries, commands, and live watches.

--- a/apps/docs/src/content/server-operations.md
+++ b/apps/docs/src/content/server-operations.md
@@ -1,4 +1,4 @@
-# Operations
+# Operations and maintenance
 
 Day-two concerns for a running sync server: the structured-events hook,
 the admin console, commit-log pruning, reaction retention, blob GC, and the

--- a/apps/docs/src/content/server-operations.md
+++ b/apps/docs/src/content/server-operations.md
@@ -1,8 +1,8 @@
 # Operations
 
 Day-two concerns for a running sync server: the structured-events hook,
-the admin console, commit-log pruning, blob GC, and the load-test suite.
-Everything here is host-scheduled and opt-in.
+the admin console, commit-log pruning, reaction retention, blob GC, and the
+load-test suite. Everything here is host-scheduled and opt-in.
 
 ## Structured events
 
@@ -36,16 +36,20 @@ extra wiring; the realtime hub and `pruneCommitLog` take the same sink via
 their own options. There is no logger dependency: a Sentry or metrics
 adapter is a ~20-line `emit` implementation. The full event catalog
 (`request.handled`, `push.applied` / `push.rejected` / `push.conflicted`,
-`pull.served`, `segment.downloaded`, `blob.swept`, `realtime.*`,
+`pull.served`, `segment.downloaded`, `blob.swept`, `reaction.*`, `realtime.*`,
 `prune.completed`, `scopes.resolve_failed`) is in the
 [server README](https://github.com/syncular/syncular/blob/main/packages/server/README.md).
+Reaction lifecycle meanings and the durable state machine are covered in
+[Durable server reactions](/server-reactions/#observe-and-inspect-reactions).
 
 ## The admin console
 
 `SyncularAdmin` is a read-only, partition-scoped query surface over server
 storage plus the event ring: clients and their cursors, commit metadata
 (never payloads), per-row version and scopes, scope activity, horizon
-status, segment/blob stats, and the event tail.
+status, durable reactions, segment/blob stats, and the event tail. Reaction
+reads include their persisted payload and failure details, so admin access is
+application-data access.
 
 ```ts
 import { SyncularAdmin } from '@syncular/server';
@@ -76,6 +80,10 @@ per-partition horizon and deletes commits at or below it. Nothing prunes
 automatically; you schedule it (hourly to daily is the sensible range, and
 a pass with nothing to do is cheap).
 
+Reaction rows use a separate table. Commit-log pruning does not delete pending,
+leased, completed, or dead-lettered reactions. Use the separate reaction
+retention pass below.
+
 ```ts
 import { pruneCommitLog } from '@syncular/server';
 
@@ -99,6 +107,38 @@ your pruning health signal: a steady trickle is devices returning from
 long absences; a spike means you pruned faster than your fleet syncs and
 are paying for it in bootstrap load. Observe it via
 `pull.served` subscriptions with `status: "reset"`.
+
+## Reaction retention
+
+The host schedules `pruneReactions` per partition, alongside commit-log
+pruning. Defaults retain completed records for 30 days, dead-lettered records
+for 90 days, and remove at most 1,000 records in one pass.
+
+```ts
+import { pruneReactions } from '@syncular/server';
+
+let result;
+do {
+  result = await pruneReactions({
+    storage,
+    partition: 'main',
+    nowMs: Date.now(),
+    events,
+  });
+} while (result.mayHaveMore);
+```
+
+Only terminal records older than their cutoff are eligible. Pending and leased
+records are preserved, including expired leases that a worker can reclaim.
+Dead-letter retention determines how long operators can inspect and manually
+retry a failed record. Configure a longer duration when failure investigation
+or retry procedures require it.
+
+Each bounded pass emits `reaction.prune_completed`. A full batch reports
+`mayHaveMore: true`; repeat until false. Timestamp indexes support both age
+filters, and the delete limit keeps a maintenance pass from monopolizing the
+storage writer. The full lifecycle and retention API are in
+[Durable server reactions](/server-reactions/).
 
 ## Blob GC (`sweepOrphanBlobs`)
 
@@ -159,6 +199,9 @@ event stream, that segment *reuse* beats *build* under a storm. Full docs in
 - `prune.completed` with `advanced: false` for many consecutive passes
   while the log grows: one laggard cursor inside the active window is
   pinning retention; the floors bound the damage to `ageForceMs`.
+- `reaction.prune_completed` with `mayHaveMore: true` after every scheduled
+  batch: terminal rows are accumulating faster than the cleanup schedule
+  removes them. Raise the batch count or run passes more often.
 - `realtime.wake` with `reason: "delta-too-large"`: sustained occurrences
   mean commits routinely exceed the delta limit and clients fall back to
   HTTP pulls; raise the limit or shrink commits.

--- a/apps/docs/src/content/server-reactions.md
+++ b/apps/docs/src/content/server-reactions.md
@@ -1,0 +1,366 @@
+# Durable server reactions
+
+Durable server reactions run application work after Syncular accepts a client
+commit. Use them for email, webhooks, projection updates, and jobs that must not
+disappear when a server process stops after committing the source data.
+
+A reaction has two application callbacks with different constraints:
+
+1. `reactionPlanner` examines an accepted candidate commit inside the
+   authoritative transaction and returns bounded JSON records.
+2. `ReactionRunner` claims committed records and invokes handlers outside the
+   transaction.
+
+Delivery is at least once. A process can stop after a handler calls an external
+system and before Syncular records completion. The next worker receives the
+same reaction and the same `idempotencyKey`. Pass that key to every external
+system that supports idempotent requests.
+
+Normative behavior is defined in
+[SPEC §6.9](https://github.com/syncular/syncular/blob/main/docs/SPEC.md#69-durable-server-reactions).
+
+## Define typed reaction records
+
+Map each reaction type to its persisted payload. The type name is the handler
+registration key. `version` belongs to the record so handlers can migrate
+independently of old queued work.
+
+```ts
+import type { ReactionPlanner } from '@syncular/server';
+
+type AppReactions = {
+  'invoice.email': {
+    readonly invoiceId: string;
+    readonly customerId: string;
+  };
+};
+
+const reactionPlanner: ReactionPlanner<AppReactions> = ({ operations }) =>
+  operations.flatMap((operation) => {
+    if (
+      operation.table !== 'invoice_events' ||
+      operation.op !== 'upsert' ||
+      operation.row?.kind !== 'invoice_finalized'
+    ) {
+      return [];
+    }
+
+    const invoiceId = operation.row.invoice_id;
+    const customerId = operation.row.customer_id;
+    if (typeof invoiceId !== 'string' || typeof customerId !== 'string') {
+      throw new Error('invalid invoice_finalized event');
+    }
+
+    return [
+      {
+        key: `finalized-email:${invoiceId}`,
+        type: 'invoice.email',
+        version: 1,
+        payload: { invoiceId, customerId },
+        maxAttempts: 8,
+      },
+    ];
+  });
+```
+
+Each planner `key` must be unique within the source commit. Syncular derives
+the persisted handler key from
+`[partition, clientId, clientCommitId, plannerKey]`, so retries and partitions
+cannot collide.
+
+The planner may use its candidate-state `read` API when the operations do not
+contain enough information. Reads observe all staged sibling operations. Keep
+the planner short and deterministic because the authoritative transaction and
+partition serialization remain open until it returns.
+
+The planner must not send messages, call a provider, publish to a queue, or
+perform another external effect. TypeScript cannot enforce callback purity. A
+planner exception rolls the transaction back and surfaces as a server failure,
+so a later client retry may run the planner again.
+
+## Add the planner to the server
+
+Pass the planner with the rest of the canonical server configuration:
+
+```ts
+import type { SyncServerConfig } from '@syncular/server';
+
+const config: SyncServerConfig = {
+  schema,
+  storage,
+  segments,
+  resolveScopes,
+  reactionPlanner,
+};
+```
+
+For a new accepted commit, Syncular persists the app rows, commit metadata,
+reaction records, and applied idempotency result in one transaction. A
+conflict, authorization failure, validator rejection, or whole-commit
+rejection plans and enqueues nothing. Replaying an already applied client
+commit returns the cached result without running the planner again.
+
+An invalid planned record fails the source transaction. Current bounds are:
+
+| Field | Limit |
+|---|---|
+| Reactions per commit | 100 |
+| `key` | 256 UTF-8 bytes |
+| `type` | 128 UTF-8 bytes, code-like characters |
+| `version` | Positive signed 32-bit integer |
+| `payload` | Plain JSON, 64 KiB, maximum depth 16 |
+| `maxAttempts` | 1 through 100, default 10 |
+
+Payloads cannot contain class instances, functions, accessors, symbols,
+`undefined`, cyclic values, or non-finite numbers.
+
+## Run handlers after commit
+
+`ReactionRunner` performs one bounded delivery pass. Call `runOnce()` from a
+host scheduler, queue wake, process loop, cron event, or Durable Object alarm.
+The runner does not start a timer or background task itself.
+
+```ts
+import {
+  PermanentReactionError,
+  ReactionRunner,
+} from '@syncular/server';
+
+const runner = new ReactionRunner<AppReactions>({
+  storage,
+  partition: 'tenant-42',
+  workerId: 'invoice-email-worker-1',
+  batchSize: 10,
+  leaseDurationMs: 30_000,
+  handlers: {
+    'invoice.email': async ({
+      version,
+      payload,
+      idempotencyKey,
+      extendLease,
+    }) => {
+      if (version !== 1) {
+        throw new PermanentReactionError('invoice.email_version_unsupported', {
+          version,
+        });
+      }
+
+      await extendLease();
+      await emailProvider.sendInvoice({
+        invoiceId: payload.invoiceId,
+        customerId: payload.customerId,
+        idempotencyKey,
+      });
+    },
+  },
+});
+
+const result = await runner.runOnce();
+console.log(result);
+// { claimed, completed, retried, deadLettered, lostLeases }
+```
+
+The runner claims only types present in `handlers`. Each `runOnce()` call uses
+a fresh lease token. Before starting each handler in the claimed batch, it
+renews that row and skips it if another worker reclaimed the expired lease.
+Completion, failure, and explicit lease extension also compare the token.
+
+Call `extendLease()` before the current lease expires when a handler has a long
+phase. Repeat it as the work progresses when one extension is insufficient. A
+handler that runs past its lease can overlap with a later delivery.
+
+Use a separate runner per partition. This keeps tenant isolation and the
+per-partition commit model intact. Several runners may process one partition;
+their atomic claims normally return disjoint records.
+
+## Classify failures
+
+An ordinary exception and `RetryableReactionError` schedule another attempt.
+The delay is bounded exponential backoff, starting at one second and capped at
+five minutes by default.
+
+```ts
+import {
+  PermanentReactionError,
+  RetryableReactionError,
+} from '@syncular/server';
+
+if (response.status === 429 || response.status >= 500) {
+  throw new RetryableReactionError('invoice.email_provider_unavailable', {
+    status: response.status,
+  });
+}
+
+if (response.status === 400) {
+  throw new PermanentReactionError('invoice.email_invalid_request', {
+    status: response.status,
+  });
+}
+```
+
+A permanent error enters `dead-letter` immediately. A retryable error enters
+`dead-letter` after `maxAttempts`. Persisted failure information contains a
+stable code, failure time, and optional plain JSON details limited to 8 KiB.
+Syncular does not persist the raw exception message.
+
+Manual retry is an explicit operator action:
+
+```ts
+import { retryDeadLetterReaction } from '@syncular/server';
+
+const reset = await retryDeadLetterReaction({
+  storage,
+  partition: 'tenant-42',
+  idempotencyKey,
+});
+```
+
+The reset clears attempts and failure information and makes the reaction due.
+There is no unauthenticated or automatic retry endpoint.
+
+## Understand the crash window
+
+The external effect and Syncular's completion update usually live in different
+systems. They cannot share one transaction:
+
+1. A worker claims a reaction.
+2. The handler calls the external provider successfully.
+3. The process stops before `completeReaction` commits.
+4. The lease expires and another worker calls the handler again.
+
+Both calls receive the same `idempotencyKey`. The provider or application
+receipt table must collapse the repeated request when one real-world effect is
+required. Syncular does not claim exactly-once external execution.
+
+## Observe and inspect reactions
+
+Configure `SyncularServerEvents` to receive these lifecycle events:
+
+| Event | Meaning |
+|---|---|
+| `reaction.queued` | The source transaction committed the reaction |
+| `reaction.started` | A worker confirmed its lease and began an attempt |
+| `reaction.retried` | A retryable failure recorded its next due time |
+| `reaction.completed` | The current lease owner acknowledged success |
+| `reaction.dead_lettered` | A permanent or exhausted failure stopped delivery |
+| `reaction.prune_completed` | One bounded terminal-retention pass finished |
+
+Events remain a fire-and-forget observability surface. Reaction storage is the
+durable source of lifecycle state.
+
+`SyncularAdmin` provides partition-scoped reads:
+
+```ts
+const failed = await admin.listReactions('tenant-42', {
+  statuses: ['dead-letter'],
+  types: ['invoice.email'],
+  limit: 50,
+});
+```
+
+The authenticated Hono admin routes expose the same data at
+`GET /admin/reactions?status=dead-letter&type=invoice.email&limit=50` when the
+admin app is mounted at `/admin`. The response includes persisted payloads and
+failure details. Treat access as application-data access and keep limits small
+when payloads are large.
+
+## Storage and migrations
+
+SQLite and PostgreSQL create `sync_reactions` and its indexes through their
+normal storage migration path. D1 construction does not apply DDL during a
+request. Regenerate the shared SQLite/D1 migration from
+`sqliteDdlStatements()` and apply it before enabling a planner.
+
+D1 source pushes still require the per-partition Durable Object coordinator.
+Reaction records join the same atomic `D1Database.batch()` as the source
+commit. Delivery claims use one `UPDATE ... RETURNING` statement and fail if
+the runtime cannot execute that statement atomically. See
+[Cloudflare Workers](/server-workers/) for the coordinator and migration
+wiring.
+
+Commit-log pruning never deletes reactions in any lifecycle state. Schedule
+`pruneReactions` separately for every partition:
+
+```ts
+import { pruneReactions } from '@syncular/server';
+
+let result;
+do {
+  result = await pruneReactions({
+    storage,
+    partition: 'tenant-42',
+    nowMs: Date.now(),
+    events,
+    retention: {
+      completedRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      deadLetterRetentionMs: 90 * 24 * 60 * 60 * 1000,
+      batchSize: 1000,
+    },
+  });
+} while (result.mayHaveMore);
+```
+
+Those values are the defaults. A pass removes at most `batchSize` terminal
+rows. It deletes a `completed` row only when `completedAtMs` is strictly older
+than the completed cutoff. It deletes a `dead-letter` row only when its failure
+time is strictly older than the dead-letter cutoff. Pending and leased rows,
+including expired leases, are never eligible.
+
+The longer dead-letter window preserves failure diagnostics and the manual
+retry opportunity. Lower it only when another system retains the information
+operators need. Cleanup and manual retry are atomic storage operations, so a
+race either resets the row or removes it. `reaction.prune_completed` reports
+the cutoffs, limit, removal counts, and `mayHaveMore` value for each pass.
+
+## Performance boundaries
+
+Reaction durability adds work to the source commit. Each record is normalized,
+serialized, inserted, and indexed before acknowledgement. Keep payloads small
+and avoid using the 100-record limit as a normal batch size.
+
+PostgreSQL currently inserts planned reactions one statement at a time. D1
+adds one statement per reaction to the transaction batch; include those
+statements when checking the
+[current D1 limits](https://developers.cloudflare.com/d1/platform/limits/).
+SQLite lifecycle writes share its serialized connection with pushes. Large
+backlogs or slow planners can therefore increase push and worker latency.
+
+A successful delivery uses the batch claim plus an ownership-confirmation
+write and a completion write for each record. Long handlers add lease-extension
+writes. Choose `batchSize` and polling frequency from handler duration and
+database capacity.
+
+Terminal cleanup uses timestamp indexes and bounded deletes. Run passes until
+`mayHaveMore` is false, then wait for the next scheduled interval. A result can
+conservatively report `mayHaveMore: true` when the final full batch emptied the
+backlog, which causes one harmless empty pass.
+
+## Testing checklist
+
+Use a virtual clock and deterministic promises around handlers. Tests should
+cover:
+
+- source commit and reaction enqueue commit or roll back together;
+- rejected and conflicted commits enqueue nothing;
+- replay of the same client commit does not plan twice;
+- retry due times and attempt exhaustion;
+- permanent failure and operator reset;
+- lease expiry after a worker stops;
+- repeated delivery after the handler succeeds and acknowledgement fails;
+- concurrent workers and stale claimed-batch members;
+- commit-log pruning with pending work;
+- terminal cleanup bounds, strict cutoffs, and active-row preservation;
+- the same storage contract on SQLite, PostgreSQL, and D1.
+
+The repository examples are in
+[`packages/server/test/reactions.test.ts`](https://github.com/syncular/syncular/blob/main/packages/server/test/reactions.test.ts)
+and
+[`packages/server/test/storage-contract.ts`](https://github.com/syncular/syncular/blob/main/packages/server/test/storage-contract.ts).
+
+## Choosing the server mechanism
+
+Use a durable reaction when work derives from an accepted Syncular commit and
+must execute under server ownership. Use an immutable application row when
+history must sync to clients or support relational queries. Use a normal
+`SyncClient` when the worker needs a local replica, subscriptions, or its own
+outbox.

--- a/apps/docs/src/content/server-storage.md
+++ b/apps/docs/src/content/server-storage.md
@@ -311,7 +311,7 @@ rule. Do **not** put an S3/R2 lifecycle-expiration rule on the `blob/`
 prefix; it would delete still-referenced attachments out from under live
 rows. Reclamation is reference-driven: the only thing that deletes a blob
 is the scheduled `sweepOrphanBlobs` pass, which deletes only blobs no live
-row references. See [Operations](/server-operations/).
+row references. See [Operations and maintenance](/server-operations/).
 
 Two independent presign switches take the server out of the blob byte
 path: `blobSignedUrls: s3PresignedBlobUrls(blobs)` issues presigned
@@ -326,7 +326,7 @@ upload grants. Absent config means clients stream through the direct
   server.
 - [Cloudflare Workers](/server-workers/): D1, R2, and Durable Object
   realtime end to end.
-- [Operations](/server-operations/): pruning the commit log and sweeping
+- [Operations and maintenance](/server-operations/): pruning the commit log and sweeping
   orphan blobs.
 - [Bootstrap & segments](/concepts-bootstrap/): why segments are cache
   entries and how reuse absorbs storms.

--- a/apps/docs/src/content/server-workers.md
+++ b/apps/docs/src/content/server-workers.md
@@ -94,6 +94,13 @@ wrangler d1 create syncular
 wrangler d1 migrations apply syncular
 ```
 
+The generated migration must include `sync_reactions` before configuring a
+`reactionPlanner`. Planned records join the source commit's atomic batch.
+`ReactionRunner` claims work with one atomic write statement and can be driven
+from a scheduled Worker event or Durable Object alarm. D1 statement and
+invocation limits apply to the source batch and delivery passes; see
+[Durable server reactions](/server-reactions/#storage-and-migrations).
+
 **Per-partition write serialization.** Every push must serialize before row
 reads/validation/CRDT merge and re-check idempotency under that boundary. The
 Workers adapter forwards `/sync` to one DO per partition and the DO uses an
@@ -208,14 +215,19 @@ Secrets (`wrangler secret put`): `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
 HTTP-only deployment, keep the DO binding/migration and use `coordinator`
 instead of `realtime`; only the WebSocket route is omitted.
 
-## Blob GC on a schedule
+## Maintenance on a schedule
 
-Nothing reclaims blobs automatically. The host schedules the sweep. On
-Workers the natural place is a cron trigger: add `[triggers] crons = [...]`
-and run `sweepOrphanBlobs` per partition from the `scheduled` handler.
+The host schedules reaction retention, commit-log pruning, and blob cleanup.
+On Workers the natural place is a cron trigger: add
+`[triggers] crons = [...]` and run the maintenance helpers per partition from
+the `scheduled` handler.
 
 ```ts
-import { sweepOrphanBlobs, D1ServerStorage } from '@syncular/server';
+import {
+  D1ServerStorage,
+  pruneReactions,
+  sweepOrphanBlobs,
+} from '@syncular/server';
 
 export default {
   fetch: /* … as above … */,
@@ -223,13 +235,24 @@ export default {
     const storage = new D1ServerStorage(env.DB);
     const blobs = makeBlobs(env); // the same S3BlobStore config
     for (const partition of await listPartitions(env)) {
+      let result;
+      do {
+        result = await pruneReactions({
+          storage,
+          partition,
+          nowMs: Date.now(),
+        });
+      } while (result.mayHaveMore);
+
       await sweepOrphanBlobs(storage, blobs, partition);
     }
   },
 };
 ```
 
-The sweep is safe only with a correctly sized grace period; the full
+Reaction cleanup retains completed records for 30 days and dead-lettered
+records for 90 days by default. It never deletes pending or leased records.
+Blob cleanup is safe only with a correctly sized grace period. The full
 runbook is in [Operations](/server-operations/).
 
 ## Where to go next

--- a/apps/docs/src/content/server-workers.md
+++ b/apps/docs/src/content/server-workers.md
@@ -253,11 +253,11 @@ export default {
 Reaction cleanup retains completed records for 30 days and dead-lettered
 records for 90 days by default. It never deletes pending or leased records.
 Blob cleanup is safe only with a correctly sized grace period. The full
-runbook is in [Operations](/server-operations/).
+runbook is in [Operations and maintenance](/server-operations/).
 
 ## Where to go next
 
-- [Operations](/server-operations/): events, pruning, blob GC, and what to
+- [Operations and maintenance](/server-operations/): events, pruning, blob GC, and what to
   alert on.
 - [Storage backends](/server-storage/): how D1 compares to SQLite and
   Postgres, and the R2 store details.

--- a/apps/docs/src/content/tooling-queries.md
+++ b/apps/docs/src/content/tooling-queries.md
@@ -10,6 +10,11 @@ Read the dedicated [SYQL guide](/syql/) or the
 [formal language specification](https://github.com/syncular/syncular/blob/main/docs/SYQL.md)
 for the complete language.
 
+The same generated descriptor can be registered as a scoped or privileged
+[authoritative remote query](/guide-remote-operations/#registered-typed-queries).
+Remote callers send its generated ID and typed parameters; SQL remains in the
+server registry.
+
 ## Plain `.sql`
 
 ```sql

--- a/apps/docs/src/content/tooling-testing.md
+++ b/apps/docs/src/content/tooling-testing.md
@@ -189,6 +189,9 @@ the other hooks.
   `@syncular/conformance` instead. See [Conformance](/guide-conformance/).
 - The clock advances only when your test moves it; setTimeout runs on its
   own. See the clock note above.
+- Durable reaction planners and runners use server integration and storage
+  contract tests with the same virtual-clock discipline. See the
+  [reaction testing checklist](/server-reactions/#testing-checklist).
 
 ## Where to go next
 

--- a/apps/docs/src/content/what-is.md
+++ b/apps/docs/src/content/what-is.md
@@ -36,7 +36,7 @@ with two independent, conformance-locked implementations:
 - A **Rust core** for everything else: rusqlite on the device filesystem,
   shipped through a five-function C FFI.
 
-Both pass the same golden byte-level vectors and the same 96-scenario
+Both pass the same golden byte-level vectors and the same 97-scenario
 conformance catalog, run against both cores in CI. The platform bindings are
 thin marshaling over the shared Rust core, so protocol behavior is identical
 everywhere:
@@ -59,7 +59,7 @@ On the server you get a framework-neutral core with adapters for
 [SQLite, Postgres, or D1](/server-storage/), and segments/blobs on
 S3-compatible stores.
 
-Backend processes can also run a [headless `SyncClient`](/guide-headless-clients/)
+Backend processes can also run a [server-side `SyncClient`](/guide-server-clients/)
 with persistent SQLite. Processes that do not need a replica use
 [`SyncRemoteClient`](/guide-remote-operations/) for ordinary commits,
 registered typed queries, authoritative commands, and live query snapshots.

--- a/apps/docs/src/content/what-is.md
+++ b/apps/docs/src/content/what-is.md
@@ -36,7 +36,7 @@ with two independent, conformance-locked implementations:
 - A **Rust core** for everything else: rusqlite on the device filesystem,
   shipped through a five-function C FFI.
 
-Both pass the same golden byte-level vectors and the same 95-scenario
+Both pass the same golden byte-level vectors and the same 96-scenario
 conformance catalog, run against both cores in CI. The platform bindings are
 thin marshaling over the shared Rust core, so protocol behavior is identical
 everywhere:
@@ -58,6 +58,13 @@ On the server you get a framework-neutral core with adapters for
 [Cloudflare Workers](/server-workers/), storage on
 [SQLite, Postgres, or D1](/server-storage/), and segments/blobs on
 S3-compatible stores.
+
+Backend processes can also run a [headless `SyncClient`](/guide-headless-clients/)
+with persistent SQLite. Processes that do not need a replica use
+[`SyncRemoteClient`](/guide-remote-operations/) for ordinary commits,
+registered typed queries, authoritative commands, and live query snapshots.
+Application intent is represented by [domain event rows](/guide-domain-events/)
+written atomically with the state change.
 
 ## Boundaries
 

--- a/apps/docs/src/nav.ts
+++ b/apps/docs/src/nav.ts
@@ -57,13 +57,13 @@ export const nav: readonly NavSection[] = [
     title: 'Server',
     items: [
       { slug: 'guide-server', title: 'Server setup' },
-      { slug: 'guide-headless-clients', title: 'Headless Node & Bun clients' },
+      { slug: 'guide-server-clients', title: 'Server-side sync clients' },
       { slug: 'guide-remote-operations', title: 'Remote server operations' },
       { slug: 'guide-domain-events', title: 'Domain actions & event rows' },
       { slug: 'server-reactions', title: 'Durable reactions' },
       { slug: 'server-storage', title: 'Storage backends' },
       { slug: 'server-workers', title: 'Cloudflare Workers' },
-      { slug: 'server-operations', title: 'Operations' },
+      { slug: 'server-operations', title: 'Operations and maintenance' },
     ],
   },
   {

--- a/apps/docs/src/nav.ts
+++ b/apps/docs/src/nav.ts
@@ -57,6 +57,7 @@ export const nav: readonly NavSection[] = [
     title: 'Server',
     items: [
       { slug: 'guide-server', title: 'Server setup' },
+      { slug: 'server-reactions', title: 'Durable reactions' },
       { slug: 'server-storage', title: 'Storage backends' },
       { slug: 'server-workers', title: 'Cloudflare Workers' },
       { slug: 'server-operations', title: 'Operations' },

--- a/apps/docs/src/nav.ts
+++ b/apps/docs/src/nav.ts
@@ -57,6 +57,9 @@ export const nav: readonly NavSection[] = [
     title: 'Server',
     items: [
       { slug: 'guide-server', title: 'Server setup' },
+      { slug: 'guide-headless-clients', title: 'Headless Node & Bun clients' },
+      { slug: 'guide-remote-operations', title: 'Remote server operations' },
+      { slug: 'guide-domain-events', title: 'Domain actions & event rows' },
       { slug: 'server-reactions', title: 'Durable reactions' },
       { slug: 'server-storage', title: 'Storage backends' },
       { slug: 'server-workers', title: 'Cloudflare Workers' },

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -27,7 +27,7 @@ const FEATURES = [
 // test/conformance-count.test.ts; the catalog itself is Bun-only
 // (import.meta.dir plus the full client/server stacks), so the landing
 // page cannot import it during the Astro build.
-const CONFORMANCE_SCENARIOS = 96;
+const CONFORMANCE_SCENARIOS = 97;
 
 const PLATFORM_LINKS = [
   { label: 'WEB', href: '/platform-web/' },

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -27,7 +27,7 @@ const FEATURES = [
 // test/conformance-count.test.ts; the catalog itself is Bun-only
 // (import.meta.dir plus the full client/server stacks), so the landing
 // page cannot import it during the Astro build.
-const CONFORMANCE_SCENARIOS = 95;
+const CONFORMANCE_SCENARIOS = 96;
 
 const PLATFORM_LINKS = [
   { label: 'WEB', href: '/platform-web/' },

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -133,8 +133,9 @@ Swift suite: init/create, raw command round-trip, mutate → readRows (the
 optimistic row with `version == -1`), the query fast path, `{error}` surfacing as
 `SyncularException`, the offline outbox (`pendingCommitIds`), a network command
 reporting `transport.unavailable` on the lean core (`sync()` returns
-`{ok:false, errorCode}` by design), the idle event poll, `close()` idempotence,
-and a `pause()`/`resume()` cycle.
+`{ok:false, errorCode}` by design), `close()` idempotence, and a
+`pause()`/`resume()` cycle. The Rust FFI suite covers empty event-queue polling
+directly.
 
 **Detect-and-skip:** the gate needs JDK 21+ and Gradle. On a machine without
 them (e.g. a Command-Line-Tools-only mac, which ships a non-functional

--- a/bindings/kotlin/src/test/kotlin/dev/syncular/SyncularClientTest.kt
+++ b/bindings/kotlin/src/test/kotlin/dev/syncular/SyncularClientTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
  * Coverage mirrors the Swift suite: init/create, command round-trip, mutate →
  * readRows (optimistic row), the query fast path, error surfacing, the offline
  * outbox, a network command reporting transport.unavailable on the lean core,
- * event-poll (none pending), close idempotence, and pause/resume.
+ * close idempotence, and pause/resume.
  */
 class SyncularClientTest {
     private fun todoSchema(): JsonValue = JsonValue.obj(
@@ -127,16 +127,6 @@ class SyncularClientTest {
             val outcome = client.sync()
             assertEquals(false, outcome["ok"]?.bool)
             assertTrue(outcome["errorCode"]?.string?.contains("transport") == true)
-        }
-    }
-
-    @Test
-    fun pollEventDeliversNothingWhenIdle() {
-        makeClient().use { client ->
-            val count = java.util.concurrent.atomic.AtomicInteger(0)
-            client.listener = SyncularEventListener { count.incrementAndGet() }
-            Thread.sleep(300)
-            assertEquals(0, count.get())
         }
     }
 

--- a/bindings/react-native/example/migrations/0001_initial/up.sql
+++ b/bindings/react-native/example/migrations/0001_initial/up.sql
@@ -1,4 +1,4 @@
--- The demo `todos` schema is byte-identical to apps/demo-react's todos, so
+-- The B6 demo `todos` schema — byte-identical to apps/demo-react's todos, so
 -- the RN example is the same todo over the native core.
 -- `attachment` is a §5.9 blob_ref column (tag 7): a nullable reference to an
 -- uploaded file, resolved on demand via the /blobs endpoints.

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -143,8 +143,9 @@ init/create, raw command round-trip, mutate → readRows (the optimistic row wit
 `version == -1`), the query fast path, `{error}` surfacing as `SyncularError`,
 the offline outbox (`pendingCommitIds`), a network command reporting
 `transport.unavailable` on the lean core (by design `sync()` returns
-`{ok:false, errorCode}` rather than erroring out-of-band), the non-blocking
-event poll, `close()` idempotence, and a `pause()`/`resume()` cycle.
+`{ok:false, errorCode}` rather than erroring out-of-band), `close()`
+idempotence, and a `pause()`/`resume()` cycle. The Rust FFI suite covers empty
+event-queue polling directly.
 
 The tests use **Swift Testing** (`import Testing`) — the framework that ships
 with the Swift toolchain, so `swift test` runs on a Command-Line-Tools-only mac

--- a/bindings/swift/Tests/SyncularTests/SyncularClientTests.swift
+++ b/bindings/swift/Tests/SyncularTests/SyncularClientTests.swift
@@ -9,8 +9,8 @@
 // `mutate` is optimistic and immediately visible via `readRows`/`query`. That
 // is the hermetic path used here. We cover:
 //   init/create · command round-trip · mutate → readRows (optimistic row) ·
-//   query fast path · error surfacing · event poll (none pending) · close
-//   idempotence · a network command failing loudly on the lean core.
+//   query fast path · error surfacing · close idempotence · a network command
+//   failing loudly on the lean core.
 
 import Testing
 import Foundation
@@ -106,19 +106,6 @@ private func upsert(id: String, title: String) -> JSONValue {
     }
 }
 
-@Test func pollEventNonBlockingWhenNoneQueued() async throws {
-    let client = try makeClient()
-    defer { client.close() }
-    // Creation emits one privacy-safe diagnostics snapshot. Once startup
-    // evidence has drained, idle polling must not invent repeated events.
-    let box = EventBox()
-    client.onEvent = { _ in box.mark() }
-    try await Task.sleep(nanoseconds: 300_000_000)
-    let startupCount = box.count
-    try await Task.sleep(nanoseconds: 300_000_000)
-    #expect(box.count == startupCount)
-}
-
 @Test func pendingCommitsAfterOfflineMutate() throws {
     let client = try makeClient()
     defer { client.close() }
@@ -160,12 +147,4 @@ private func upsert(id: String, title: String) -> JSONValue {
     // Still functional after a pause/resume cycle.
     try client.subscribe(id: "s1", table: "todo")
     #expect(try client.subscriptionState(id: "s1") == "active")
-}
-
-/// A tiny thread-safe counter for the inverted event-poll assertion.
-private final class EventBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value = 0
-    func mark() { lock.lock(); value += 1; lock.unlock() }
-    var count: Int { lock.lock(); defer { lock.unlock() }; return value }
 }

--- a/bindings/tauri/example/src/frontend/syncular.queries.ts
+++ b/bindings/tauri/example/src/frontend/syncular.queries.ts
@@ -71,6 +71,7 @@ export interface NamedQuery<Row, Params = undefined> {
   readonly sql: string;
   readonly mapRow: (row: Readonly<Record<string, unknown>>) => Row;
   readonly tables: readonly string[];
+  readonly resultColumns: readonly QueryResultColumn[];
   readonly bind: (params: Params) => readonly QueryValue[];
   readonly sqlFor?: (params: Params) => string;
   readonly dependencies: (params: Params) => readonly QueryDependency[];
@@ -83,6 +84,12 @@ export interface NamedQuery<Row, Params = undefined> {
 export interface QueryDependency {
   readonly table: string;
   readonly scopeKeys?: readonly string[];
+}
+
+export interface QueryResultColumn {
+  readonly name: string;
+  readonly type: 'string' | 'integer' | 'float' | 'boolean' | 'json' | 'bytes' | 'blob_ref' | 'crdt';
+  readonly nullable: boolean;
 }
 
 export interface WindowCoverage {
@@ -159,6 +166,7 @@ export const listTodosQuery: NamedQuery<ListTodosRow, ListTodosParams> = {
   mapRow: listTodosMapRow,
   sqlFor: (params: ListTodosParams) => listTodosSelect(params).sql,
   tables: listTodosTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'listId', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }, { name: 'position', type: 'integer', nullable: false }, { name: 'updatedAtMs', type: 'integer', nullable: false }, { name: 'attachment', type: 'blob_ref', nullable: true }],
   dependencies: (params) => [
     { table: 'todos', scopeKeys: ['list:' + String(params.listId) + ''] },
   ],

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@syncular/core": "workspace:*",
         "@syncular/server": "workspace:*",
         "@syncular/server-hono": "workspace:*",
-        "hono": "^4.11.0",
+        "hono": "^4.12.34",
       },
       "devDependencies": {
         "@syncular/typegen": "workspace:*",
@@ -194,7 +194,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@syncular/server": "workspace:*",
-        "hono": "^4.11.0",
+        "hono": "^4.12.34",
       },
       "devDependencies": {
         "@syncular/core": "workspace:*",
@@ -280,10 +280,13 @@
     },
   },
   "overrides": {
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.18",
     "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "svgo": "^4.0.2",
+    "undici": "7.29.0",
   },
   "packages": {
     "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.1", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.1", "@astrojs/compiler-binding-darwin-x64": "0.3.1", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-x64-musl": "0.3.1", "@astrojs/compiler-binding-wasm32-wasi": "0.3.1", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1" } }, "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ=="],
@@ -1014,7 +1017,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1132,7 +1135,7 @@
 
     "hermes-parser": ["hermes-parser@0.36.0", "", { "dependencies": { "hermes-estree": "0.36.0" } }, "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w=="],
 
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
@@ -1182,7 +1185,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsc-safe-url": ["jsc-safe-url@0.2.4", "", {}, "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q=="],
 
@@ -1314,7 +1317,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -1560,7 +1563,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -5,7 +5,7 @@
 
 This protocol serves database-less processes that need authoritative reads or
 server-authoritative commands. Ordinary row commits use the push-only SSP2
-binding in `SPEC.md` §6.9.
+binding in `SPEC.md` §6.10.
 
 An operation-only client does not require a client schema or `/sync`
 transport. Those capabilities are required when it prepares and sends an
@@ -19,7 +19,12 @@ SQL and command code stay in the server process.
 
 Host authentication maps every HTTP request or WebSocket upgrade to an
 `actorId` and partition before the operation runs. Revision 1 is
-partition-local.
+partition-local. If the supplied `clientId` already belongs to another actor
+in that partition, the operation fails with `sync.invalid_client_id`. The
+authenticated actor remains the authority; a host must not treat the
+caller-supplied `clientId` as an authentication credential. Client IDs
+beginning with the internal `["remote-command",` prefix are reserved and fail
+with the same code.
 
 The runtime admin API, `SyncularServerEvents`, durable server reactions, and
 remote application operations are separate surfaces. Remote operations read or
@@ -31,7 +36,8 @@ retained follow-up work after an accepted commit.
 
 A registered query uses a generated `NamedQuery` descriptor. The descriptor
 provides its ID, selected positional SQL, bind values, table dependencies,
-result mapper, and scope coverage.
+result-column metadata, result mapper, and scope coverage. Registration fails
+if result-column metadata is missing, empty, or contains duplicate names.
 
 Before execution, storage replaces every generated application-table relation
 with a derived relation that selects the table's application columns and binds
@@ -40,6 +46,10 @@ interpolated into SQL. A table with `materialize: false` cannot be queried.
 
 Storage executes the query and reads the partition's `maxCommitSeq` in one
 database snapshot. A success response carries both rows and `maxCommitSeq`.
+The server returns only columns named by the generated result metadata and
+normalizes their database values to the declared types. A missing value, a
+null for a non-nullable column, or an invalid value fails with
+`operation.query_failed`.
 
 Every query sets `maxRows` to an integer from 1 through 10,000. Storage executes
 the query with `LIMIT maxRows + 1`. A larger result fails as
@@ -49,9 +59,11 @@ the query with `LIMIT maxRows + 1`. A larger result fails as
 
 Every query uses one registration mode:
 
-- `scoped`: generated coverage must name every table read by the query. The
-  server resolves the actor's allowed scopes and verifies every coverage value
-  before SQL execution. Empty or incomplete coverage fails closed.
+- `scoped`: generated coverage must contain exactly one record for every table
+  read by the query and cover every scope variable declared by that table. The
+  server resolves the actor's allowed scopes and verifies every covered value
+  before SQL execution. Empty, duplicate, extra, or incomplete coverage fails
+  closed. SYQL emits this proof only for a valid `sync query`.
 - `privileged`: registration supplies a query-specific `authorize` callback.
   A false result fails with `operation.forbidden`.
 
@@ -74,9 +86,15 @@ Each invocation carries a non-empty caller-owned `requestId`. The server maps
 the command to the ordinary push idempotency identity:
 
 ```text
-clientId       = "command:" + request.clientId
-clientCommitId = operationId + ":" + requestId
+clientId       = JSON.stringify(["remote-command", actorId, request.clientId])
+clientCommitId = JSON.stringify([operationId, requestId])
 ```
+
+The tuple encoding prevents delimiter collisions between distinct command and
+request IDs and isolates two authenticated actors that happen to supply the
+same client ID. The sync server rejects ordinary SSP2 client IDs beginning
+with the internal `["remote-command",` prefix, so an ordinary commit cannot
+occupy a command result key.
 
 The command callback runs after the partition write lock and the serialized
 idempotency recheck. It may call `getRow(table, rowId)` and returns one or more
@@ -105,12 +123,14 @@ collisions with application object keys.
 | boolean | `{"t":"boolean","v":true}` |
 | finite number | `{"t":"number","v":1.5}` |
 | string | `{"t":"string","v":"x"}` |
-| integer / bigint | `{"t":"integer","v":"42"}` |
+| signed 64-bit integer / bigint | `{"t":"integer","v":"42"}` |
 | bytes | `{"t":"bytes","v":"AAE="}` using standard padded base64 |
 | array | `{"t":"array","v":[...]}` |
 | object | `{"t":"object","v":[["key",...],...]}` |
 
 The complete request or response object is itself encoded as an object value.
+Integer text uses canonical decimal form and the range -2^63 through 2^63-1.
+Base64 must use its canonical padded form.
 
 ## 5. HTTP binding
 
@@ -154,12 +174,16 @@ type Success =
       status: 'applied' | 'cached' | 'rejected';
       commitSeq?: number;
       results: unknown[];
-    };
+};
 ```
 
+`maxCommitSeq` is a non-negative safe integer. A present command `commitSeq`
+is a positive safe integer.
+
 An operation-level failure uses an encoded response with `kind: 'error'`, a
-stable `code`, `message`, and `retryable`. Host authentication and content-type
-failures may use the normal HTTP JSON error response before operation decoding.
+stable `code`, `message`, and `retryable`. Host authentication failures may use
+the normal HTTP JSON error response before operation decoding. A request with
+another content type fails with HTTP 415.
 
 ## 6. Live query watches
 
@@ -188,6 +212,10 @@ one of the descriptor's tables reruns the query. Commits arriving during a run
 set one dirty flag, producing at most one pending rerun at a time. Commits for
 other tables do not rerun it.
 
+`watchId` is unique within one connection. Reusing an active ID fails with
+`operation.invalid_request`. An `unwatch` removes the registration and
+suppresses a query result that was still running for it.
+
 Closing the session removes every watch. Revision 1 has no durable watch cursor
 or reconnect token. The client reconnects and registers a new watch to obtain a
 fresh snapshot.
@@ -198,10 +226,14 @@ fresh snapshot.
 |---|---:|---|
 | `operation.unknown` | no | The ID is absent or has the wrong operation kind |
 | `operation.forbidden` | no | Scope or custom authorization denies access |
-| `operation.invalid_request` | no | The message, coverage, command plan, or parameters are invalid |
+| `operation.invalid_request` | no | The message, generated query coverage, or command mutation plan is invalid |
 | `operation.result_too_large` | no | The query exceeds `maxRows` |
 | `operation.storage_unsupported` | no | Storage lacks authoritative query support |
 | `operation.query_failed` | no | Registered SQL execution fails |
+| `operation.execution_failed` | no | Registered operation code or infrastructure fails unexpectedly |
+
+Identity binding can also produce `sync.invalid_client_id`. Normal command
+commit validation can produce the `sync.*` result codes defined by `SPEC.md`.
 
 Host validator codes follow `SPEC.md` §6.7.
 

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -1,0 +1,215 @@
+# Syncular remote operation protocol
+
+- Status: normative, revision 1
+- HTTP content type: `application/vnd.syncular.operations.v1+json`
+
+This protocol serves database-less processes that need authoritative reads or
+server-authoritative commands. Ordinary row commits use the push-only SSP2
+binding in `SPEC.md` §6.9.
+
+An operation-only client does not require a client schema or `/sync`
+transport. Those capabilities are required when it prepares and sends an
+ordinary row commit.
+
+## 1. Registry and trust boundary
+
+The server exposes a deployment-time registry of query and command operations.
+Each operation has a stable ID. A request carries the ID and encoded values.
+SQL and command code stay in the server process.
+
+Host authentication maps every HTTP request or WebSocket upgrade to an
+`actorId` and partition before the operation runs. Revision 1 is
+partition-local.
+
+The runtime admin API, `SyncularServerEvents`, durable server reactions, and
+remote application operations are separate surfaces. Remote operations read or
+change application rows. The admin API inspects Syncular runtime state.
+Operational events report protocol activity. Durable reactions schedule
+retained follow-up work after an accepted commit.
+
+## 2. Registered queries
+
+A registered query uses a generated `NamedQuery` descriptor. The descriptor
+provides its ID, selected positional SQL, bind values, table dependencies,
+result mapper, and scope coverage.
+
+Before execution, storage replaces every generated application-table relation
+with a derived relation that selects the table's application columns and binds
+`_sync_partition` to the authenticated partition. Request values are never
+interpolated into SQL. A table with `materialize: false` cannot be queried.
+
+Storage executes the query and reads the partition's `maxCommitSeq` in one
+database snapshot. A success response carries both rows and `maxCommitSeq`.
+
+Every query sets `maxRows` to an integer from 1 through 10,000. Storage executes
+the query with `LIMIT maxRows + 1`. A larger result fails as
+`operation.result_too_large`; a partial result is never returned.
+
+### 2.1 Authorization
+
+Every query uses one registration mode:
+
+- `scoped`: generated coverage must name every table read by the query. The
+  server resolves the actor's allowed scopes and verifies every coverage value
+  before SQL execution. Empty or incomplete coverage fails closed.
+- `privileged`: registration supplies a query-specific `authorize` callback.
+  A false result fails with `operation.forbidden`.
+
+The `'*'` allowed-scope value grants every value for that variable. It does not
+turn a scoped query into a privileged registration.
+
+The authored statement is checked by the current typegen SQLite analyzer.
+SQLite and D1 execute that statement directly after partition rewriting.
+Postgres converts bind placeholders and executes the same SQL. Applications
+that register queries on Postgres MUST keep those queries within the common
+SQL subset and test them against Postgres.
+
+## 3. Registered commands
+
+A command has a typed descriptor ID and a mandatory custom `authorize`
+callback. The server also resolves normal write scopes. Command reads return
+only rows authorized by those resolved scopes.
+
+Each invocation carries a non-empty caller-owned `requestId`. The server maps
+the command to the ordinary push idempotency identity:
+
+```text
+clientId       = "command:" + request.clientId
+clientCommitId = operationId + ":" + requestId
+```
+
+The command callback runs after the partition write lock and the serialized
+idempotency recheck. It may call `getRow(table, rowId)` and returns one or more
+full-row upserts or deletes. The returned operations then use the ordinary
+scope authorization, row validators, whole-commit validator, relational
+constraints, commit log, idempotency record, and realtime notifier.
+
+An applied retry returns `cached` without running the callback again. A normal
+push rejection is stored and replays as `rejected`. A callback exception is a
+request failure and is not a stored command outcome. Empty mutation lists fail
+with `operation.invalid_request`.
+
+The callback MUST NOT perform external side effects. It may insert a domain
+event row in its returned commit. External work uses an idempotent worker or a
+durable server reaction after the commit.
+
+## 4. Value encoding
+
+HTTP and WebSocket operation messages use UTF-8 JSON with a recursively tagged
+value encoding. Tagging preserves integers, bytes, arrays, and objects without
+collisions with application object keys.
+
+| Value | Encoded form |
+|---|---|
+| `null` | `{"t":"null"}` |
+| boolean | `{"t":"boolean","v":true}` |
+| finite number | `{"t":"number","v":1.5}` |
+| string | `{"t":"string","v":"x"}` |
+| integer / bigint | `{"t":"integer","v":"42"}` |
+| bytes | `{"t":"bytes","v":"AAE="}` using standard padded base64 |
+| array | `{"t":"array","v":[...]}` |
+| object | `{"t":"object","v":[["key",...],...]}` |
+
+The complete request or response object is itself encoded as an object value.
+
+## 5. HTTP binding
+
+`POST <mount>/operations` accepts one encoded request. Decoded request shapes:
+
+```ts
+type Request =
+  | {
+      revision: 1;
+      kind: 'query';
+      clientId: string;
+      operationId: string;
+      params: unknown;
+    }
+  | {
+      revision: 1;
+      kind: 'command';
+      clientId: string;
+      operationId: string;
+      requestId: string;
+      params: unknown;
+    };
+```
+
+Decoded success shapes:
+
+```ts
+type Success =
+  | {
+      revision: 1;
+      kind: 'query';
+      operationId: string;
+      rows: Record<string, unknown>[];
+      maxCommitSeq: number;
+    }
+  | {
+      revision: 1;
+      kind: 'command';
+      operationId: string;
+      requestId: string;
+      status: 'applied' | 'cached' | 'rejected';
+      commitSeq?: number;
+      results: unknown[];
+    };
+```
+
+An operation-level failure uses an encoded response with `kind: 'error'`, a
+stable `code`, `message`, and `retryable`. Host authentication and content-type
+failures may use the normal HTTP JSON error response before operation decoding.
+
+## 6. Live query watches
+
+`<mount>/operations/realtime` is the conventional WebSocket path. The runtime
+host owns the upgrade and passes authenticated bytes to
+`RemoteOperationWatchHub`.
+
+Decoded client messages are:
+
+```ts
+type ClientMessage =
+  | {
+      revision: 1;
+      kind: 'watch';
+      watchId: string;
+      clientId: string;
+      operationId: string;
+      params: unknown;
+    }
+  | { revision: 1; kind: 'unwatch'; watchId: string };
+```
+
+A watch runs the same query and authorization path as HTTP. It receives a full
+replacement `snapshot` containing `rows` and `maxCommitSeq`. A commit touching
+one of the descriptor's tables reruns the query. Commits arriving during a run
+set one dirty flag, producing at most one pending rerun at a time. Commits for
+other tables do not rerun it.
+
+Closing the session removes every watch. Revision 1 has no durable watch cursor
+or reconnect token. The client reconnects and registers a new watch to obtain a
+fresh snapshot.
+
+## 7. Errors
+
+| Code | Retryable | Produced when |
+|---|---:|---|
+| `operation.unknown` | no | The ID is absent or has the wrong operation kind |
+| `operation.forbidden` | no | Scope or custom authorization denies access |
+| `operation.invalid_request` | no | The message, coverage, command plan, or parameters are invalid |
+| `operation.result_too_large` | no | The query exceeds `maxRows` |
+| `operation.storage_unsupported` | no | Storage lacks authoritative query support |
+| `operation.query_failed` | no | Registered SQL execution fails |
+
+Host validator codes follow `SPEC.md` §6.7.
+
+## 8. Conformance
+
+The catalog scenario `remote-producer/push-only-idempotency` requires both
+pairings to accept a push-only request and return `cached` for an identical
+retry without allocating another commit sequence.
+
+Package tests additionally cover scoped query execution, partition rewriting,
+command retry without a second callback run, and watch replacement snapshots.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2923,6 +2923,133 @@ table/index/value selection to an untrusted caller. Exact server lookups,
 client-visible scope indexes, correlated multi-variable scopes, and explicit
 materialized reverse-index/work-queue rows remain distinct mechanisms.
 
+### 6.9 Durable server reactions
+
+Operational events are a fire-and-forget observability seam. Application work
+that must follow an accepted commit uses a durable server reaction. Reactions
+are a server-host feature and add no SSP2 frame or client-visible authority.
+
+**Planning order.** A host MAY configure one `reactionPlanner`. The server runs
+it only for a new commit after every operation and §6.7/§6.8 validator has
+accepted the final candidate state. It runs before commit-log append,
+idempotency append, and transaction commit:
+
+`optimistic idempotency → partition serialization → locked idempotency →
+decode/auth/row validation/write × N → whole-commit validation → reaction
+planning → append log/reactions/idempotency → commit`
+
+The planner receives the same `clientId`, `clientCommitId`, `actorId`,
+`partition`, ordered operation evidence, and candidate-state reader as §6.8.
+It MUST be pure with respect to storage outside the transaction and every
+external system. It MAY perform candidate reads and return data. It MUST NOT
+send email, invoke a webhook, publish a message, start a job, or perform any
+other user-visible side effect. TypeScript cannot prove callback purity, so
+this is a host correctness requirement. A planner throw aborts the open
+transaction and surfaces as a server failure. It does not persist a rejected
+client outcome; a later delivery may run the planner again.
+
+A conflict, protocol rejection, authorization rejection, row-validator
+rejection, or whole-commit rejection MUST enqueue zero reactions. A locked
+idempotency hit MUST skip the planner. Replaying an applied commit returns its
+cached result and MUST NOT add a second reaction row.
+
+**Planned record.** Each record contains:
+
+- `key`: non-empty, unique within the source commit, at most 256 UTF-8 bytes.
+- `type`: a code-like handler name at most 128 UTF-8 bytes.
+- `version`: a positive signed 32-bit integer. A handler MUST branch on
+  versions it supports and treat an unsupported version as a permanent
+  failure.
+- `payload`: plain JSON with finite numbers, at most 16 levels deep and at
+  most 65,536 UTF-8 bytes after normalization. Functions, `undefined`,
+  non-finite numbers, class instances, and cyclic values are invalid.
+- `maxAttempts`: an integer from 1 through 100; the default is 10.
+
+A commit may plan at most 100 records. Any invalid record fails the push
+transaction before commit. The persisted handler idempotency key is the stable
+JSON encoding of `[partition, clientId, clientCommitId, key]`. The tuple makes
+a planner key local to its source commit and partition, and removes delimiter
+ambiguity. A handler MUST pass this idempotency key to an external system when
+that system supports idempotent requests.
+
+**Atomic storage.** App rows, commit metadata and changes, reaction rows, and
+the applied idempotency result MUST commit in one authoritative transaction.
+The reaction table is partition-scoped and independent of commit-log/change
+tables. `pruneCommitLog` MUST NOT delete pending, leased, completed, or
+dead-lettered reactions. A missing transaction enqueue capability MUST fail
+before app-row mutation when a planner is configured.
+
+SQLite and PostgreSQL write reaction rows through the existing §6.3 push
+transaction. D1 buffers them into the same atomic `D1Database.batch()` as the
+source commit and requires the existing per-partition coordinator assertion.
+D1 MUST fail closed before the push when that assertion is absent. A D1 claim
+MUST use one write statement that both chooses due rows and returns their new
+leases; a select followed by a later update cannot provide the required claim
+guarantee. A D1 runtime that cannot execute that statement atomically MUST fail
+closed for reaction delivery.
+
+**Delivery state machine.** A host drives `ReactionRunner.runOnce()` from its
+scheduler or queue wake. Rows move through `pending`, `leased`, `completed`,
+and `dead-letter` states. A claim is one atomic storage operation over one
+partition and the worker's registered handler types. It selects due pending
+rows and expired leases, changes the owner/expiry, and increments `attempts`.
+PostgreSQL uses row locks with `SKIP LOCKED`; SQLite and D1 use one atomic
+`UPDATE ... RETURNING` statement. Concurrent workers therefore normally
+receive disjoint leases.
+
+Every runner call uses a fresh opaque lease-owner token. Before starting each
+handler in a claimed batch, the runner renews that row using the token. If the
+row expired and another worker reclaimed it while an earlier batch member was
+running, renewal fails and the stale runner skips the handler.
+
+Handlers execute after the authoritative push transaction has committed. A
+handler receives its payload and version, source client/commit/sequence,
+current attempt, maximum attempts, partition, and stable idempotency key. A
+long handler MAY call `extendLease()` before expiry. Completion, lease
+extension, retry, and dead-letter updates compare the current lease owner. A
+stale worker cannot acknowledge or alter a lease that another worker has
+claimed.
+
+Delivery is at least once. If a process crashes after a handler performs its
+side effect and before completion is recorded, the lease expires and another
+worker may invoke the handler again with the same idempotency key. External
+systems decide whether that repeated request collapses to one effect.
+Syncular does not promise exactly-once execution for external side effects.
+
+An ordinary throw and `RetryableReactionError` are retryable. The retry delay
+is bounded exponential backoff:
+`min(maxBackoffMs, initialBackoffMs × 2^(attempt − 1))`, with defaults of one
+second and five minutes. `PermanentReactionError` dead-letters immediately;
+a retryable failure dead-letters when `attempts >= maxAttempts`. Persisted
+failure information contains a stable error code, failure time, and optional
+plain JSON details bounded to 8,192 bytes. Raw exception text is not persisted.
+An operator may reset a dead-lettered row through
+`retryDeadLetterReaction`; the reset clears failure information and attempts
+and makes the row immediately due.
+
+**Terminal retention.** Reaction storage MUST provide a bounded,
+partition-scoped cleanup operation over terminal rows. A cleanup pass MUST
+delete only `completed` rows whose completion time is strictly older than its
+completed cutoff and `dead-letter` rows whose failure time is strictly older
+than its dead-letter cutoff. It MUST NOT delete `pending` or `leased` rows,
+including expired leases. Cleanup is independent of commit-log pruning and
+MUST NOT alter source commits, app rows, or idempotency results.
+
+`pruneReactions` applies separate retention floors and a maximum row count per
+pass. Defaults retain completed reactions for 30 days, dead-lettered reactions
+for 90 days, and delete at most 1,000 rows per pass. A host schedules passes and
+repeats while the result reports that more rows may remain. Manual retry and
+cleanup may race; their storage operations MUST serialize so exactly one
+terminal transition wins. Every pass MAY emit `reaction.prune_completed` with
+the cutoffs, per-status removal counts, limit, and `mayHaveMore` flag.
+
+**Observability and reads.** Lifecycle events are `reaction.queued` after the
+source transaction commits, `reaction.started`, `reaction.retried`,
+`reaction.completed`, and `reaction.dead_lettered`. They remain
+fire-and-forget operational events and do not replace reaction storage.
+`SyncularAdmin.listReactions` and the authenticated Hono
+`GET /admin/reactions` route expose partition-scoped lifecycle state.
+
 ---
 
 ## 7. Offline writes and replay

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -414,7 +414,7 @@ envelope codec rejects a no-content request as a **decode error** under
 
 | Field | Type | Semantics |
 |---|---|---|
-| `clientId` | `str` | Stable per-device identifier, non-empty. A server MUST reject a `clientId` already bound to a different actor in the same partition (`sync.invalid_client_id`) |
+| `clientId` | `str` | Stable per-device identifier, non-empty. A server MUST reject a `clientId` already bound to a different actor in the same partition or beginning with the reserved `["remote-command",` server-command prefix (`sync.invalid_client_id`) |
 | `schemaVersion` | `i32` | The client's generated schema version, ≥ 1. Gates codec selection and segment reuse |
 
 ### 1.6 Response message grammar
@@ -4242,16 +4242,17 @@ Recommended actions: `refreshAuth`, `checkPermissions`, `fixRequest`,
 |---|---|---|---|---|
 | `operation.unknown` | not-found | no | regenerateClient | A registered query or command ID is absent or has the wrong kind ([REMOTE.md](./REMOTE.md)) |
 | `operation.forbidden` | forbidden | no | checkPermissions | Registered query scope coverage or an operation authorizer denies access ([REMOTE.md](./REMOTE.md)) |
-| `operation.invalid_request` | invalid-request | no | fixRequest | A remote operation message, query coverage, command plan, or parameter set is invalid ([REMOTE.md](./REMOTE.md)) |
+| `operation.invalid_request` | invalid-request | no | fixRequest | A remote operation message, generated query coverage, or command mutation plan is invalid ([REMOTE.md](./REMOTE.md)) |
 | `operation.result_too_large` | invalid-request | no | fixRequest | A registered query returns more than its configured `maxRows` ([REMOTE.md](./REMOTE.md)) |
 | `operation.storage_unsupported` | internal | no | inspectServer | Configured storage lacks authoritative query support ([REMOTE.md](./REMOTE.md)) |
 | `operation.query_failed` | internal | no | inspectServer | Registered authoritative SQL execution or result decoding fails ([REMOTE.md](./REMOTE.md)) |
+| `operation.execution_failed` | internal | no | inspectServer | Registered operation code or infrastructure fails unexpectedly ([REMOTE.md](./REMOTE.md)) |
 | `sync.auth_required` | auth-required | yes | refreshAuth | Host authentication absent/failed (HTTP 401; WS close) |
 | `sync.auth_lease_required` | auth-required | yes | refreshAuth | The host opted the request into lease authorization (a live-resolver outage) but no valid lease exists for `(partition, clientId)` — expired, actor-mismatched, or never issued (§7.3.3) — *new in SSP2*; request-level |
 | `sync.auth_lease_revoked` | auth-required | yes | refreshAuth | A lease-authorized round was attempted on a lease the host revoked by `leaseId` (§7.3.4) — *new in SSP2*; request-level. Distinct from `sync.scope_revoked` (§3.3): the grant was pulled, but no local data is purged |
 | `sync.forbidden` | forbidden | no | checkPermissions | Write-path scope denial (§3.4); segment scope-digest mismatch (§5.5); `resolveScopes` threw on a write |
 | `sync.invalid_request` | invalid-request | no | fixRequest | Malformed envelope/frame, bad content type, missing required fields |
-| `sync.invalid_client_id` | invalid-request | no | resetClientId | `clientId` bound to a different actor (§1.5) |
+| `sync.invalid_client_id` | invalid-request | no | resetClientId | `clientId` bound to a different actor or uses the reserved server-command namespace (§1.5) |
 | `sync.invalid_subscription` | invalid-request | no | fixRequest | Duplicate subscription id; undeclared scope key (requested **or** resolved — §3.2) |
 | `sync.empty_commit` | invalid-request | no | fixRequest | `PUSH_COMMIT` with zero operations |
 | `sync.unknown_table` | schema-mismatch | no | regenerateClient | Subscription (request-level) or push operation (commit-level, §1.7) names a table the server doesn't handle |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -228,6 +228,8 @@ A server mounts these routes under a host-chosen prefix `<mount>`:
 | `<mount>/blobs/{blobId}/upload-grant` | POST | Presigned-upload grant: mint a direct-to-storage PUT URL (§5.9.3) |
 | `<mount>/blobs/{blobId}` | GET | Blob download with row-derived re-authorization (§5.9.5) |
 | `<mount>/realtime` | GET (WebSocket upgrade) | Realtime channel (§8) |
+| `<mount>/operations` | POST | Registered authoritative query or command ([REMOTE.md](./REMOTE.md)) |
+| `<mount>/operations/realtime` | GET (WebSocket upgrade) | Live registered-query watches ([REMOTE.md](./REMOTE.md)) |
 
 Content type for SSP2 bodies is `application/vnd.syncular.sync.v2`. A
 server MUST reject a `<mount>/sync` request with any other content type
@@ -2763,7 +2765,8 @@ classified as safe for the actor that already passed the row write gate.
 
 **Host codes MUST be distinguishable from protocol codes.** A host
 validation code **MUST NOT** begin with any reserved protocol-family
-prefix: **`sync.`**, **`blob.`**, **`presence.`**, or **`client.`**. These
+prefix: **`sync.`**, **`blob.`**, **`operation.`**, **`presence.`**, or
+**`client.`**. These
 namespace the protocol's own error families (§10.2 and the client-local
 codes of §10.3); reserving them guarantees a code appearing in a rejection
 record is unambiguously either a protocol code or a host code, never a
@@ -3049,6 +3052,32 @@ source transaction commits, `reaction.started`, `reaction.retried`,
 fire-and-forget operational events and do not replace reaction storage.
 `SyncularAdmin.listReactions` and the authenticated Hono
 `GET /admin/reactions` route expose partition-scoped lifecycle state.
+
+### 6.10 Database-less commit producers
+
+A process MAY submit ordinary commits without maintaining a local replica.
+It sends a push-only SSP2 request to `POST <mount>/sync`: `REQ_HEADER`, one or
+more `PUSH_COMMIT` frames, and `END`. A `PULL_HEADER` is unnecessary. The
+server applies the same authorization, conflict, validation, atomicity,
+idempotency, commit-log, and realtime rules as every replica-originated push.
+
+The producer MUST supply a stable `clientId` for its service identity and a
+stable `clientCommitId` for each logical operation. Losing the response does
+not authorize a new id. A retry MUST resend the byte-equivalent commit under
+the original `(partition, clientId, clientCommitId)` key (§2.3). The caller is
+responsible for retaining or deterministically deriving that identity because
+there is no Syncular outbox.
+
+A database-less producer has no local rows, subscriptions, cursor, optimistic
+state, rollback journal, or offline queue. It receives the terminal
+`PUSH_RESULT` directly. A conflict record carries the authoritative row bytes
+and version exactly as it does for a replica client. The caller decides
+whether to issue a corrected commit under a new `clientCommitId`.
+
+The application-facing remote operation protocol for authoritative queries,
+commands, and live query watches is defined separately in
+[`docs/REMOTE.md`](./REMOTE.md). Ordinary commits continue to use SSP2 so
+there is one commit path.
 
 ---
 
@@ -4211,6 +4240,12 @@ Recommended actions: `refreshAuth`, `checkPermissions`, `fixRequest`,
 
 | Code | Category | Retryable | Action | Produced when |
 |---|---|---|---|---|
+| `operation.unknown` | not-found | no | regenerateClient | A registered query or command ID is absent or has the wrong kind ([REMOTE.md](./REMOTE.md)) |
+| `operation.forbidden` | forbidden | no | checkPermissions | Registered query scope coverage or an operation authorizer denies access ([REMOTE.md](./REMOTE.md)) |
+| `operation.invalid_request` | invalid-request | no | fixRequest | A remote operation message, query coverage, command plan, or parameter set is invalid ([REMOTE.md](./REMOTE.md)) |
+| `operation.result_too_large` | invalid-request | no | fixRequest | A registered query returns more than its configured `maxRows` ([REMOTE.md](./REMOTE.md)) |
+| `operation.storage_unsupported` | internal | no | inspectServer | Configured storage lacks authoritative query support ([REMOTE.md](./REMOTE.md)) |
+| `operation.query_failed` | internal | no | inspectServer | Registered authoritative SQL execution or result decoding fails ([REMOTE.md](./REMOTE.md)) |
 | `sync.auth_required` | auth-required | yes | refreshAuth | Host authentication absent/failed (HTTP 401; WS close) |
 | `sync.auth_lease_required` | auth-required | yes | refreshAuth | The host opted the request into lease authorization (a live-resolver outage) but no valid lease exists for `(partition, clientId)` — expired, actor-mismatched, or never issued (§7.3.3) — *new in SSP2*; request-level |
 | `sync.auth_lease_revoked` | auth-required | yes | refreshAuth | A lease-authorized round was attempted on a lease the host revoked by `leaseId` (§7.3.4) — *new in SSP2*; request-level. Distinct from `sync.scope_revoked` (§3.3): the grant was pulled, but no local data is purged |
@@ -4307,7 +4342,7 @@ code — it is opaque to the client runtime, which applies generic rejection
 handling and never hardcodes its `category`/`retryable`/`recommendedAction`
 (those fields are catalog-fixed only for the codes in §10.2). A host code
 MUST NOT begin with the reserved protocol-family prefixes `sync.`,
-`blob.`, `presence.`, or `client.` (§6.7), so a code in a rejection record
+`blob.`, `operation.`, `presence.`, or `client.` (§6.7), so a code in a rejection record
 is always unambiguously either a protocol code (this catalog, its fixed
 metadata applies) or a host code (opaque, app-defined). This keeps the
 wire catalog closed while letting hosts mint their own business-rule

--- a/package.json
+++ b/package.json
@@ -13,15 +13,18 @@
     "bindings/tauri/example"
   ],
   "overrides": {
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.18",
     "svgo": "^4.0.2",
     "postcss": "^8.5.23",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "undici": "7.29.0"
   },
   "scripts": {
     "postinstall": "git config core.hooksPath .githooks 2>/dev/null || true; test -e CLAUDE.md || ln -s AGENTS.md CLAUDE.md || true",
-    "//audit-ignore": "react-router GHSA-qwww-vcr4-c8h2 is ignored, not unfixed: it is an RSC-mode CSRF bypass, and react-router-dom has no release carrying the 8.3.0 fix — the DOM entry points moved into react-router itself in v8, which needs React 19 via useOptimistic. It reaches us only as a devDependency of packages/react used by one test, react-router-scheduling.test.tsx, which drives the data router without RSC and ships to nobody. Drop this ignore when the react lane moves to React 19. The svgo/postcss/sharp advisories are fixed for real, via the root overrides above.",
-    "audit": "bun audit --ignore GHSA-qwww-vcr4-c8h2",
+    "//audit-ignore": "react-router GHSA-qwww-vcr4-c8h2 is ignored, not unfixed: it is an RSC-mode CSRF bypass, and react-router-dom has no release carrying the 8.3.0 fix — the DOM entry points moved into react-router itself in v8, which needs React 19 via useOptimistic. It reaches us only as a devDependency of packages/react used by one test, react-router-scheduling.test.tsx, which drives the data router without RSC and ships to nobody. image-size GHSA-w3rx-r6r6-pgpr and GHSA-5p2g-fcmc-qvqq have no fixed release; image-size is present only through the React Native Metro development toolchain, and Syncular never passes ICNS, JXL, or HEIF input to it. Drop each ignore when its dependency has a compatible fix. The svgo/postcss/sharp advisories are fixed for real, via the root overrides above.",
+    "audit": "bun audit --ignore GHSA-qwww-vcr4-c8h2 --ignore GHSA-w3rx-r6r6-pgpr --ignore GHSA-5p2g-fcmc-qvqq",
     "check": "bun run version:check && bun run check:code",
     "check:code": "bun run typecheck && bun run lint && bun run knip && bun run test",
     "version:print": "bun scripts/version.ts print",

--- a/packages/conformance/src/catalog/index.ts
+++ b/packages/conformance/src/catalog/index.ts
@@ -18,6 +18,7 @@ import { observationScenarios } from './observation';
 import { offlineScenarios } from './offline';
 import { presenceScenarios } from './presence';
 import { realtimeScenarios } from './realtime';
+import { remoteProducerScenarios } from './remote-producer';
 import { reconnectStormScenarios } from './reconnect-storm';
 import { schemaBumpScenarios } from './schema-bump';
 import { scopeScenarios } from './scopes';
@@ -44,6 +45,7 @@ export const CATALOG: readonly Scenario[] = [
   ...lifecycleScenarios,
   ...schemaBumpScenarios,
   ...realtimeScenarios,
+  ...remoteProducerScenarios,
   ...wsRoundScenarios,
   ...presenceScenarios,
   ...reconnectStormScenarios,

--- a/packages/conformance/src/catalog/remote-producer.ts
+++ b/packages/conformance/src/catalog/remote-producer.ts
@@ -1,12 +1,17 @@
 import { check, checkEqual } from '../checks';
 import { ALL_SCOPES, task } from '../fixture';
-import { rawPushCommit, rawUpsert, responsePushResults } from '../raw';
+import {
+  rawPullHeader,
+  rawPushCommit,
+  rawUpsert,
+  responsePushResults,
+} from '../raw';
 import type { Scenario } from '../scenario';
 
 export const remoteProducerScenarios: readonly Scenario[] = [
   {
     name: 'remote-producer/push-only-idempotency',
-    specRefs: ['§6.9', '§2.3', '§6.4'],
+    specRefs: ['§6.10', '§2.3', '§6.4'],
     async run(ctx) {
       await ctx.server.setAllowedScopes('worker', ALL_SCOPES);
       const frames = [
@@ -19,7 +24,7 @@ export const remoteProducerScenarios: readonly Scenario[] = [
         ]),
       ];
       const options = {
-        clientId: 'headless-producer',
+        clientId: 'remote-producer',
         schemaVersion: ctx.serverSchema.version,
       };
       const first = await ctx.rawSync('worker', frames, options);
@@ -42,6 +47,24 @@ export const remoteProducerScenarios: readonly Scenario[] = [
         await ctx.server.getMaxCommitSeq(),
         1,
         'retry allocated no second commit sequence',
+      );
+    },
+  },
+  {
+    name: 'remote-producer/reserved-command-client-namespace',
+    specRefs: ['§1.5', '§6.10'],
+    async run(ctx) {
+      await ctx.server.setAllowedScopes('worker', ALL_SCOPES);
+      const result = await ctx.rawSync('worker', [rawPullHeader()], {
+        clientId: '["remote-command","spoofed"]',
+        schemaVersion: ctx.serverSchema.version,
+      });
+      check(!result.ok, 'reserved command client namespace is rejected');
+      if (result.ok) return;
+      checkEqual(
+        result.error.code,
+        'sync.invalid_client_id',
+        'reserved command client namespace uses the stable identity error',
       );
     },
   },

--- a/packages/conformance/src/catalog/remote-producer.ts
+++ b/packages/conformance/src/catalog/remote-producer.ts
@@ -1,0 +1,48 @@
+import { check, checkEqual } from '../checks';
+import { ALL_SCOPES, task } from '../fixture';
+import { rawPushCommit, rawUpsert, responsePushResults } from '../raw';
+import type { Scenario } from '../scenario';
+
+export const remoteProducerScenarios: readonly Scenario[] = [
+  {
+    name: 'remote-producer/push-only-idempotency',
+    specRefs: ['§6.9', '§2.3', '§6.4'],
+    async run(ctx) {
+      await ctx.server.setAllowedScopes('worker', ALL_SCOPES);
+      const frames = [
+        rawPushCommit('job-42', [
+          rawUpsert(
+            ctx.serverSchema,
+            'tasks',
+            task('task-42', 'p1', 'database-less'),
+          ),
+        ]),
+      ];
+      const options = {
+        clientId: 'headless-producer',
+        schemaVersion: ctx.serverSchema.version,
+      };
+      const first = await ctx.rawSync('worker', frames, options);
+      check(first.ok, 'push-only request applies without a pull section');
+      if (!first.ok) return;
+      checkEqual(
+        responsePushResults(first.message)[0]?.status,
+        'applied',
+        'first delivery applies',
+      );
+      const replay = await ctx.rawSync('worker', frames, options);
+      check(replay.ok, 'identical push-only retry succeeds');
+      if (!replay.ok) return;
+      checkEqual(
+        responsePushResults(replay.message)[0]?.status,
+        'cached',
+        'identical push-only retry is cached',
+      );
+      checkEqual(
+        await ctx.server.getMaxCommitSeq(),
+        1,
+        'retry allocated no second commit sequence',
+      );
+    },
+  },
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from './message';
 export * from './realtime';
 export * from './rejection-details';
 export * from './relational-identifier';
+export * from './remote-operations';
 export * from './render';
 export * from './row-codec';
 export * from './segment';

--- a/packages/core/src/remote-operations.test.ts
+++ b/packages/core/src/remote-operations.test.ts
@@ -12,7 +12,7 @@ test('remote operation values preserve nested integers and bytes', () => {
     operationId: 'reports/by-project',
     params: {
       projectId: 'project-1',
-      cursor: 9_007_199_254_740_993n,
+      cursor: 9_223_372_036_854_775_807n,
       digest: new Uint8Array([0, 1, 2, 255]),
       nested: [true, null, { count: -42n }],
     },
@@ -29,4 +29,54 @@ test('remote operation decoding rejects malformed tagged values', () => {
       new TextEncoder().encode('{"t":"bytes","v":"=bad"}'),
     ),
   ).toThrow('invalid base64 value');
+});
+
+test('remote operation values reject lossy JavaScript inputs', () => {
+  expect(() =>
+    encodeRemoteOperationRequest({
+      revision: 1,
+      kind: 'query',
+      clientId: 'worker',
+      operationId: 'reports/by-project',
+      params: { missing: undefined },
+    }),
+  ).toThrow('cannot be undefined');
+  expect(() =>
+    encodeRemoteOperationRequest({
+      revision: 1,
+      kind: 'query',
+      clientId: 'worker',
+      operationId: 'reports/by-project',
+      params: new Date(0),
+    }),
+  ).toThrow('plain object');
+  expect(() =>
+    encodeRemoteOperationRequest({
+      revision: 1,
+      kind: 'query',
+      clientId: 'worker',
+      operationId: 'reports/by-project',
+      params: 9_223_372_036_854_775_808n,
+    }),
+  ).toThrow('signed 64-bit');
+});
+
+test('remote operation decoding rejects duplicate object keys', () => {
+  expect(() =>
+    decodeRemoteOperationRequest(
+      new TextEncoder().encode(
+        '{"t":"object","v":[["x",{"t":"null"}],["x",{"t":"null"}]]}',
+      ),
+    ),
+  ).toThrow('duplicate remote object key');
+  expect(() =>
+    decodeRemoteOperationRequest(
+      new TextEncoder().encode('{"t":"bytes","v":"AB=="}'),
+    ),
+  ).toThrow('invalid base64 value');
+  expect(() =>
+    decodeRemoteOperationRequest(
+      new TextEncoder().encode('{"t":"integer","v":"9223372036854775808"}'),
+    ),
+  ).toThrow('signed 64-bit');
 });

--- a/packages/core/src/remote-operations.test.ts
+++ b/packages/core/src/remote-operations.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import {
+  decodeRemoteOperationRequest,
+  encodeRemoteOperationRequest,
+} from './remote-operations';
+
+test('remote operation values preserve nested integers and bytes', () => {
+  const request = {
+    revision: 1,
+    kind: 'query',
+    clientId: 'worker',
+    operationId: 'reports/by-project',
+    params: {
+      projectId: 'project-1',
+      cursor: 9_007_199_254_740_993n,
+      digest: new Uint8Array([0, 1, 2, 255]),
+      nested: [true, null, { count: -42n }],
+    },
+  } as const;
+
+  expect(
+    decodeRemoteOperationRequest(encodeRemoteOperationRequest(request)),
+  ).toEqual(request);
+});
+
+test('remote operation decoding rejects malformed tagged values', () => {
+  expect(() =>
+    decodeRemoteOperationRequest(
+      new TextEncoder().encode('{"t":"bytes","v":"=bad"}'),
+    ),
+  ).toThrow('invalid base64 value');
+});

--- a/packages/core/src/remote-operations.ts
+++ b/packages/core/src/remote-operations.ts
@@ -1,0 +1,247 @@
+import { bytesToBase64 } from './render';
+
+export type RemoteOperationRequest =
+  | {
+      readonly revision: 1;
+      readonly kind: 'query';
+      readonly clientId: string;
+      readonly operationId: string;
+      readonly params: unknown;
+    }
+  | {
+      readonly revision: 1;
+      readonly kind: 'command';
+      readonly clientId: string;
+      readonly operationId: string;
+      readonly requestId: string;
+      readonly params: unknown;
+    };
+
+export type RemoteOperationResponse =
+  | {
+      readonly revision: 1;
+      readonly kind: 'query';
+      readonly operationId: string;
+      readonly rows: readonly Readonly<Record<string, unknown>>[];
+      readonly maxCommitSeq: number;
+    }
+  | {
+      readonly revision: 1;
+      readonly kind: 'command';
+      readonly operationId: string;
+      readonly requestId: string;
+      readonly status: 'applied' | 'cached' | 'rejected';
+      readonly commitSeq?: number;
+      readonly results: readonly unknown[];
+    }
+  | {
+      readonly revision: 1;
+      readonly kind: 'error';
+      readonly code: string;
+      readonly message: string;
+      readonly retryable: boolean;
+    };
+
+export type RemoteOperationRealtimeMessage =
+  | {
+      readonly revision: 1;
+      readonly kind: 'watch';
+      readonly watchId: string;
+      readonly clientId: string;
+      readonly operationId: string;
+      readonly params: unknown;
+    }
+  | {
+      readonly revision: 1;
+      readonly kind: 'unwatch';
+      readonly watchId: string;
+    }
+  | {
+      readonly revision: 1;
+      readonly kind: 'snapshot';
+      readonly watchId: string;
+      readonly operationId: string;
+      readonly rows: readonly Readonly<Record<string, unknown>>[];
+      readonly maxCommitSeq: number;
+    }
+  | {
+      readonly revision: 1;
+      readonly kind: 'watch_error';
+      readonly watchId: string;
+      readonly code: string;
+      readonly message: string;
+      readonly retryable: boolean;
+    };
+
+type EncodedValue =
+  | { readonly t: 'null' }
+  | { readonly t: 'boolean'; readonly v: boolean }
+  | { readonly t: 'number'; readonly v: number }
+  | { readonly t: 'string'; readonly v: string }
+  | { readonly t: 'integer'; readonly v: string }
+  | { readonly t: 'bytes'; readonly v: string }
+  | { readonly t: 'array'; readonly v: readonly EncodedValue[] }
+  | {
+      readonly t: 'object';
+      readonly v: readonly (readonly [string, EncodedValue])[];
+    };
+
+function base64ToBytes(text: string): Uint8Array {
+  const alphabet =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  if (
+    text.length % 4 !== 0 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      text,
+    )
+  ) {
+    throw new Error('invalid base64 value');
+  }
+  const padding = text.endsWith('==') ? 2 : text.endsWith('=') ? 1 : 0;
+  const out = new Uint8Array((text.length / 4) * 3 - padding);
+  let offset = 0;
+  for (let index = 0; index < text.length; index += 4) {
+    const values = [...text.slice(index, index + 4)].map((char) =>
+      char === '=' ? 0 : alphabet.indexOf(char),
+    );
+    if (values.some((value) => value < 0))
+      throw new Error('invalid base64 value');
+    const chunk =
+      ((values[0] ?? 0) << 18) |
+      ((values[1] ?? 0) << 12) |
+      ((values[2] ?? 0) << 6) |
+      (values[3] ?? 0);
+    if (offset < out.length) out[offset++] = (chunk >> 16) & 255;
+    if (offset < out.length) out[offset++] = (chunk >> 8) & 255;
+    if (offset < out.length) out[offset++] = chunk & 255;
+  }
+  return out;
+}
+
+function encodeValue(value: unknown): EncodedValue {
+  if (value === null || value === undefined) return { t: 'null' };
+  if (typeof value === 'boolean') return { t: 'boolean', v: value };
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value))
+      throw new Error('remote operation number must be finite');
+    return { t: 'number', v: value };
+  }
+  if (typeof value === 'string') return { t: 'string', v: value };
+  if (typeof value === 'bigint') return { t: 'integer', v: value.toString() };
+  if (value instanceof Uint8Array) {
+    return { t: 'bytes', v: bytesToBase64(value) };
+  }
+  if (Array.isArray(value)) {
+    return { t: 'array', v: value.map(encodeValue) };
+  }
+  if (typeof value === 'object') {
+    return {
+      t: 'object',
+      v: Object.entries(value).map(([key, entry]) => [key, encodeValue(entry)]),
+    };
+  }
+  throw new Error('remote operation value has an unsupported type');
+}
+
+function decodeValue(value: EncodedValue): unknown {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    typeof value.t !== 'string'
+  ) {
+    throw new Error('invalid remote operation value');
+  }
+  switch (value.t) {
+    case 'null':
+      return null;
+    case 'boolean':
+      if (typeof value.v !== 'boolean')
+        throw new Error('invalid remote boolean value');
+      return value.v;
+    case 'number':
+      if (typeof value.v !== 'number' || !Number.isFinite(value.v))
+        throw new Error('invalid remote number value');
+      return value.v;
+    case 'string':
+      if (typeof value.v !== 'string')
+        throw new Error('invalid remote string value');
+      return value.v;
+    case 'integer': {
+      if (typeof value.v !== 'string' || !/^-?(?:0|[1-9][0-9]*)$/.test(value.v))
+        throw new Error('invalid remote integer value');
+      return BigInt(value.v);
+    }
+    case 'bytes':
+      if (typeof value.v !== 'string')
+        throw new Error('invalid remote bytes value');
+      return base64ToBytes(value.v);
+    case 'array':
+      if (!Array.isArray(value.v))
+        throw new Error('invalid remote array value');
+      return value.v.map(decodeValue);
+    case 'object': {
+      if (!Array.isArray(value.v))
+        throw new Error('invalid remote object value');
+      const entries: Array<readonly [string, unknown]> = [];
+      for (const entry of value.v) {
+        if (
+          !Array.isArray(entry) ||
+          entry.length !== 2 ||
+          typeof entry[0] !== 'string'
+        ) {
+          throw new Error('invalid remote object entry');
+        }
+        entries.push([entry[0], decodeValue(entry[1])]);
+      }
+      return Object.fromEntries(entries);
+    }
+    default:
+      throw new Error('unknown remote operation value tag');
+  }
+}
+
+function encodeEnvelope(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(encodeValue(value)));
+}
+
+function decodeEnvelope(bytes: Uint8Array): unknown {
+  return decodeValue(
+    JSON.parse(new TextDecoder().decode(bytes)) as EncodedValue,
+  );
+}
+
+export function encodeRemoteOperationRequest(
+  request: RemoteOperationRequest,
+): Uint8Array {
+  return encodeEnvelope(request);
+}
+
+export function decodeRemoteOperationRequest(
+  bytes: Uint8Array,
+): RemoteOperationRequest {
+  return decodeEnvelope(bytes) as RemoteOperationRequest;
+}
+
+export function encodeRemoteOperationResponse(
+  response: RemoteOperationResponse,
+): Uint8Array {
+  return encodeEnvelope(response);
+}
+
+export function decodeRemoteOperationResponse(
+  bytes: Uint8Array,
+): RemoteOperationResponse {
+  return decodeEnvelope(bytes) as RemoteOperationResponse;
+}
+
+export function encodeRemoteOperationRealtimeMessage(
+  message: RemoteOperationRealtimeMessage,
+): Uint8Array {
+  return encodeEnvelope(message);
+}
+
+export function decodeRemoteOperationRealtimeMessage(
+  bytes: Uint8Array,
+): RemoteOperationRealtimeMessage {
+  return decodeEnvelope(bytes) as RemoteOperationRealtimeMessage;
+}

--- a/packages/core/src/remote-operations.ts
+++ b/packages/core/src/remote-operations.ts
@@ -115,11 +115,14 @@ function base64ToBytes(text: string): Uint8Array {
     if (offset < out.length) out[offset++] = (chunk >> 8) & 255;
     if (offset < out.length) out[offset++] = chunk & 255;
   }
+  if (bytesToBase64(out) !== text) throw new Error('invalid base64 value');
   return out;
 }
 
 function encodeValue(value: unknown): EncodedValue {
-  if (value === null || value === undefined) return { t: 'null' };
+  if (value === null) return { t: 'null' };
+  if (value === undefined)
+    throw new Error('remote operation value cannot be undefined');
   if (typeof value === 'boolean') return { t: 'boolean', v: value };
   if (typeof value === 'number') {
     if (!Number.isFinite(value))
@@ -127,7 +130,15 @@ function encodeValue(value: unknown): EncodedValue {
     return { t: 'number', v: value };
   }
   if (typeof value === 'string') return { t: 'string', v: value };
-  if (typeof value === 'bigint') return { t: 'integer', v: value.toString() };
+  if (typeof value === 'bigint') {
+    if (
+      value < -9_223_372_036_854_775_808n ||
+      value > 9_223_372_036_854_775_807n
+    ) {
+      throw new Error('remote operation integer exceeds signed 64-bit range');
+    }
+    return { t: 'integer', v: value.toString() };
+  }
   if (value instanceof Uint8Array) {
     return { t: 'bytes', v: bytesToBase64(value) };
   }
@@ -135,6 +146,10 @@ function encodeValue(value: unknown): EncodedValue {
     return { t: 'array', v: value.map(encodeValue) };
   }
   if (typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error('remote operation value must be a plain object');
+    }
     return {
       t: 'object',
       v: Object.entries(value).map(([key, entry]) => [key, encodeValue(entry)]),
@@ -169,7 +184,14 @@ function decodeValue(value: EncodedValue): unknown {
     case 'integer': {
       if (typeof value.v !== 'string' || !/^-?(?:0|[1-9][0-9]*)$/.test(value.v))
         throw new Error('invalid remote integer value');
-      return BigInt(value.v);
+      const integer = BigInt(value.v);
+      if (
+        integer < -9_223_372_036_854_775_808n ||
+        integer > 9_223_372_036_854_775_807n
+      ) {
+        throw new Error('remote operation integer exceeds signed 64-bit range');
+      }
+      return integer;
     }
     case 'bytes':
       if (typeof value.v !== 'string')
@@ -183,6 +205,7 @@ function decodeValue(value: EncodedValue): unknown {
       if (!Array.isArray(value.v))
         throw new Error('invalid remote object value');
       const entries: Array<readonly [string, unknown]> = [];
+      const keys = new Set<string>();
       for (const entry of value.v) {
         if (
           !Array.isArray(entry) ||
@@ -191,6 +214,8 @@ function decodeValue(value: EncodedValue): unknown {
         ) {
           throw new Error('invalid remote object entry');
         }
+        if (keys.has(entry[0])) throw new Error('duplicate remote object key');
+        keys.add(entry[0]);
         entries.push([entry[0], decodeValue(entry[1])]);
       }
       return Object.fromEntries(entries);

--- a/packages/create-app/template/tauri/src/syncular.queries.ts
+++ b/packages/create-app/template/tauri/src/syncular.queries.ts
@@ -71,6 +71,7 @@ export interface NamedQuery<Row, Params = undefined> {
   readonly sql: string;
   readonly mapRow: (row: Readonly<Record<string, unknown>>) => Row;
   readonly tables: readonly string[];
+  readonly resultColumns: readonly QueryResultColumn[];
   readonly bind: (params: Params) => readonly QueryValue[];
   readonly sqlFor?: (params: Params) => string;
   readonly dependencies: (params: Params) => readonly QueryDependency[];
@@ -83,6 +84,12 @@ export interface NamedQuery<Row, Params = undefined> {
 export interface QueryDependency {
   readonly table: string;
   readonly scopeKeys?: readonly string[];
+}
+
+export interface QueryResultColumn {
+  readonly name: string;
+  readonly type: 'string' | 'integer' | 'float' | 'boolean' | 'json' | 'bytes' | 'blob_ref' | 'crdt';
+  readonly nullable: boolean;
 }
 
 export interface WindowCoverage {
@@ -158,6 +165,7 @@ export const listTodosQuery: NamedQuery<ListTodosRow, ListTodosParams> = {
   mapRow: listTodosMapRow,
   sqlFor: (params: ListTodosParams) => listTodosSelect(params).sql,
   tables: listTodosTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'listId', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }, { name: 'position', type: 'integer', nullable: false }, { name: 'updatedAtMs', type: 'integer', nullable: false }],
   dependencies: (params) => [
     { table: 'todos', scopeKeys: ['list:' + String(params.listId) + ''] },
   ],

--- a/packages/server-hono/package.json
+++ b/packages/server-hono/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@syncular/server": "workspace:*",
-    "hono": "^4.11.0"
+    "hono": "^4.12.34"
   },
   "devDependencies": {
     "@syncular/core": "workspace:*"

--- a/packages/server-hono/src/admin.test.ts
+++ b/packages/server-hono/src/admin.test.ts
@@ -52,6 +52,13 @@ function harness() {
     storage,
     segments,
     resolveScopes: () => ({ project_id: ['p1'] }),
+    reactionPlanner: ({ operations }) =>
+      operations.map((operation) => ({
+        key: `task:${operation.rowId}`,
+        type: 'email.send',
+        version: 1,
+        payload: { taskId: operation.rowId },
+      })),
     events: ring,
   };
   const sync = createSyncularHono({
@@ -172,6 +179,25 @@ describe('JSON endpoints mirror the read surface', () => {
       commits: { commitSeq: number; tables: string[] }[];
     };
     expect(body.commits[0]).toMatchObject({ commitSeq: 1, tables: ['tasks'] });
+  });
+
+  test('GET /admin/reactions', async () => {
+    const { app, seed, auth } = harness();
+    await seed();
+    const res = await app.request(
+      '/admin/reactions?status=pending&type=email.send',
+      auth,
+    );
+    const body = (await res.json()) as {
+      reactions: { status: string; type: string; sourceCommitSeq: number }[];
+    };
+    expect(body.reactions).toEqual([
+      expect.objectContaining({
+        status: 'pending',
+        type: 'email.send',
+        sourceCommitSeq: 1,
+      }),
+    ]);
   });
 
   test('GET /admin/rows/:table/:rowId', async () => {

--- a/packages/server-hono/src/admin.ts
+++ b/packages/server-hono/src/admin.ts
@@ -7,13 +7,14 @@
  * refuses to mount without a host-provided `authorize` guard (it throws at
  * construction). Every request runs the guard first; a falsy result is a
  * 401. Admin is a privileged surface (it reads every partition's clients,
- * commit metadata, and scope activity) and SPEC.md deliberately says nothing
- * about it — authorization is entirely the host's, and mandatory.
+ * commit metadata, scope activity, and reactions) and authorization is
+ * entirely the host's and mandatory.
  */
 import {
   errorBody,
   matchesRingQuery,
   type RingEventQuery,
+  type ReactionStatus,
   SyncError,
   type SyncularAdmin,
   type SyncularServerEvent,
@@ -154,6 +155,32 @@ export function createSyncularAdminRoutes(
         ...(table !== undefined ? { table } : {}),
       });
       return Response.json({ commits });
+    } catch (error) {
+      return jsonError(error);
+    }
+  });
+
+  app.get('/reactions', async (c) => {
+    try {
+      const status = c.req.query('status');
+      const type = c.req.query('type');
+      const allowed = new Set<ReactionStatus>([
+        'pending',
+        'leased',
+        'completed',
+        'dead-letter',
+      ]);
+      if (status !== undefined && !allowed.has(status as ReactionStatus)) {
+        throw new SyncError('sync.invalid_request', 'invalid reaction status');
+      }
+      const reactions = await admin.listReactions(partitionOf(c), {
+        ...(status !== undefined
+          ? { statuses: [status as ReactionStatus] }
+          : {}),
+        ...(type !== undefined ? { types: [type] } : {}),
+        limit: intParam(c.req.query('limit'), 100),
+      });
+      return Response.json({ reactions });
     } catch (error) {
       return jsonError(error);
     }

--- a/packages/server-hono/src/index.test.ts
+++ b/packages/server-hono/src/index.test.ts
@@ -8,12 +8,16 @@ import {
   canonicalScopeJson,
   decodeMessage,
   encodeMessage,
+  encodeRemoteOperationRequest,
+  decodeRemoteOperationResponse,
   encodeRow,
   PROTOCOL_WIRE_VERSION,
   type RowColumn,
 } from '@syncular/core';
 import {
   MemorySegmentStore,
+  registerRemoteQuery,
+  RemoteOperationRegistry,
   type ServerSchema,
   SqliteServerStorage,
   SSP2_CONTENT_TYPE,
@@ -41,7 +45,10 @@ const SCHEMA: ServerSchema = {
   ],
 };
 
-function makeApp(events?: SyncularServerEvents) {
+function makeApp(
+  events?: SyncularServerEvents,
+  operations?: RemoteOperationRegistry,
+) {
   const config: SyncServerConfig = {
     schema: SCHEMA,
     storage: new SqliteServerStorage(),
@@ -52,6 +59,7 @@ function makeApp(events?: SyncularServerEvents) {
   };
   return createSyncularHono({
     config,
+    ...(operations !== undefined ? { operations } : {}),
     authenticate: async (request) => {
       const token = request.headers.get('authorization');
       if (token !== 'Bearer good') return null;
@@ -97,6 +105,57 @@ function requestBytes(title = 'hello'): Uint8Array {
 }
 
 describe('hono adapter', () => {
+  test('POST /operations runs a registered query', async () => {
+    const descriptor = {
+      id: 'sha256:test/allTasks',
+      hasParams: false,
+      sql: 'SELECT id, title FROM tasks ORDER BY id',
+      tables: ['tasks'],
+      bind: () => [],
+      dependencies: () => [{ table: 'tasks' }],
+      coverage: () => [],
+    };
+    const app = makeApp(
+      undefined,
+      new RemoteOperationRegistry([
+        registerRemoteQuery(descriptor, {
+          maxRows: 10,
+          auth: {
+            access: 'privileged',
+            authorize: () => true,
+          },
+        }),
+      ]),
+    );
+    const response = await app.request('/operations', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/vnd.syncular.operations.v1+json',
+        authorization: 'Bearer good',
+      },
+      body: encodeRemoteOperationRequest({
+        revision: 1,
+        kind: 'query',
+        clientId: 'admin-worker',
+        operationId: descriptor.id,
+        params: null,
+      }).slice().buffer as ArrayBuffer,
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      decodeRemoteOperationResponse(
+        new Uint8Array(await response.arrayBuffer()),
+      ),
+    ).toEqual({
+      revision: 1,
+      kind: 'query',
+      operationId: descriptor.id,
+      rows: [],
+      maxCommitSeq: 0,
+    });
+  });
+
   test('POST /sync round-trips SSP2 bytes', async () => {
     const app = makeApp();
     const response = await app.request('/sync', {

--- a/packages/server-hono/src/index.test.ts
+++ b/packages/server-hono/src/index.test.ts
@@ -111,6 +111,10 @@ describe('hono adapter', () => {
       hasParams: false,
       sql: 'SELECT id, title FROM tasks ORDER BY id',
       tables: ['tasks'],
+      resultColumns: [
+        { name: 'id', type: 'string', nullable: false },
+        { name: 'title', type: 'string', nullable: false },
+      ] as const,
       bind: () => [],
       dependencies: () => [{ table: 'tasks' }],
       coverage: () => [],
@@ -153,6 +157,22 @@ describe('hono adapter', () => {
       operationId: descriptor.id,
       rows: [],
       maxCommitSeq: 0,
+    });
+  });
+
+  test('POST /operations rejects the wrong content type with HTTP 415', async () => {
+    const app = makeApp();
+
+    const response = await app.request('/operations', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(response.status).toBe(415);
+    expect(await response.json()).toMatchObject({
+      code: 'operation.invalid_request',
+      retryable: false,
     });
   });
 

--- a/packages/server-hono/src/index.ts
+++ b/packages/server-hono/src/index.ts
@@ -71,12 +71,15 @@ export function createSyncularHono(options: SyncularHonoOptions): Hono {
   });
 
   app.post('/operations', async (c) => {
-    if (options.operations === undefined) {
-      return errorResponse(new SyncError('operation.unknown'));
-    }
     const contentType = c.req.header('content-type')?.split(';')[0]?.trim();
     if (contentType !== 'application/vnd.syncular.operations.v1+json') {
-      return errorResponse(new SyncError('operation.invalid_request'));
+      return Response.json(
+        errorBody(new SyncError('operation.invalid_request')),
+        { status: 415 },
+      );
+    }
+    if (options.operations === undefined) {
+      return errorResponse(new SyncError('operation.unknown'));
     }
     const auth = await options.authenticate(c.req.raw);
     if (auth === null)

--- a/packages/server-hono/src/index.ts
+++ b/packages/server-hono/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * Hono adapter: a thin wrapper proving the embed boundary.
  * Hono is a dependency of this adapter only, never of the server core.
- * Mounts the §1.1 routes: POST /sync and GET /segments/:segmentId
- * (realtime upgrades are runtime-specific and stay with the host).
+ * Mounts the §1.1 routes including sync, registered operations, segments, and
+ * blobs. Realtime upgrades are runtime-specific and stay with the host.
  */
 import {
   encodeSegmentBody,
@@ -11,6 +11,8 @@ import {
   handleBlobUpload,
   handleBlobUploadGrant,
   handleSegmentDownload,
+  handleRemoteOperation,
+  type RemoteOperationRegistry,
   handleSyncRequest,
   SSP2_CONTENT_TYPE,
   SyncError,
@@ -22,6 +24,7 @@ export * from './admin';
 
 export interface SyncularHonoOptions {
   readonly config: SyncServerConfig;
+  readonly operations?: RemoteOperationRegistry;
   /** Host authentication (§1.1); `null` ⇒ 401 `sync.auth_required`. */
   readonly authenticate: (
     request: Request,
@@ -65,6 +68,28 @@ export function createSyncularHono(options: SyncularHonoOptions): Hono {
     } catch (error) {
       return errorResponse(error);
     }
+  });
+
+  app.post('/operations', async (c) => {
+    if (options.operations === undefined) {
+      return errorResponse(new SyncError('operation.unknown'));
+    }
+    const contentType = c.req.header('content-type')?.split(';')[0]?.trim();
+    if (contentType !== 'application/vnd.syncular.operations.v1+json') {
+      return errorResponse(new SyncError('operation.invalid_request'));
+    }
+    const auth = await options.authenticate(c.req.raw);
+    if (auth === null)
+      return errorResponse(new SyncError('sync.auth_required'));
+    const bytes = new Uint8Array(await c.req.arrayBuffer());
+    const out = await handleRemoteOperation(
+      bytes,
+      { ...options.config, ...auth },
+      options.operations,
+    );
+    return c.body(out.slice().buffer as ArrayBuffer, 200, {
+      'Content-Type': 'application/vnd.syncular.operations.v1+json',
+    });
   });
 
   app.get('/segments/:segmentId', async (c) => {

--- a/packages/server-workers/README.md
+++ b/packages/server-workers/README.md
@@ -113,7 +113,9 @@ wrangler d1 migrations apply syncular
 
 The schema is plain SQLite DDL (shared with `bun:sqlite` via
 `sqlite-dialect.ts`), so it is portable across the two SQLite-family
-storages.
+storages. Regenerate and apply a migration when upgrading Syncular adds a core
+table. The durable reaction queue uses `sync_reactions`; a Worker running a
+reaction planner or runner fails closed if that migration is absent.
 
 ## Storage: D1 (`D1ServerStorage`)
 
@@ -128,6 +130,19 @@ immediately (autocommit) and **buffers** writes, flushing them as one atomic
 `db.batch()` at `commit()` (the §6.4 all-or-nothing commit; a rejected op
 rolls back by never flushing). A read-your-own-writes overlay makes `getRow`
 see buffered writes of the same commit.
+
+Durable reactions use the same model. Planned rows join the source commit's
+atomic batch. `ReactionRunner` claims due rows with one
+`UPDATE ... RETURNING` statement, so concurrent Workers have no select/update
+gap. Reaction handlers execute outside the source transaction. Run the runner
+from a Worker scheduler, queue consumer, Workflow step, or Durable Object
+alarm according to the application's hosting model.
+
+Schedule `pruneReactions` per partition as a separate maintenance pass.
+Defaults retain completed rows for 30 days and dead-lettered rows for 90 days,
+with at most 1,000 deletions per pass. Repeat while `mayHaveMore` is true.
+Pending and leased rows are never eligible. D1 executes each bounded cleanup
+as one `DELETE ... RETURNING` statement.
 
 **Concurrency posture.** Every push, not only whole-commit validation, must
 serialize before operation reads and re-check idempotency under that boundary.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -8,6 +8,17 @@ pruning (§4.6), and signed-URL token issuance (§5.4). `SPEC.md` is
 normative for everything on the wire; this README covers the **host
 surface** — in particular the ops seam and the pruning runbook.
 
+Application processes can expose generated named queries and transactional
+commands through `RemoteOperationRegistry`. Queries stay in the server
+registry, command mutations use the ordinary serialized push path, and
+`RemoteOperationWatchHub` provides live replacement snapshots. The protocol is
+specified in [`docs/REMOTE.md`](../../docs/REMOTE.md) and the practical setup is
+in the [remote operations guide](https://syncular.dev/guide-remote-operations/).
+
+Application intent belongs in immutable domain event rows written in the same
+commit as the state change. `SyncularServerEvents` below remains operational
+telemetry. See the [domain event guide](https://syncular.dev/guide-domain-events/).
+
 ## Deployment matrix (runtime adapters)
 
 The server core is **runtime-neutral TypeScript** — `handleSyncRequest` and

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -263,6 +263,118 @@ must check for it and fail closed. See the public
 for a user-scoped key-grant table revoked through a Workspace index and for the
 atomic reverse-index/queue fallback required by ordered or derived lookups.
 
+## Durable server reactions
+
+`reactionPlanner` turns an accepted candidate commit into bounded work records.
+It runs after operation and whole-commit validation, inside the authoritative
+push transaction. It may use the candidate-state reader and must perform no
+external side effects. A rejected or replayed commit does not run it.
+
+```ts
+import {
+  ReactionRunner,
+  type ReactionPlanner,
+  type SyncServerConfig,
+} from '@syncular/server';
+
+type AppReactions = {
+  'invoice.email': { invoiceId: string };
+};
+
+const reactionPlanner: ReactionPlanner<AppReactions> = ({ operations }) =>
+  operations.flatMap((operation) =>
+    operation.table === 'invoice_events' &&
+    operation.row?.kind === 'invoice_finalized' &&
+    typeof operation.row.invoice_id === 'string'
+      ? [{
+          key: `invoice:${operation.row.invoice_id}`,
+          type: 'invoice.email',
+          version: 1,
+          payload: { invoiceId: operation.row.invoice_id },
+          maxAttempts: 8,
+        }]
+      : [],
+  );
+
+const config: SyncServerConfig = {
+  schema, storage, segments, resolveScopes, reactionPlanner,
+};
+```
+
+App rows, commit metadata, reaction rows, and the push idempotency result land
+in one transaction. The handler idempotency key is derived from the source
+`partition`, `clientId`, `clientCommitId`, and planner `key`. Reaction rows use
+their own partition-scoped table and survive `pruneCommitLog`.
+
+Drive delivery from a host scheduler or queue wake:
+
+```ts
+const runner = new ReactionRunner<AppReactions>({
+  storage,
+  partition: 'main',
+  workerId: 'invoice-worker-1',
+  handlers: {
+    'invoice.email': async ({ payload, idempotencyKey, extendLease }) => {
+      await extendLease();
+      await emailProvider.send({
+        invoiceId: payload.invoiceId,
+        idempotencyKey,
+      });
+    },
+  },
+});
+
+await runner.runOnce();
+```
+
+Claims and acknowledgements compare a lease owner. Expired leases can be
+claimed by another worker, and long handlers can call `extendLease()`. Ordinary
+throws and `RetryableReactionError` retry with bounded exponential backoff.
+`PermanentReactionError` and exhausted retry limits enter `dead-letter`.
+`retryDeadLetterReaction` resets one row for an explicit operator retry.
+Each `runOnce()` uses a fresh lease token and rechecks ownership before
+starting every handler in a claimed batch.
+
+Schedule terminal retention separately from commit-log pruning:
+
+```ts
+import { pruneReactions } from '@syncular/server';
+
+let result;
+do {
+  result = await pruneReactions({
+    storage,
+    partition: 'main',
+    nowMs: Date.now(),
+    events,
+  });
+} while (result.mayHaveMore);
+```
+
+Defaults retain completed rows for 30 days, dead-lettered rows for 90 days,
+and remove at most 1,000 rows per pass. Override them with
+`retention: { completedRetentionMs, deadLetterRetentionMs, batchSize }`.
+Only terminal rows strictly older than their cutoff are eligible. Pending and
+leased work is preserved, including expired leases. Cleanup and manual retry
+serialize at storage, so one transition wins a race. Each pass emits
+`reaction.prune_completed` with both cutoffs, both removal counts, the limit,
+and `mayHaveMore`.
+
+Delivery is at least once. A crash after the handler's external call and before
+acknowledgement can run that call again. Handlers receive the same stable
+`idempotencyKey` on every attempt and should pass it to external providers.
+Syncular does not claim exactly-once external effects.
+
+Planned payloads are plain JSON, versioned, limited to 64 KiB and 16 levels,
+with at most 100 reactions per commit. Failure details are plain JSON limited
+to 8 KiB. The planner API cannot enforce purity in JavaScript; running an
+external effect from the planner violates the transaction contract.
+
+SQLite and PostgreSQL use their existing push transactions. D1 appends the
+reaction writes to the same atomic batch as the source commit and retains its
+mandatory per-partition Durable Object coordination for pushes. D1 claims use
+one `UPDATE ... RETURNING` statement, so there is no claim read/write gap.
+
 ## Structured events (the ops seam)
 
 One optional interface, `SyncularServerEvents`, carries every
@@ -310,6 +422,12 @@ context). The demo server wires it behind `SYNCULAR_DEMO_EVENTS=1`.
 | `push.applied` | A `PUSH_COMMIT` applied, or replayed from the idempotency cache (§2.3) | `clientId`, `clientCommitId`, `operations`, `commitSeq?`, `replay` |
 | `push.rejected` | A commit rejected (§6.3) | `clientId`, `clientCommitId`, `operations`, `code` (§10.2), `opIndex` |
 | `push.conflicted` | A commit terminated by a version conflict (§6.2) | `clientId`, `clientCommitId`, `operations`, `opIndex` |
+| `reaction.queued` | A planned reaction committed with its source push | `clientId`, `clientCommitId`, `commitSeq`, `idempotencyKey`, `reactionType`, `version` |
+| `reaction.started` | A worker claimed and began one attempt | `workerId`, `idempotencyKey`, `reactionType`, `version`, `attempt` |
+| `reaction.retried` | A retryable attempt failed and was rescheduled | started fields plus `nextAttemptAtMs`, `errorCode` |
+| `reaction.completed` | A handler finished and its owner acknowledged | started fields |
+| `reaction.dead_lettered` | A permanent or exhausted failure was recorded | started fields plus `errorCode` |
+| `reaction.prune_completed` | One bounded terminal-reaction retention pass finished | `completedBeforeMs`, `deadLetterBeforeMs`, `limit`, `removedCompleted`, `removedDeadLetter`, `mayHaveMore` |
 | `pull.served` | Once per served pull half, after all sections streamed | `clientId`, `subscriptions[]`: `{id, table, status, mode` (`bootstrap` \| `incremental` \| `none`)`, fromCursor, nextCursor, commits, changes, segments[]}`; each segment: `{mediaType` (`rows` \| `sqlite`)`, delivery` (`inline` \| `ref`)`, origin` (`built` \| `reused`)`, bytes, rows}` |
 | `segment.downloaded` | Every direct segment download (§5.5), success or failure | `segmentId`, `outcome` (`ok` \| `error`), `errorCode?`, `mediaType?`, `bytes?`, `durationMs` |
 | `blob.swept` | Every `sweepOrphanBlobs` pass (§5.9.2 orphan GC) | `partition`, `swept` (deleted count), `referenced` (keep-set size), `graceMs` |
@@ -325,10 +443,9 @@ exists) `partition` / `actorId`.
 
 ## Admin / console surface (`SyncularAdmin`)
 
-The operator-facing read surface over the server core. It is a module in
-this package — **not** a separate UI package — and adds **zero** wire
-protocol: SPEC.md says nothing about it, because authorization for these
-reads is entirely the host's. It delivers the 80% operator value (who's
+The operator-facing read surface over the server core lives in this package
+and adds **zero** wire protocol. Authorization for these reads is entirely the
+host's. It delivers the 80% operator value (who's
 connected, what's flowing,
 horizon health, the event tail) as a handful of read-only, partition-scoped,
 JSON-able queries.
@@ -367,6 +484,7 @@ by design:
 | `listClients(partition)` | Known clients: `clientId`, `actorId`, `cursor`, `lag` (commits not yet pulled: `maxCommitSeq − max(cursor, 0)`), `updatedAtMs`, `subscriptions[]`, and an `active` flag (cursor touched within the §4.6 active window). |
 | `clientDetail(partition, clientId, {eventLimit?})` | One client's drill-down: `{exists, client?, lease?, events}` — the record (with lag), its §7.3 lease when a lease store is wired, and its slice of the event tail. Answers "why is this client stale" in one read. |
 | `listCommits(partition, {afterSeq?, limit?, table?})` | Commit-log **metadata** (never payloads), newest first: `commitSeq`, `clientId`, `clientCommitId`, `actorId`, `createdAtMs`, `changeCount`, `tables[]`. |
+| `listReactions(partition, {statuses?, types?, limit?})` | Durable reaction lifecycle rows, newest first, including source commit, attempts, lease, completion, and bounded failure information. |
 | `inspectRow(partition, table, rowId)` | `{exists, serverVersion?, scopes?}` — current row version + stored scopes, payload **not** decoded. |
 | `scopeActivity(partition, {variable, value}, {limit?})` | Recent commits touching one scope key, via the §3.1 change-scope index (never a log scan). |
 | `horizonStatus(partition)` | `{maxCommitSeq, horizonSeq, retainedCommits, activeCursorFloor, recommendedHorizonSeq, recommendation}` — the horizon a prune pass would reach now (§4.6) + a coarse `up-to-date` / `prune-recommended`. |
@@ -413,6 +531,7 @@ app.route('/admin', routes);
 | `GET /clients` | `listClients` |
 | `GET /clients/:clientId?eventLimit` | `clientDetail` |
 | `GET /commits?afterSeq&limit&table` | `listCommits` |
+| `GET /reactions?status&type&limit` | `listReactions` |
 | `GET /rows/:table/:rowId` | `inspectRow` |
 | `GET /scope-activity?variable&value&limit` | `scopeActivity` |
 | `GET /horizon` | `horizonStatus` |

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -4,9 +4,8 @@
  * `ServerStorage`, the optional segment/blob store stats, and an in-memory
  * event ring. It delivers the 80% operator value (who's connected, what's
  * flowing, horizon health, the event tail) as a handful of queries in the
- * server package — no separate
- * UI package, no framework, no wire-protocol surface (SPEC.md is untouched;
- * this is host surface, mirrored in the server README).
+ * server package — no separate UI package, no framework, and no wire-protocol
+ * surface. This host surface is mirrored in the server README.
  *
  * Nothing here is on the sync hot path. Every method is a plain read; the
  * additive optional storage/store methods it depends on are documented as
@@ -25,8 +24,10 @@ import type { SegmentStore, SegmentStoreStats } from './segment-store';
 import type {
   ClientRecord,
   CommitMetadata,
+  ReactionStatus,
   ScopeCommitActivity,
   ServerStorage,
+  StoredReaction,
 } from './storage';
 
 /** A connected/known client as the console sees it (§4.5, §8.1). */
@@ -137,6 +138,12 @@ export interface AdminScopeActivityOptions {
   readonly limit?: number;
 }
 
+export interface AdminListReactionsOptions {
+  readonly statuses?: readonly ReactionStatus[];
+  readonly types?: readonly string[];
+  readonly limit?: number;
+}
+
 export interface AdminStats {
   readonly segments?: SegmentStoreStats;
   readonly blobs?: BlobStoreStats;
@@ -164,6 +171,7 @@ export interface SyncularAdminOptions {
 
 const DEFAULT_COMMIT_LIMIT = 50;
 const DEFAULT_SCOPE_LIMIT = 50;
+const DEFAULT_REACTION_LIMIT = 100;
 const DEFAULT_CLIENT_EVENT_LIMIT = 100;
 const DEFAULT_METRICS_WINDOW_MS = 5 * 60 * 1000;
 const DEFAULT_METRICS_BUCKETS = 30;
@@ -310,6 +318,22 @@ export class SyncularAdmin {
       afterSeq: options.afterSeq ?? 0,
       limit: options.limit ?? DEFAULT_COMMIT_LIMIT,
       ...(options.table !== undefined ? { table: options.table } : {}),
+    });
+  }
+
+  /** Pending, leased, completed, and dead-lettered durable reactions. */
+  async listReactions(
+    partition: string,
+    options: AdminListReactionsOptions = {},
+  ): Promise<StoredReaction[]> {
+    const read = required(
+      this.#storage.listReactions?.bind(this.#storage),
+      'storage',
+    );
+    return read(partition, {
+      limit: options.limit ?? DEFAULT_REACTION_LIMIT,
+      ...(options.statuses !== undefined ? { statuses: options.statuses } : {}),
+      ...(options.types !== undefined ? { types: options.types } : {}),
     });
   }
 

--- a/packages/server/src/authoritative-query.ts
+++ b/packages/server/src/authoritative-query.ts
@@ -1,0 +1,218 @@
+import type { CompiledTable } from './schema';
+import { quoteIdent, SYNC_PARTITION_COLUMN } from './relational-rows';
+import type { AuthoritativeQueryValue } from './storage';
+
+export interface PreparedAuthoritativeQuery {
+  readonly sql: string;
+  readonly params: readonly (AuthoritativeQueryValue | typeof PARTITION_BIND)[];
+}
+
+export interface BoundAuthoritativeQuery {
+  readonly sql: string;
+  readonly params: readonly AuthoritativeQueryValue[];
+}
+
+const PARTITION_BIND = Symbol('syncular.authoritative_partition');
+
+const RESERVED_ALIAS = new Set([
+  'on',
+  'where',
+  'group',
+  'order',
+  'inner',
+  'left',
+  'right',
+  'full',
+  'outer',
+  'natural',
+  'join',
+  'cross',
+  'using',
+  'limit',
+  'having',
+]);
+const IDENT = '[A-Za-z_][A-Za-z0-9_]*';
+const TABLE_REF_RE = new RegExp(
+  `\\b(FROM|(?:NATURAL\\s+)?(?:(?:LEFT|RIGHT|FULL)(?:\\s+OUTER)?|INNER|CROSS)?\\s*JOIN)\\s+((?:\\(\\s*)*)(${IDENT})(?:\\s+(?:AS\\s+)?((?!(?:${[...RESERVED_ALIAS].join('|')})\\b)${IDENT}))?`,
+  'gi',
+);
+
+function protectedSqlEnd(sql: string, index: number): number | undefined {
+  const char = sql[index];
+  const next = sql[index + 1];
+  if (char === "'" || char === '"' || char === '`') {
+    let end = index + 1;
+    while (end < sql.length) {
+      if (sql[end] === char && sql[end + 1] === char) end += 2;
+      else if (sql[end] === char) return end + 1;
+      else end += 1;
+    }
+    return sql.length;
+  }
+  if (char === '[') {
+    const end = sql.indexOf(']', index + 1);
+    return end < 0 ? sql.length : end + 1;
+  }
+  if (char === '-' && next === '-') {
+    const end = sql.indexOf('\n', index);
+    return end < 0 ? sql.length : end;
+  }
+  if (char === '/' && next === '*') {
+    const end = sql.indexOf('*/', index + 2);
+    return end < 0 ? sql.length : end + 2;
+  }
+  return undefined;
+}
+
+function maskedSql(sql: string): string {
+  let out = '';
+  let index = 0;
+  while (index < sql.length) {
+    const end = protectedSqlEnd(sql, index);
+    if (end === undefined) out += sql[index];
+    else out += sql.slice(index, end).replace(/[^\n]/g, ' ');
+    index = end ?? index + 1;
+  }
+  return out;
+}
+
+/**
+ * Turn generated local SQL into a partition-local authoritative statement.
+ * Only relations declared by the generated descriptor are rewritten. Values
+ * remain parameters; request data is never interpolated into SQL.
+ */
+export function prepareAuthoritativeQuery(
+  sql: string,
+  params: readonly AuthoritativeQueryValue[],
+  declaredTables: readonly string[],
+  tables: ReadonlyMap<string, CompiledTable>,
+): PreparedAuthoritativeQuery {
+  if (maskedSql(sql).includes(';'))
+    throw new Error('registered query must be one SELECT');
+  const declared = new Set(declaredTables);
+  const masked = maskedSql(sql);
+  const replacements: Array<{
+    readonly start: number;
+    readonly end: number;
+    readonly text: string;
+  }> = [];
+  const found = new Set<string>();
+  for (const match of masked.matchAll(TABLE_REF_RE)) {
+    const rawTable = match[3] as string;
+    const table = tables.get(rawTable);
+    if (table === undefined) continue;
+    if (!declared.has(table.name)) {
+      throw new Error('registered query table metadata does not match its SQL');
+    }
+    if (!table.materialize) {
+      throw new Error('registered query targets a non-materialized table');
+    }
+    let alias = match[4];
+    if (alias !== undefined && RESERVED_ALIAS.has(alias.toLowerCase())) {
+      alias = undefined;
+    }
+    const matchStart = match.index ?? 0;
+    const afterOperator = (match[1] as string).length;
+    const relative = match[0]
+      .toLowerCase()
+      .indexOf(rawTable.toLowerCase(), afterOperator);
+    const start = matchStart + relative;
+    const projection = table.columns.map((column) => quoteIdent(column.name));
+    replacements.push({
+      start,
+      end: start + rawTable.length,
+      text: `(SELECT ${projection.join(', ')} FROM ${quoteIdent(table.name)} WHERE ${quoteIdent(SYNC_PARTITION_COLUMN)}=/*syncular_partition*/?)${alias === undefined ? ` AS ${quoteIdent(table.name)}` : ''}`,
+    });
+    found.add(table.name);
+  }
+  if (
+    found.size !== declared.size ||
+    [...declared].some((table) => !found.has(table))
+  ) {
+    throw new Error('registered query table metadata does not match its SQL');
+  }
+  let rewritten = sql;
+  for (const replacement of replacements.sort(
+    (left, right) => right.start - left.start,
+  )) {
+    rewritten =
+      rewritten.slice(0, replacement.start) +
+      replacement.text +
+      rewritten.slice(replacement.end);
+  }
+
+  const bound: (AuthoritativeQueryValue | typeof PARTITION_BIND)[] = [];
+  let anonymousIndex = 0;
+  let rendered = '';
+  for (let index = 0; index < rewritten.length; index += 1) {
+    if (rewritten.startsWith('/*syncular_partition*/?', index)) {
+      rendered += '?';
+      bound.push(PARTITION_BIND);
+      index += '/*syncular_partition*/?'.length - 1;
+      continue;
+    }
+    const protectedEnd = protectedSqlEnd(rewritten, index);
+    if (protectedEnd !== undefined) {
+      rendered += rewritten.slice(index, protectedEnd);
+      index = protectedEnd - 1;
+      continue;
+    }
+    const char = rewritten[index] as string;
+    if (char !== '?') {
+      rendered += char;
+      continue;
+    }
+    let end = index + 1;
+    while (end < rewritten.length && /[0-9]/.test(rewritten[end] as string)) {
+      end += 1;
+    }
+    const numbered = rewritten.slice(index + 1, end);
+    const parameterIndex =
+      numbered.length > 0
+        ? Number.parseInt(numbered, 10) - 1
+        : anonymousIndex++;
+    if (numbered.length > 0) {
+      anonymousIndex = Math.max(anonymousIndex, parameterIndex + 1);
+    }
+    if (parameterIndex < 0 || parameterIndex >= params.length) {
+      throw new Error('registered query bind metadata does not match its SQL');
+    }
+    const value = params[parameterIndex];
+    if (value === undefined) {
+      throw new Error('registered query bind metadata does not match its SQL');
+    }
+    rendered += '?';
+    bound.push(value);
+    index = end - 1;
+  }
+  return { sql: rendered, params: bound };
+}
+
+export function bindAuthoritativePartition(
+  prepared: PreparedAuthoritativeQuery,
+  partition: string,
+): BoundAuthoritativeQuery {
+  return {
+    sql: prepared.sql,
+    params: prepared.params.map((value) =>
+      value === PARTITION_BIND ? partition : value,
+    ),
+  };
+}
+
+export function postgresPlaceholders(sql: string): string {
+  let bind = 0;
+  let rendered = '';
+  for (let index = 0; index < sql.length; index += 1) {
+    const protectedEnd = protectedSqlEnd(sql, index);
+    if (protectedEnd !== undefined) {
+      rendered += sql.slice(index, protectedEnd);
+      index = protectedEnd - 1;
+    } else if (sql[index] === '?') {
+      rendered += `$${++bind}`;
+    } else {
+      rendered += sql[index];
+    }
+  }
+  return rendered;
+}

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -9,6 +9,7 @@ import type { BlobStore } from './blob-store';
 import type { CrdtMergerRegistry } from './crdt-merger';
 import type { SyncularServerEvents } from './events';
 import type { LeaseStore } from './lease-store';
+import type { AnyReactionPlanner } from './reactions';
 import type { ServerSchema } from './schema';
 import type { SegmentStore } from './segment-store';
 import type {
@@ -119,6 +120,12 @@ export interface SyncServerConfig {
    * commit-log/idempotency append. A throw rolls back the complete commit.
    */
   readonly commitValidator?: CommitValidator;
+  /**
+   * Pure durable-reaction planner. Runs once after candidate validation and
+   * before commit-log/idempotency append. Its bounded records are enqueued in
+   * the same transaction; handlers run later through `ReactionRunner`.
+   */
+  readonly reactionPlanner?: AnyReactionPlanner;
   readonly resolveScopes: ResolveScopes;
   /**
    * §7.3 auth leases. Absent ⇒ the feature is off: no `LEASE` frame is

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -24,6 +24,9 @@ import type { CommitValidator, ValidatorRegistry } from './validate';
 /** SSP2 body content type (§1.1). */
 export const SSP2_CONTENT_TYPE = 'application/vnd.syncular.sync.v2';
 
+/** Internal idempotency namespace. Ordinary SSP2 client IDs cannot use it. */
+export const REMOTE_COMMAND_CLIENT_ID_PREFIX = '["remote-command",';
+
 export interface ResolveScopesArgs {
   readonly partition: string;
   readonly actorId: string;

--- a/packages/server/src/d1-storage.ts
+++ b/packages/server/src/d1-storage.ts
@@ -40,6 +40,10 @@
  * rather than a lock D1 does not expose.
  */
 import { decodeRow, type RowValue } from '@syncular/core';
+import {
+  bindAuthoritativePartition,
+  prepareAuthoritativeQuery,
+} from './authoritative-query';
 import { syncError } from './errors';
 import {
   commitWindowPageSql,
@@ -79,6 +83,8 @@ import {
   toStoredRow,
 } from './sqlite-dialect';
 import type {
+  AuthoritativeQueryRequest,
+  AuthoritativeQueryResult,
   ClientCursorInfo,
   ClientRecord,
   ClientSubscription,
@@ -910,6 +916,61 @@ export class D1ServerStorage implements ServerStorage {
       .bind(partition)
       .first<{ max_commit_seq: number }>();
     return row?.max_commit_seq ?? 0;
+  }
+
+  async queryAuthoritative(
+    partition: string,
+    query: AuthoritativeQueryRequest,
+  ): Promise<AuthoritativeQueryResult> {
+    if (this.#tables === undefined) {
+      throw new Error(
+        'ensureSchema(schema) must run before registered queries',
+      );
+    }
+    const prepared = bindAuthoritativePartition(
+      prepareAuthoritativeQuery(
+        query.sql,
+        query.params,
+        query.tables,
+        this.#tables,
+      ),
+      partition,
+    );
+    const results = await this.#db.batch([
+      this.#db.prepare(prepared.sql).bind(...prepared.params),
+      this.#db
+        .prepare('SELECT max_commit_seq FROM sync_partitions WHERE partition=?')
+        .bind(partition),
+    ]);
+    const rowsResult = results[0];
+    const cursorResult = results[1];
+    if (
+      typeof rowsResult !== 'object' ||
+      rowsResult === null ||
+      !('results' in rowsResult) ||
+      !Array.isArray(rowsResult.results) ||
+      typeof cursorResult !== 'object' ||
+      cursorResult === null ||
+      !('results' in cursorResult) ||
+      !Array.isArray(cursorResult.results)
+    ) {
+      throw new Error('D1 registered query returned an invalid batch result');
+    }
+    const cursor = cursorResult.results[0];
+    const maxCommitSeq =
+      typeof cursor === 'object' &&
+      cursor !== null &&
+      'max_commit_seq' in cursor &&
+      typeof cursor.max_commit_seq === 'number'
+        ? cursor.max_commit_seq
+        : 0;
+    return {
+      rows: rowsResult.results.filter(
+        (row): row is Readonly<Record<string, unknown>> =>
+          typeof row === 'object' && row !== null,
+      ),
+      maxCommitSeq,
+    };
   }
 
   async getHorizonSeq(partition: string): Promise<number> {

--- a/packages/server/src/d1-storage.ts
+++ b/packages/server/src/d1-storage.ts
@@ -85,8 +85,16 @@ import type {
   CommitMetadata,
   CommitMetadataQuery,
   CommitWindowQuery,
+  DurableJsonValue,
   IndexRowScanQuery,
   NewCommit,
+  NewReaction,
+  PrunedReactionCounts,
+  ReactionClaimQuery,
+  ReactionFailure,
+  ReactionFailureUpdate,
+  ReactionListQuery,
+  ReactionPruneQuery,
   RowScanQuery,
   ScopeActivityQuery,
   ScopeCommitActivity,
@@ -94,6 +102,7 @@ import type {
   StorageTransaction,
   StoredCommit,
   StoredPushResult,
+  StoredReaction,
   StoredRow,
 } from './storage';
 import { isD1ConstraintError, StorageConstraintError } from './storage-errors';
@@ -120,6 +129,52 @@ export interface D1Database {
 interface BufferedStatement {
   readonly sql: string;
   readonly params: readonly unknown[];
+}
+
+interface D1ReactionRecord {
+  idempotency_key: string;
+  type: string;
+  version: number;
+  payload: string;
+  source_client_id: string;
+  source_client_commit_id: string;
+  source_commit_seq: number;
+  created_at_ms: number;
+  available_at_ms: number;
+  status: StoredReaction['status'];
+  attempts: number;
+  max_attempts: number;
+  lease_owner: string | null;
+  lease_expires_at_ms: number | null;
+  completed_at_ms: number | null;
+  last_failure: string | null;
+}
+
+function toStoredReaction(record: D1ReactionRecord): StoredReaction {
+  return {
+    idempotencyKey: record.idempotency_key,
+    type: record.type,
+    version: record.version,
+    payload: JSON.parse(record.payload) as DurableJsonValue,
+    sourceClientId: record.source_client_id,
+    sourceClientCommitId: record.source_client_commit_id,
+    sourceCommitSeq: record.source_commit_seq,
+    createdAtMs: record.created_at_ms,
+    maxAttempts: record.max_attempts,
+    status: record.status,
+    attempts: record.attempts,
+    availableAtMs: record.available_at_ms,
+    ...(record.lease_owner !== null ? { leaseOwner: record.lease_owner } : {}),
+    ...(record.lease_expires_at_ms !== null
+      ? { leaseExpiresAtMs: record.lease_expires_at_ms }
+      : {}),
+    ...(record.completed_at_ms !== null
+      ? { completedAtMs: record.completed_at_ms }
+      : {}),
+    ...(record.last_failure !== null
+      ? { lastFailure: JSON.parse(record.last_failure) as ReactionFailure }
+      : {}),
+  };
 }
 
 function relationalValuesEqual(left: RowValue, right: RowValue): boolean {
@@ -588,6 +643,32 @@ class D1Transaction implements StorageTransaction {
     );
   }
 
+  async enqueueReactions(reactions: readonly NewReaction[]): Promise<void> {
+    this.#assertOpen();
+    for (const reaction of reactions) {
+      this.#buffer_(
+        `INSERT INTO sync_reactions(
+           partition, idempotency_key, type, version, payload,
+           source_client_id, source_client_commit_id, source_commit_seq,
+           created_at_ms, available_at_ms, status, attempts, max_attempts
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,'pending',0,?)`,
+        [
+          this.#partition,
+          reaction.idempotencyKey,
+          reaction.type,
+          reaction.version,
+          JSON.stringify(reaction.payload),
+          reaction.sourceClientId,
+          reaction.sourceClientCommitId,
+          reaction.sourceCommitSeq,
+          reaction.createdAtMs,
+          reaction.createdAtMs,
+          reaction.maxAttempts,
+        ],
+      );
+    }
+  }
+
   async commit(): Promise<void> {
     this.#assertOpen();
     if (this.#buffer.length === 0) {
@@ -916,6 +997,216 @@ export class D1ServerStorage implements ServerStorage {
         'persisted push result unreadable (§6.3)',
       );
     }
+  }
+
+  async claimReactions(
+    partition: string,
+    query: ReactionClaimQuery,
+  ): Promise<StoredReaction[]> {
+    if (query.types.length === 0 || query.limit <= 0) return [];
+    if (query.types.length + 7 > D1_MAX_BIND_PARAMS) {
+      throw new Error('D1 reaction claim exceeds the bound-parameter limit');
+    }
+    const typeParams = query.types.map(() => '?').join(',');
+    const { results } = await this.#db
+      .prepare(
+        `UPDATE sync_reactions
+            SET status='leased', attempts=attempts+1,
+                lease_owner=?, lease_expires_at_ms=?, completed_at_ms=NULL
+          WHERE (partition, idempotency_key) IN (
+            SELECT partition, idempotency_key
+              FROM sync_reactions
+             WHERE partition=? AND type IN (${typeParams})
+               AND ((status='pending' AND available_at_ms<=?)
+                 OR (status='leased' AND lease_expires_at_ms<=?))
+             ORDER BY CASE WHEN status='leased' THEN lease_expires_at_ms
+                           ELSE available_at_ms END,
+                      created_at_ms, idempotency_key
+             LIMIT ?
+          )
+        RETURNING *`,
+      )
+      .bind(
+        query.leaseOwner,
+        Math.min(Number.MAX_SAFE_INTEGER, query.nowMs + query.leaseDurationMs),
+        partition,
+        ...query.types,
+        query.nowMs,
+        query.nowMs,
+        query.limit,
+      )
+      .all<D1ReactionRecord>();
+    return results
+      .map(toStoredReaction)
+      .sort(
+        (a, b) =>
+          a.createdAtMs - b.createdAtMs ||
+          a.idempotencyKey.localeCompare(b.idempotencyKey),
+      );
+  }
+
+  async completeReaction(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    completedAtMs: number,
+  ): Promise<boolean> {
+    const record = await this.#db
+      .prepare(
+        `UPDATE sync_reactions
+            SET status='completed', completed_at_ms=?,
+                lease_owner=NULL, lease_expires_at_ms=NULL
+          WHERE partition=? AND idempotency_key=?
+            AND status='leased' AND lease_owner=?
+        RETURNING idempotency_key`,
+      )
+      .bind(completedAtMs, partition, idempotencyKey, leaseOwner)
+      .first<{ idempotency_key: string }>();
+    return record !== null;
+  }
+
+  async extendReactionLease(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    leaseExpiresAtMs: number,
+  ): Promise<boolean> {
+    const record = await this.#db
+      .prepare(
+        `UPDATE sync_reactions SET lease_expires_at_ms=?
+          WHERE partition=? AND idempotency_key=?
+            AND status='leased' AND lease_owner=?
+        RETURNING idempotency_key`,
+      )
+      .bind(leaseExpiresAtMs, partition, idempotencyKey, leaseOwner)
+      .first<{ idempotency_key: string }>();
+    return record !== null;
+  }
+
+  async failReaction(
+    partition: string,
+    idempotencyKey: string,
+    update: ReactionFailureUpdate,
+  ): Promise<boolean> {
+    const record = await this.#db
+      .prepare(
+        `UPDATE sync_reactions
+            SET status=?, available_at_ms=?, last_failure=?,
+                lease_owner=NULL, lease_expires_at_ms=NULL
+          WHERE partition=? AND idempotency_key=?
+            AND status='leased' AND lease_owner=?
+        RETURNING idempotency_key`,
+      )
+      .bind(
+        update.retryAtMs === undefined ? 'dead-letter' : 'pending',
+        update.retryAtMs ?? update.failure.atMs,
+        JSON.stringify(update.failure),
+        partition,
+        idempotencyKey,
+        update.leaseOwner,
+      )
+      .first<{ idempotency_key: string }>();
+    return record !== null;
+  }
+
+  async retryReaction(
+    partition: string,
+    idempotencyKey: string,
+    nowMs: number,
+  ): Promise<boolean> {
+    const record = await this.#db
+      .prepare(
+        `UPDATE sync_reactions
+            SET status='pending', attempts=0, available_at_ms=?,
+                last_failure=NULL, lease_owner=NULL, lease_expires_at_ms=NULL,
+                completed_at_ms=NULL
+          WHERE partition=? AND idempotency_key=? AND status='dead-letter'
+        RETURNING idempotency_key`,
+      )
+      .bind(nowMs, partition, idempotencyKey)
+      .first<{ idempotency_key: string }>();
+    return record !== null;
+  }
+
+  async getReaction(
+    partition: string,
+    idempotencyKey: string,
+  ): Promise<StoredReaction | undefined> {
+    const record = await this.#db
+      .prepare(
+        'SELECT * FROM sync_reactions WHERE partition=? AND idempotency_key=?',
+      )
+      .bind(partition, idempotencyKey)
+      .first<D1ReactionRecord>();
+    return record === null ? undefined : toStoredReaction(record);
+  }
+
+  async listReactions(
+    partition: string,
+    query: ReactionListQuery,
+  ): Promise<StoredReaction[]> {
+    const where = ['partition=?'];
+    const params: (string | number)[] = [partition];
+    if (query.statuses !== undefined && query.statuses.length > 0) {
+      where.push(`status IN (${query.statuses.map(() => '?').join(',')})`);
+      params.push(...query.statuses);
+    }
+    if (query.types !== undefined && query.types.length > 0) {
+      where.push(`type IN (${query.types.map(() => '?').join(',')})`);
+      params.push(...query.types);
+    }
+    if (params.length + 1 > D1_MAX_BIND_PARAMS) {
+      throw new Error('D1 reaction list exceeds the bound-parameter limit');
+    }
+    params.push(query.limit);
+    const { results } = await this.#db
+      .prepare(
+        `SELECT * FROM sync_reactions WHERE ${where.join(' AND ')}
+          ORDER BY created_at_ms DESC, idempotency_key DESC LIMIT ?`,
+      )
+      .bind(...params)
+      .all<D1ReactionRecord>();
+    return results.map(toStoredReaction);
+  }
+
+  async pruneReactions(
+    partition: string,
+    query: ReactionPruneQuery,
+  ): Promise<PrunedReactionCounts> {
+    if (query.limit <= 0) return { completed: 0, deadLetter: 0 };
+    const { results } = await this.#db
+      .prepare(
+        `DELETE FROM sync_reactions
+          WHERE partition=? AND idempotency_key IN (
+            SELECT idempotency_key FROM sync_reactions
+             WHERE partition=?
+               AND ((status='completed' AND completed_at_ms IS NOT NULL
+                     AND completed_at_ms<?)
+                 OR (status='dead-letter' AND available_at_ms<?))
+             ORDER BY CASE WHEN status='completed' THEN completed_at_ms
+                           ELSE available_at_ms END,
+                      idempotency_key
+             LIMIT ?
+          )
+            AND ((status='completed' AND completed_at_ms IS NOT NULL
+                  AND completed_at_ms<?)
+              OR (status='dead-letter' AND available_at_ms<?))
+        RETURNING status`,
+      )
+      .bind(
+        partition,
+        partition,
+        query.completedBeforeMs,
+        query.deadLetterBeforeMs,
+        query.limit,
+        query.completedBeforeMs,
+        query.deadLetterBeforeMs,
+      )
+      .all<{ status: 'completed' | 'dead-letter' }>();
+    return {
+      completed: results.filter((row) => row.status === 'completed').length,
+      deadLetter: results.filter((row) => row.status === 'dead-letter').length,
+    };
   }
 
   async readCommitWindow(

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -14,8 +14,44 @@ export interface ErrorCatalogEntry {
   readonly httpStatus: number;
 }
 
-/** The §10.2 wire catalog (21 sync.* + 4 blob.* codes), keyed by stable code. */
+/** The §10.2 wire catalog, keyed by stable code. */
 export const ERROR_CATALOG: Readonly<Record<string, ErrorCatalogEntry>> = {
+  'operation.unknown': {
+    category: 'not-found',
+    retryable: false,
+    recommendedAction: 'regenerateClient',
+    httpStatus: 404,
+  },
+  'operation.forbidden': {
+    category: 'forbidden',
+    retryable: false,
+    recommendedAction: 'checkPermissions',
+    httpStatus: 403,
+  },
+  'operation.invalid_request': {
+    category: 'invalid-request',
+    retryable: false,
+    recommendedAction: 'fixRequest',
+    httpStatus: 400,
+  },
+  'operation.result_too_large': {
+    category: 'invalid-request',
+    retryable: false,
+    recommendedAction: 'fixRequest',
+    httpStatus: 400,
+  },
+  'operation.storage_unsupported': {
+    category: 'internal',
+    retryable: false,
+    recommendedAction: 'inspectServer',
+    httpStatus: 500,
+  },
+  'operation.query_failed': {
+    category: 'internal',
+    retryable: false,
+    recommendedAction: 'inspectServer',
+    httpStatus: 500,
+  },
   'sync.auth_required': {
     category: 'auth-required',
     retryable: true,

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -52,6 +52,12 @@ export const ERROR_CATALOG: Readonly<Record<string, ErrorCatalogEntry>> = {
     recommendedAction: 'inspectServer',
     httpStatus: 500,
   },
+  'operation.execution_failed': {
+    category: 'internal',
+    retryable: false,
+    recommendedAction: 'inspectServer',
+    httpStatus: 500,
+  },
   'sync.auth_required': {
     category: 'auth-required',
     retryable: true,

--- a/packages/server/src/events.ts
+++ b/packages/server/src/events.ts
@@ -1,6 +1,6 @@
 /**
- * Structured server events — the one operational seam (host surface, not
- * wire protocol; SPEC.md is untouched by this module).
+ * Structured server events — the one operational seam (host surface, outside
+ * the wire protocol).
  *
  * Design rules:
  * - Every event is a flat, JSON-able object with a stable `type` string:
@@ -79,6 +79,62 @@ export interface PushConflictedEvent extends PushEventBase {
   readonly replay: boolean;
   readonly recordedAtMs?: number;
   readonly cacheIdentity?: string;
+}
+
+/** A planned reaction committed atomically with its accepted source commit. */
+export interface ReactionQueuedEvent {
+  readonly type: 'reaction.queued';
+  readonly atMs: number;
+  readonly partition: string;
+  readonly actorId: string;
+  readonly clientId: string;
+  readonly clientCommitId: string;
+  readonly commitSeq: number;
+  readonly idempotencyKey: string;
+  readonly reactionType: string;
+  readonly version: number;
+}
+
+interface ReactionDeliveryEventBase {
+  readonly atMs: number;
+  readonly partition: string;
+  readonly workerId: string;
+  readonly idempotencyKey: string;
+  readonly reactionType: string;
+  readonly version: number;
+  readonly attempt: number;
+}
+
+export interface ReactionStartedEvent extends ReactionDeliveryEventBase {
+  readonly type: 'reaction.started';
+}
+
+export interface ReactionRetriedEvent extends ReactionDeliveryEventBase {
+  readonly type: 'reaction.retried';
+  readonly nextAttemptAtMs: number;
+  readonly errorCode: string;
+}
+
+export interface ReactionCompletedEvent extends ReactionDeliveryEventBase {
+  readonly type: 'reaction.completed';
+}
+
+export interface ReactionDeadLetteredEvent extends ReactionDeliveryEventBase {
+  readonly type: 'reaction.dead_lettered';
+  readonly errorCode: string;
+}
+
+/** One bounded terminal-reaction retention pass. */
+export interface ReactionPruneCompletedEvent {
+  readonly type: 'reaction.prune_completed';
+  readonly atMs: number;
+  readonly partition: string;
+  readonly completedBeforeMs: number;
+  readonly deadLetterBeforeMs: number;
+  readonly limit: number;
+  readonly removedCompleted: number;
+  readonly removedDeadLetter: number;
+  readonly mayHaveMore: boolean;
 }
 
 /** One emitted segment within a pull subscription section. */
@@ -248,6 +304,12 @@ export type SyncularServerEvent =
   | PushAppliedEvent
   | PushRejectedEvent
   | PushConflictedEvent
+  | ReactionQueuedEvent
+  | ReactionStartedEvent
+  | ReactionRetriedEvent
+  | ReactionCompletedEvent
+  | ReactionDeadLetteredEvent
+  | ReactionPruneCompletedEvent
   | PullServedEvent
   | SegmentDownloadedEvent
   | BlobUploadedEvent

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -23,7 +23,12 @@ import {
   type SubscriptionFrame,
 } from '@syncular/core';
 import type { SyncRequestContext } from './context';
-import { clockOf, limitsOf, RESOLVER_OUTAGE } from './context';
+import {
+  clockOf,
+  limitsOf,
+  REMOTE_COMMAND_CLIENT_ID_PREFIX,
+  RESOLVER_OUTAGE,
+} from './context';
 import { SyncError, syncError } from './errors';
 import {
   emitEvent,
@@ -213,6 +218,13 @@ async function planRequest(
       schemaFloor: true,
       leaseToEmit: undefined,
     };
+  }
+
+  if (header.clientId.startsWith(REMOTE_COMMAND_CLIENT_ID_PREFIX)) {
+    throw syncError(
+      'sync.invalid_client_id',
+      'clientId uses a reserved server-command namespace (§1.5)',
+    );
   }
 
   // §1.5: a clientId already bound to a different actor is rejected.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,35 @@ export * from './prune';
 export * from './pull';
 export * from './push';
 export * from './readiness';
+export {
+  DEFAULT_REACTION_INITIAL_BACKOFF_MS,
+  DEFAULT_REACTION_LEASE_MS,
+  DEFAULT_REACTION_MAX_ATTEMPTS,
+  DEFAULT_REACTION_MAX_BACKOFF_MS,
+  DEFAULT_REACTION_RETENTION,
+  MAX_REACTION_FAILURE_DETAILS_BYTES,
+  MAX_REACTION_PAYLOAD_BYTES,
+  MAX_REACTIONS_PER_COMMIT,
+  PermanentReactionError,
+  pruneReactions,
+  ReactionRunner,
+  reactionIdempotencyKey,
+  retryDeadLetterReaction,
+  RetryableReactionError,
+  type PlannedReaction,
+  type PruneReactionsOptions,
+  type ReactionHandler,
+  type ReactionHandlerInput,
+  type ReactionHandlers,
+  type ReactionPlan,
+  type ReactionPlanner,
+  type ReactionPlannerInput,
+  type ReactionPruneResult,
+  type ReactionRetentionPolicy,
+  type ReactionRunnerOptions,
+  type ReactionRunResult,
+  type ReactionTypeMap,
+} from './reactions';
 export * from './realtime';
 export * from './relational-rows';
 export * from './s3-blob-store';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@
  * handler (§5.5), and signed-URL token issuance/verification (§5.4).
  */
 export * from './admin';
+export * from './authoritative-query';
 export * from './blob-handlers';
 export * from './blob-store';
 export * from './content-encoding';
@@ -20,6 +21,8 @@ export * from './events-ring';
 export * from './frame-bytes';
 export * from './handler';
 export * from './lease-store';
+export * from './operations';
+export * from './operations-realtime';
 // The `PgExecutor` seam + Postgres storage/fanout are driver-agnostic (zero
 // runtime deps). Concrete driver adapters (pglite for tests; Bun.sql /
 // node-postgres for production, documented in the README) live in separate

--- a/packages/server/src/operations-realtime.ts
+++ b/packages/server/src/operations-realtime.ts
@@ -4,6 +4,7 @@ import {
   type RemoteOperationRealtimeMessage,
 } from '@syncular/core';
 import type { RealtimeNotifier, SyncRequestContext } from './context';
+import { REMOTE_COMMAND_CLIENT_ID_PREFIX } from './context';
 import { SyncError, syncError } from './errors';
 import type {
   RegisteredRemoteQuery,
@@ -54,23 +55,67 @@ class WatchSession implements RemoteOperationWatchSession {
     let message: RemoteOperationRealtimeMessage;
     try {
       message = decodeRemoteOperationRealtimeMessage(bytes);
-    } catch {
+      if (
+        typeof message !== 'object' ||
+        message === null ||
+        message.revision !== 1 ||
+        (message.kind !== 'watch' && message.kind !== 'unwatch') ||
+        typeof message.watchId !== 'string' ||
+        message.watchId.length === 0
+      ) {
+        throw syncError('operation.invalid_request');
+      }
+      if (message.kind === 'watch') {
+        if (
+          typeof message.clientId !== 'string' ||
+          message.clientId.length === 0 ||
+          typeof message.operationId !== 'string' ||
+          message.operationId.length === 0
+        ) {
+          throw syncError('operation.invalid_request');
+        }
+      }
+    } catch (error) {
+      if (error instanceof SyncError) throw error;
       throw syncError('operation.invalid_request');
     }
-    if (message.revision !== 1) throw syncError('operation.invalid_request');
     if (message.kind === 'unwatch') {
       this.#watches.delete(message.watchId);
       return;
     }
-    if (message.kind !== 'watch') {
-      throw syncError('operation.invalid_request');
+    if (this.#watches.has(message.watchId)) {
+      this.#sendError(
+        message.watchId,
+        syncError('operation.invalid_request', 'watchId is already active'),
+      );
+      return;
     }
+    if (message.clientId.startsWith(REMOTE_COMMAND_CLIENT_ID_PREFIX)) {
+      this.#sendError(
+        message.watchId,
+        syncError(
+          'sync.invalid_client_id',
+          'clientId uses a reserved server-command namespace (§1.5)',
+        ),
+      );
+      return;
+    }
+    const clientRecord = await this.#ctx.storage.getClientRecord(
+      this.#ctx.partition,
+      message.clientId,
+    );
     if (
-      message.watchId.length === 0 ||
-      message.clientId.length === 0 ||
-      message.operationId.length === 0
+      clientRecord !== undefined &&
+      clientRecord.actorId !== this.#ctx.actorId
     ) {
-      throw syncError('operation.invalid_request');
+      this.#sendError(
+        message.watchId,
+        syncError(
+          'sync.invalid_client_id',
+          'clientId is bound to a different actor in this partition (§1.5)',
+        ),
+      );
+      return;
     }
     const operation = this.#registry.get(message.operationId);
     if (operation === undefined || operation.kind !== 'query') {
@@ -113,6 +158,9 @@ class WatchSession implements RemoteOperationWatchSession {
             state.clientId,
             state.params,
           );
+          if (this.#isClosed || this.#watches.get(state.watchId) !== state) {
+            return;
+          }
           if (response.kind !== 'query') {
             throw syncError('operation.query_failed');
           }
@@ -130,6 +178,9 @@ class WatchSession implements RemoteOperationWatchSession {
           )
             return;
         } catch (error) {
+          if (this.#isClosed || this.#watches.get(state.watchId) !== state) {
+            return;
+          }
           this.#sendError(
             state.watchId,
             error instanceof SyncError
@@ -161,6 +212,7 @@ class WatchSession implements RemoteOperationWatchSession {
   }
 
   #emit(bytes: Uint8Array): boolean {
+    if (this.#isClosed) return false;
     try {
       this.#send(bytes);
       return true;

--- a/packages/server/src/operations-realtime.ts
+++ b/packages/server/src/operations-realtime.ts
@@ -1,0 +1,220 @@
+import {
+  decodeRemoteOperationRealtimeMessage,
+  encodeRemoteOperationRealtimeMessage,
+  type RemoteOperationRealtimeMessage,
+} from '@syncular/core';
+import type { RealtimeNotifier, SyncRequestContext } from './context';
+import { SyncError, syncError } from './errors';
+import type {
+  RegisteredRemoteQuery,
+  RemoteOperationRegistry,
+} from './operations';
+import type { StoredCommit } from './storage';
+
+export interface RemoteOperationWatchSession {
+  receive(bytes: Uint8Array): Promise<void>;
+  close(): void;
+}
+
+interface WatchState {
+  readonly watchId: string;
+  readonly clientId: string;
+  readonly operation: RegisteredRemoteQuery;
+  readonly params: unknown;
+  running: boolean;
+  dirty: boolean;
+}
+
+class WatchSession implements RemoteOperationWatchSession {
+  readonly #ctx: SyncRequestContext;
+  readonly #registry: RemoteOperationRegistry;
+  readonly #send: (bytes: Uint8Array) => void;
+  readonly #closed: () => void;
+  readonly #watches = new Map<string, WatchState>();
+  #isClosed = false;
+
+  get partition(): string {
+    return this.#ctx.partition;
+  }
+
+  constructor(
+    ctx: SyncRequestContext,
+    registry: RemoteOperationRegistry,
+    send: (bytes: Uint8Array) => void,
+    closed: () => void,
+  ) {
+    this.#ctx = ctx;
+    this.#registry = registry;
+    this.#send = send;
+    this.#closed = closed;
+  }
+
+  async receive(bytes: Uint8Array): Promise<void> {
+    if (this.#isClosed) return;
+    let message: RemoteOperationRealtimeMessage;
+    try {
+      message = decodeRemoteOperationRealtimeMessage(bytes);
+    } catch {
+      throw syncError('operation.invalid_request');
+    }
+    if (message.revision !== 1) throw syncError('operation.invalid_request');
+    if (message.kind === 'unwatch') {
+      this.#watches.delete(message.watchId);
+      return;
+    }
+    if (message.kind !== 'watch') {
+      throw syncError('operation.invalid_request');
+    }
+    if (
+      message.watchId.length === 0 ||
+      message.clientId.length === 0 ||
+      message.operationId.length === 0
+    ) {
+      throw syncError('operation.invalid_request');
+    }
+    const operation = this.#registry.get(message.operationId);
+    if (operation === undefined || operation.kind !== 'query') {
+      this.#sendError(message.watchId, syncError('operation.unknown'));
+      return;
+    }
+    const state: WatchState = {
+      watchId: message.watchId,
+      clientId: message.clientId,
+      operation,
+      params: message.params,
+      running: false,
+      dirty: false,
+    };
+    this.#watches.set(message.watchId, state);
+    await this.#refresh(state);
+  }
+
+  notify(tables: ReadonlySet<string>): void {
+    for (const state of this.#watches.values()) {
+      if (!state.operation.tables.some((table) => tables.has(table))) continue;
+      if (state.running) state.dirty = true;
+      else void this.#refresh(state);
+    }
+  }
+
+  async #refresh(state: WatchState): Promise<void> {
+    if (this.#isClosed || this.#watches.get(state.watchId) !== state) return;
+    if (state.running) {
+      state.dirty = true;
+      return;
+    }
+    state.running = true;
+    try {
+      do {
+        state.dirty = false;
+        try {
+          const response = await state.operation.run(
+            this.#ctx,
+            state.clientId,
+            state.params,
+          );
+          if (response.kind !== 'query') {
+            throw syncError('operation.query_failed');
+          }
+          if (
+            !this.#emit(
+              encodeRemoteOperationRealtimeMessage({
+                revision: 1,
+                kind: 'snapshot',
+                watchId: state.watchId,
+                operationId: response.operationId,
+                rows: response.rows,
+                maxCommitSeq: response.maxCommitSeq,
+              }),
+            )
+          )
+            return;
+        } catch (error) {
+          this.#sendError(
+            state.watchId,
+            error instanceof SyncError
+              ? error
+              : syncError('operation.query_failed'),
+          );
+        }
+      } while (
+        state.dirty &&
+        !this.#isClosed &&
+        this.#watches.get(state.watchId) === state
+      );
+    } finally {
+      state.running = false;
+    }
+  }
+
+  #sendError(watchId: string, error: SyncError): void {
+    this.#emit(
+      encodeRemoteOperationRealtimeMessage({
+        revision: 1,
+        kind: 'watch_error',
+        watchId,
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+      }),
+    );
+  }
+
+  #emit(bytes: Uint8Array): boolean {
+    try {
+      this.#send(bytes);
+      return true;
+    } catch {
+      this.close();
+      return false;
+    }
+  }
+
+  close(): void {
+    if (this.#isClosed) return;
+    this.#isClosed = true;
+    this.#watches.clear();
+    this.#closed();
+  }
+}
+
+/** In-memory invalidation hub. Every notification reruns affected watches. */
+export class RemoteOperationWatchHub implements RealtimeNotifier {
+  readonly #registry: RemoteOperationRegistry;
+  readonly #sessions = new Set<WatchSession>();
+
+  constructor(registry: RemoteOperationRegistry) {
+    this.#registry = registry;
+  }
+
+  connect(
+    ctx: SyncRequestContext,
+    send: (bytes: Uint8Array) => void,
+  ): RemoteOperationWatchSession {
+    const session = new WatchSession(ctx, this.#registry, send, () => {
+      this.#sessions.delete(session);
+    });
+    this.#sessions.add(session);
+    return session;
+  }
+
+  notifyCommit(partition: string, commit: StoredCommit): void {
+    const tables = new Set(commit.changes.map((change) => change.table));
+    for (const session of this.#sessions) {
+      if (session.partition === partition) session.notify(tables);
+    }
+  }
+}
+
+/** Fan one applied commit into sync deltas and registered query watches. */
+export function composeRealtimeNotifiers(
+  ...notifiers: readonly RealtimeNotifier[]
+): RealtimeNotifier {
+  return {
+    notifyCommit: async (partition, commit) => {
+      await Promise.all(
+        notifiers.map((notifier) => notifier.notifyCommit(partition, commit)),
+      );
+    },
+  };
+}

--- a/packages/server/src/operations.ts
+++ b/packages/server/src/operations.ts
@@ -9,7 +9,7 @@ import {
   type ScopeMap,
 } from '@syncular/core';
 import type { SyncRequestContext } from './context';
-import { RESOLVER_OUTAGE } from './context';
+import { REMOTE_COMMAND_CLIENT_ID_PREFIX, RESOLVER_OUTAGE } from './context';
 import { SyncError, syncError } from './errors';
 import { processPushOperationsWithTrace } from './push';
 import { compileSchema } from './schema';
@@ -38,7 +38,7 @@ export interface AuthoritativeQueryDescriptor<Params = undefined> {
   readonly hasParams: boolean;
   readonly sql: string;
   readonly tables: readonly string[];
-  readonly resultColumns?: readonly {
+  readonly resultColumns: readonly {
     readonly name: string;
     readonly type:
       | 'string'
@@ -94,6 +94,9 @@ export type CommandMutation =
 export interface RemoteCommandContext {
   readonly actorId: string;
   readonly partition: string;
+  readonly clientId: string;
+  readonly operationId: string;
+  readonly requestId: string;
   getRow(table: string, rowId: string): Promise<ValidateRow | undefined>;
 }
 
@@ -153,18 +156,28 @@ function normalizeQueryRows(
   rows: readonly Readonly<Record<string, unknown>>[],
   columns: AuthoritativeQueryDescriptor<unknown>['resultColumns'],
 ): readonly Readonly<Record<string, unknown>>[] {
-  if (columns === undefined) return rows;
   return rows.map((row) => {
-    const normalized: Record<string, unknown> = { ...row };
+    const normalized: Record<string, unknown> = Object.create(null);
     for (const column of columns) {
       const value = row[column.name];
-      if (value === null || value === undefined) continue;
+      if (value === undefined || (value === null && !column.nullable)) {
+        throw syncError(
+          'operation.query_failed',
+          'registered query returned a missing or invalid null value',
+        );
+      }
+      if (value === null) {
+        normalized[column.name] = null;
+        continue;
+      }
       switch (column.type) {
         case 'integer': {
           const integer =
-            typeof value === 'bigint' || typeof value === 'string'
+            typeof value === 'bigint'
               ? Number(value)
-              : value;
+              : typeof value === 'string' && /^-?(?:0|[1-9][0-9]*)$/.test(value)
+                ? Number(value)
+                : value;
           if (typeof integer !== 'number' || !Number.isSafeInteger(integer)) {
             throw syncError(
               'operation.query_failed',
@@ -175,27 +188,46 @@ function normalizeQueryRows(
           break;
         }
         case 'float':
-          if (typeof value !== 'number' || !Number.isFinite(value)) {
-            throw syncError(
-              'operation.query_failed',
-              'registered query returned an invalid float',
-            );
+          {
+            const float =
+              typeof value === 'string' &&
+              /^-?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/.test(
+                value,
+              )
+                ? Number(value)
+                : value;
+            if (typeof float !== 'number' || !Number.isFinite(float)) {
+              throw syncError(
+                'operation.query_failed',
+                'registered query returned an invalid float',
+              );
+            }
+            normalized[column.name] = float;
           }
           break;
         case 'boolean':
-          if (typeof value === 'number') normalized[column.name] = value !== 0;
-          else if (typeof value !== 'boolean') {
+          if (typeof value === 'number' && Number.isFinite(value)) {
+            normalized[column.name] = value !== 0;
+          } else if (typeof value !== 'boolean') {
             throw syncError(
               'operation.query_failed',
               'registered query returned an invalid boolean',
             );
           }
           break;
-        case 'json':
-          if (typeof value !== 'string') {
-            normalized[column.name] = JSON.stringify(value);
+        case 'json': {
+          const json =
+            typeof value === 'string' ? value : JSON.stringify(value);
+          if (json === undefined) {
+            throw syncError(
+              'operation.query_failed',
+              'registered query returned invalid JSON',
+            );
           }
+          JSON.parse(json);
+          normalized[column.name] = json;
           break;
+        }
         case 'bytes':
         case 'crdt': {
           const bytes =
@@ -232,6 +264,7 @@ function normalizeQueryRows(
           }
           break;
       }
+      if (!(column.name in normalized)) normalized[column.name] = value;
     }
     return normalized;
   });
@@ -242,6 +275,18 @@ export function registerRemoteQuery<Params>(
   descriptor: AuthoritativeQueryDescriptor<Params>,
   options: RemoteQueryOptions<Params>,
 ): RegisteredRemoteQuery {
+  if (
+    descriptor.id.length === 0 ||
+    new Set(descriptor.tables).size !== descriptor.tables.length ||
+    !Array.isArray(descriptor.resultColumns) ||
+    descriptor.resultColumns.length === 0 ||
+    new Set(descriptor.resultColumns.map((column) => column.name)).size !==
+      descriptor.resultColumns.length
+  ) {
+    throw new Error(
+      'remote query requires a non-empty id and unique tables and result columns',
+    );
+  }
   if (
     !Number.isSafeInteger(options.maxRows) ||
     options.maxRows < 1 ||
@@ -255,6 +300,7 @@ export function registerRemoteQuery<Params>(
     tables: descriptor.tables,
     run: async (ctx, clientId, rawParams) => {
       const params = rawParams as Params;
+      const schema = compileSchema(ctx.schema);
       if (options.auth.access === 'scoped') {
         const allowed = await ctx.resolveScopes({
           partition: ctx.partition,
@@ -268,16 +314,48 @@ export function registerRemoteQuery<Params>(
           );
         }
         const coverage = descriptor.coverage(params);
-        const coveredTables = new Set(
-          coverage.map((entry) => entry.base.table),
-        );
-        if (descriptor.tables.some((table) => !coveredTables.has(table))) {
+        const coverageByTable = new Map<string, RemoteQueryCoverage>();
+        for (const entry of coverage) {
+          if (
+            coverageByTable.has(entry.base.table) ||
+            !descriptor.tables.includes(entry.base.table)
+          ) {
+            throw syncError(
+              'operation.invalid_request',
+              'scoped remote query has invalid generated scope coverage',
+            );
+          }
+          coverageByTable.set(entry.base.table, entry);
+        }
+        if (descriptor.tables.some((table) => !coverageByTable.has(table))) {
           throw syncError(
             'operation.invalid_request',
             'scoped remote query lacks complete generated scope coverage',
           );
         }
         for (const entry of coverage) {
+          const table = schema.tables.get(entry.base.table);
+          const fixedScopes = entry.base.fixedScopes ?? {};
+          const coveredVariables = new Set([
+            entry.base.variable,
+            ...Object.keys(fixedScopes),
+          ]);
+          if (
+            table === undefined ||
+            Object.prototype.hasOwnProperty.call(
+              fixedScopes,
+              entry.base.variable,
+            ) ||
+            coveredVariables.size !== table.declaredVariables.size ||
+            [...table.declaredVariables].some(
+              (variable) => !coveredVariables.has(variable),
+            )
+          ) {
+            throw syncError(
+              'operation.invalid_request',
+              'scoped remote query lacks complete generated scope coverage',
+            );
+          }
           if (entry.units.length === 0) {
             throw syncError(
               'operation.invalid_request',
@@ -289,9 +367,7 @@ export function registerRemoteQuery<Params>(
               throw syncError('operation.forbidden');
             }
           }
-          for (const [variable, values] of Object.entries(
-            entry.base.fixedScopes ?? {},
-          )) {
+          for (const [variable, values] of Object.entries(fixedScopes)) {
             if (
               values.length === 0 ||
               values.some((value) => !scopeAllowed(allowed, variable, value))
@@ -314,7 +390,6 @@ export function registerRemoteQuery<Params>(
           'configured storage does not implement authoritative queries',
         );
       }
-      const schema = compileSchema(ctx.schema);
       await ctx.storage.ensureSchema(schema);
       const selectedSql = descriptor.sqlFor?.(params) ?? descriptor.sql;
       let result;
@@ -334,11 +409,21 @@ export function registerRemoteQuery<Params>(
       if (result.rows.length > options.maxRows) {
         throw syncError('operation.result_too_large');
       }
+      let rows;
+      try {
+        rows = normalizeQueryRows(result.rows, descriptor.resultColumns);
+      } catch (error) {
+        if (error instanceof SyncError) throw error;
+        throw syncError(
+          'operation.query_failed',
+          'registered query result decoding failed',
+        );
+      }
       return {
         revision: 1,
         kind: 'query',
         operationId: descriptor.id,
-        rows: normalizeQueryRows(result.rows, descriptor.resultColumns),
+        rows,
         maxCommitSeq: result.maxCommitSeq,
       };
     },
@@ -419,10 +504,16 @@ function commandContext(
   tx: StorageTransaction,
   resolved: ResolvedScopes,
   schema: ReturnType<typeof compileSchema>,
+  clientId: string,
+  operationId: string,
+  requestId: string,
 ): RemoteCommandContext {
   return {
     actorId: ctx.actorId,
     partition: ctx.partition,
+    clientId,
+    operationId,
+    requestId,
     getRow: async (tableName, rowId) => {
       const table = schema.tables.get(tableName);
       if (table === undefined) {
@@ -451,6 +542,9 @@ export function registerRemoteCommand<Input>(
   descriptor: RemoteCommandDescriptor<Input>,
   options: RemoteCommandOptions<Input>,
 ): RegisteredRemoteCommand {
+  if (descriptor.id.length === 0) {
+    throw new Error('remote command id must be non-empty');
+  }
   return {
     kind: 'command',
     id: descriptor.id,
@@ -482,11 +576,22 @@ export function registerRemoteCommand<Input>(
         ctx,
         schema,
         resolved,
-        `command:${clientId}`,
-        `${descriptor.id}:${requestId}`,
+        JSON.stringify(['remote-command', ctx.actorId, clientId]),
+        JSON.stringify([descriptor.id, requestId]),
         async (tx) =>
           commandOperations(
-            await options.run(commandContext(ctx, tx, resolved, schema), input),
+            await options.run(
+              commandContext(
+                ctx,
+                tx,
+                resolved,
+                schema,
+                clientId,
+                descriptor.id,
+                requestId,
+              ),
+              input,
+            ),
             schema,
           ),
       );
@@ -510,8 +615,8 @@ export class RemoteOperationRegistry {
 
   constructor(operations: readonly RegisteredRemoteOperation[]) {
     for (const operation of operations) {
-      if (this.#operations.has(operation.id)) {
-        throw new Error('duplicate remote operation id');
+      if (operation.id.length === 0 || this.#operations.has(operation.id)) {
+        throw new Error('remote operation ids must be non-empty and unique');
       }
       this.#operations.set(operation.id, operation);
     }
@@ -522,14 +627,39 @@ export class RemoteOperationRegistry {
   }
 }
 
+function encodeRemoteOperationError(
+  error: unknown,
+  fallbackCode: 'operation.invalid_request' | 'operation.execution_failed',
+): Uint8Array {
+  const sync =
+    error instanceof SyncError
+      ? error
+      : syncError(
+          fallbackCode,
+          fallbackCode === 'operation.invalid_request'
+            ? 'invalid remote operation request'
+            : 'registered remote operation failed',
+        );
+  return encodeRemoteOperationResponse({
+    revision: 1,
+    kind: 'error',
+    code: sync.code,
+    message: sync.message,
+    retryable: sync.retryable,
+  });
+}
+
 export async function handleRemoteOperation(
   bytes: Uint8Array,
   ctx: SyncRequestContext,
   registry: RemoteOperationRegistry,
 ): Promise<Uint8Array> {
+  let request;
   try {
-    const request = decodeRemoteOperationRequest(bytes);
+    request = decodeRemoteOperationRequest(bytes);
     if (
+      typeof request !== 'object' ||
+      request === null ||
       request.revision !== 1 ||
       (request.kind !== 'query' && request.kind !== 'command') ||
       typeof request.clientId !== 'string' ||
@@ -538,6 +668,26 @@ export async function handleRemoteOperation(
       request.operationId.length === 0
     ) {
       throw syncError('operation.invalid_request');
+    }
+  } catch (error) {
+    return encodeRemoteOperationError(error, 'operation.invalid_request');
+  }
+  try {
+    if (request.clientId.startsWith(REMOTE_COMMAND_CLIENT_ID_PREFIX)) {
+      throw syncError(
+        'sync.invalid_client_id',
+        'clientId uses a reserved server-command namespace (§1.5)',
+      );
+    }
+    const clientRecord = await ctx.storage.getClientRecord(
+      ctx.partition,
+      request.clientId,
+    );
+    if (clientRecord !== undefined && clientRecord.actorId !== ctx.actorId) {
+      throw syncError(
+        'sync.invalid_client_id',
+        'clientId is bound to a different actor in this partition (§1.5)',
+      );
     }
     if (
       request.kind === 'command' &&
@@ -565,19 +715,6 @@ export async function handleRemoteOperation(
       ),
     );
   } catch (error) {
-    const sync =
-      error instanceof SyncError
-        ? error
-        : syncError(
-            'operation.invalid_request',
-            'invalid remote operation request',
-          );
-    return encodeRemoteOperationResponse({
-      revision: 1,
-      kind: 'error',
-      code: sync.code,
-      message: sync.message,
-      retryable: sync.retryable,
-    });
+    return encodeRemoteOperationError(error, 'operation.execution_failed');
   }
 }

--- a/packages/server/src/operations.ts
+++ b/packages/server/src/operations.ts
@@ -1,0 +1,583 @@
+import {
+  decodeRow,
+  decodeRemoteOperationRequest,
+  encodeRow,
+  encodeRemoteOperationResponse,
+  type PushOperation,
+  type RemoteOperationResponse,
+  type RowValue,
+  type ScopeMap,
+} from '@syncular/core';
+import type { SyncRequestContext } from './context';
+import { RESOLVER_OUTAGE } from './context';
+import { SyncError, syncError } from './errors';
+import { processPushOperationsWithTrace } from './push';
+import { compileSchema } from './schema';
+import { authorizeWrite, type ResolvedScopes } from './scopes';
+import type { AuthoritativeQueryValue } from './storage';
+import type { StorageTransaction } from './storage';
+import { toValidateRow, type ValidateRow } from './validate';
+
+export interface RemoteQueryDependency {
+  readonly table: string;
+  readonly scopeKeys?: readonly string[];
+}
+
+export interface RemoteQueryCoverage {
+  readonly base: {
+    readonly table: string;
+    readonly variable: string;
+    readonly fixedScopes?: Readonly<Record<string, readonly string[]>>;
+  };
+  readonly units: readonly string[];
+}
+
+/** Structural subset implemented by generated NamedQuery descriptors. */
+export interface AuthoritativeQueryDescriptor<Params = undefined> {
+  readonly id: string;
+  readonly hasParams: boolean;
+  readonly sql: string;
+  readonly tables: readonly string[];
+  readonly resultColumns?: readonly {
+    readonly name: string;
+    readonly type:
+      | 'string'
+      | 'integer'
+      | 'float'
+      | 'boolean'
+      | 'json'
+      | 'bytes'
+      | 'blob_ref'
+      | 'crdt';
+    readonly nullable: boolean;
+  }[];
+  readonly bind: (params: Params) => readonly AuthoritativeQueryValue[];
+  readonly sqlFor?: (params: Params) => string;
+  readonly dependencies: (params: Params) => readonly RemoteQueryDependency[];
+  readonly coverage: (params: Params) => readonly RemoteQueryCoverage[];
+}
+
+export interface RemoteOperationAuthContext {
+  readonly actorId: string;
+  readonly partition: string;
+  readonly clientId: string;
+}
+
+export type RegisteredRemoteQuery = {
+  readonly kind: 'query';
+  readonly id: string;
+  readonly tables: readonly string[];
+  readonly run: (
+    ctx: SyncRequestContext,
+    clientId: string,
+    params: unknown,
+  ) => Promise<RemoteOperationResponse>;
+};
+
+export interface RemoteCommandDescriptor<Input = undefined> {
+  readonly id: string;
+  readonly __input?: Input;
+}
+
+export type CommandMutation =
+  | {
+      readonly table: string;
+      readonly op: 'upsert';
+      readonly values: Readonly<Record<string, RowValue>>;
+    }
+  | {
+      readonly table: string;
+      readonly op: 'delete';
+      readonly rowId: string;
+    };
+
+export interface RemoteCommandContext {
+  readonly actorId: string;
+  readonly partition: string;
+  getRow(table: string, rowId: string): Promise<ValidateRow | undefined>;
+}
+
+export interface RemoteCommandOptions<Input> {
+  readonly authorize: (
+    context: RemoteOperationAuthContext,
+    input: Input,
+  ) => boolean | Promise<boolean>;
+  readonly run: (
+    context: RemoteCommandContext,
+    input: Input,
+  ) => readonly CommandMutation[] | Promise<readonly CommandMutation[]>;
+}
+
+export type RegisteredRemoteCommand = {
+  readonly kind: 'command';
+  readonly id: string;
+  readonly run: (
+    ctx: SyncRequestContext,
+    clientId: string,
+    requestId: string,
+    params: unknown,
+  ) => Promise<RemoteOperationResponse>;
+};
+
+export type RegisteredRemoteOperation =
+  | RegisteredRemoteQuery
+  | RegisteredRemoteCommand;
+
+type RemoteQueryAccess<Params> =
+  | { readonly access: 'scoped' }
+  | {
+      readonly access: 'privileged';
+      readonly authorize: (
+        context: RemoteOperationAuthContext,
+        params: Params,
+      ) => boolean | Promise<boolean>;
+    };
+
+export interface RemoteQueryOptions<Params> {
+  readonly maxRows: number;
+  readonly auth: RemoteQueryAccess<Params>;
+}
+
+function scopeAllowed(
+  allowed: ScopeMap,
+  variable: string,
+  value: string,
+): boolean {
+  const values = allowed[variable];
+  return (
+    values !== undefined && (values.includes('*') || values.includes(value))
+  );
+}
+
+function normalizeQueryRows(
+  rows: readonly Readonly<Record<string, unknown>>[],
+  columns: AuthoritativeQueryDescriptor<unknown>['resultColumns'],
+): readonly Readonly<Record<string, unknown>>[] {
+  if (columns === undefined) return rows;
+  return rows.map((row) => {
+    const normalized: Record<string, unknown> = { ...row };
+    for (const column of columns) {
+      const value = row[column.name];
+      if (value === null || value === undefined) continue;
+      switch (column.type) {
+        case 'integer': {
+          const integer =
+            typeof value === 'bigint' || typeof value === 'string'
+              ? Number(value)
+              : value;
+          if (typeof integer !== 'number' || !Number.isSafeInteger(integer)) {
+            throw syncError(
+              'operation.query_failed',
+              'registered query returned an invalid integer',
+            );
+          }
+          normalized[column.name] = integer;
+          break;
+        }
+        case 'float':
+          if (typeof value !== 'number' || !Number.isFinite(value)) {
+            throw syncError(
+              'operation.query_failed',
+              'registered query returned an invalid float',
+            );
+          }
+          break;
+        case 'boolean':
+          if (typeof value === 'number') normalized[column.name] = value !== 0;
+          else if (typeof value !== 'boolean') {
+            throw syncError(
+              'operation.query_failed',
+              'registered query returned an invalid boolean',
+            );
+          }
+          break;
+        case 'json':
+          if (typeof value !== 'string') {
+            normalized[column.name] = JSON.stringify(value);
+          }
+          break;
+        case 'bytes':
+        case 'crdt': {
+          const bytes =
+            value instanceof Uint8Array
+              ? value
+              : value instanceof ArrayBuffer
+                ? new Uint8Array(value)
+                : Array.isArray(value) &&
+                    value.every(
+                      (entry) =>
+                        typeof entry === 'number' &&
+                        Number.isInteger(entry) &&
+                        entry >= 0 &&
+                        entry <= 255,
+                    )
+                  ? new Uint8Array(value)
+                  : undefined;
+          if (bytes === undefined) {
+            throw syncError(
+              'operation.query_failed',
+              'registered query returned invalid bytes',
+            );
+          }
+          normalized[column.name] = bytes;
+          break;
+        }
+        case 'string':
+        case 'blob_ref':
+          if (typeof value !== 'string') {
+            throw syncError(
+              'operation.query_failed',
+              'registered query returned an invalid string',
+            );
+          }
+          break;
+      }
+    }
+    return normalized;
+  });
+}
+
+/** Register one generated named query as an authoritative remote operation. */
+export function registerRemoteQuery<Params>(
+  descriptor: AuthoritativeQueryDescriptor<Params>,
+  options: RemoteQueryOptions<Params>,
+): RegisteredRemoteQuery {
+  if (
+    !Number.isSafeInteger(options.maxRows) ||
+    options.maxRows < 1 ||
+    options.maxRows > 10_000
+  ) {
+    throw new Error('remote query maxRows must be an integer from 1 to 10,000');
+  }
+  return {
+    kind: 'query',
+    id: descriptor.id,
+    tables: descriptor.tables,
+    run: async (ctx, clientId, rawParams) => {
+      const params = rawParams as Params;
+      if (options.auth.access === 'scoped') {
+        const allowed = await ctx.resolveScopes({
+          partition: ctx.partition,
+          actorId: ctx.actorId,
+          clientId,
+        });
+        if (allowed === RESOLVER_OUTAGE) {
+          throw syncError(
+            'operation.forbidden',
+            'live scope authorization is unavailable for this query',
+          );
+        }
+        const coverage = descriptor.coverage(params);
+        const coveredTables = new Set(
+          coverage.map((entry) => entry.base.table),
+        );
+        if (descriptor.tables.some((table) => !coveredTables.has(table))) {
+          throw syncError(
+            'operation.invalid_request',
+            'scoped remote query lacks complete generated scope coverage',
+          );
+        }
+        for (const entry of coverage) {
+          if (entry.units.length === 0) {
+            throw syncError(
+              'operation.invalid_request',
+              'scoped remote query has an empty scope unit',
+            );
+          }
+          for (const value of entry.units) {
+            if (!scopeAllowed(allowed, entry.base.variable, value)) {
+              throw syncError('operation.forbidden');
+            }
+          }
+          for (const [variable, values] of Object.entries(
+            entry.base.fixedScopes ?? {},
+          )) {
+            if (
+              values.length === 0 ||
+              values.some((value) => !scopeAllowed(allowed, variable, value))
+            ) {
+              throw syncError('operation.forbidden');
+            }
+          }
+        }
+      } else if (
+        !(await options.auth.authorize(
+          { actorId: ctx.actorId, partition: ctx.partition, clientId },
+          params,
+        ))
+      ) {
+        throw syncError('operation.forbidden');
+      }
+      if (ctx.storage.queryAuthoritative === undefined) {
+        throw syncError(
+          'operation.storage_unsupported',
+          'configured storage does not implement authoritative queries',
+        );
+      }
+      const schema = compileSchema(ctx.schema);
+      await ctx.storage.ensureSchema(schema);
+      const selectedSql = descriptor.sqlFor?.(params) ?? descriptor.sql;
+      let result;
+      try {
+        result = await ctx.storage.queryAuthoritative(ctx.partition, {
+          sql: `SELECT * FROM (${selectedSql}) AS "_syncular_registered_query" LIMIT ?`,
+          params: [...descriptor.bind(params), options.maxRows + 1],
+          tables: descriptor.tables,
+        });
+      } catch (error) {
+        if (error instanceof SyncError) throw error;
+        throw syncError(
+          'operation.query_failed',
+          'registered query execution failed',
+        );
+      }
+      if (result.rows.length > options.maxRows) {
+        throw syncError('operation.result_too_large');
+      }
+      return {
+        revision: 1,
+        kind: 'query',
+        operationId: descriptor.id,
+        rows: normalizeQueryRows(result.rows, descriptor.resultColumns),
+        maxCommitSeq: result.maxCommitSeq,
+      };
+    },
+  };
+}
+
+/** A typed client/server identity for a server-authoritative command. */
+export function remoteCommand<Input = undefined>(
+  id: string,
+): RemoteCommandDescriptor<Input> {
+  if (id.length === 0) throw new Error('remote command id must be non-empty');
+  return { id };
+}
+
+function commandOperations(
+  mutations: readonly CommandMutation[],
+  schema: ReturnType<typeof compileSchema>,
+): PushOperation[] {
+  if (mutations.length === 0) {
+    throw syncError(
+      'operation.invalid_request',
+      'authoritative command produced no mutations',
+    );
+  }
+  return mutations.map((mutation) => {
+    const table = schema.tables.get(mutation.table);
+    if (table === undefined) {
+      throw syncError(
+        'operation.invalid_request',
+        'command targets an unknown table',
+      );
+    }
+    if (mutation.op === 'delete') {
+      if (mutation.rowId.length === 0) {
+        throw syncError(
+          'operation.invalid_request',
+          'command delete rowId is empty',
+        );
+      }
+      return { table: table.name, rowId: mutation.rowId, op: 'delete' };
+    }
+    const supplied = new Set(Object.keys(mutation.values));
+    for (const name of supplied) {
+      if (!table.columnIndex.has(name)) {
+        throw syncError(
+          'operation.invalid_request',
+          'command upsert has an unknown column',
+        );
+      }
+    }
+    const values = table.columns.map((column) => {
+      if (!supplied.has(column.name)) {
+        throw syncError(
+          'operation.invalid_request',
+          'command upsert must provide a full row',
+        );
+      }
+      return mutation.values[column.name] ?? null;
+    });
+    const rowId = values[table.primaryKeyIndex];
+    if (typeof rowId !== 'string' || rowId.length === 0) {
+      throw syncError(
+        'operation.invalid_request',
+        'command upsert requires a non-empty string primary key',
+      );
+    }
+    return {
+      table: table.name,
+      rowId,
+      op: 'upsert',
+      payload: encodeRow(table.columns, values),
+    };
+  });
+}
+
+function commandContext(
+  ctx: SyncRequestContext,
+  tx: StorageTransaction,
+  resolved: ResolvedScopes,
+  schema: ReturnType<typeof compileSchema>,
+): RemoteCommandContext {
+  return {
+    actorId: ctx.actorId,
+    partition: ctx.partition,
+    getRow: async (tableName, rowId) => {
+      const table = schema.tables.get(tableName);
+      if (table === undefined) {
+        throw syncError(
+          'operation.invalid_request',
+          'command read targets an unknown table',
+        );
+      }
+      const stored = await tx.getRow(tableName, rowId);
+      if (
+        stored === undefined ||
+        !authorizeWrite(table, stored.scopes, resolved)
+      ) {
+        return undefined;
+      }
+      return toValidateRow(
+        table.columns,
+        decodeRow(table.columns, stored.payload),
+      );
+    },
+  };
+}
+
+/** Register custom command code that plans one ordinary Syncular commit. */
+export function registerRemoteCommand<Input>(
+  descriptor: RemoteCommandDescriptor<Input>,
+  options: RemoteCommandOptions<Input>,
+): RegisteredRemoteCommand {
+  return {
+    kind: 'command',
+    id: descriptor.id,
+    run: async (ctx, clientId, requestId, rawInput) => {
+      const input = rawInput as Input;
+      if (
+        !(await options.authorize(
+          { actorId: ctx.actorId, partition: ctx.partition, clientId },
+          input,
+        ))
+      ) {
+        throw syncError('operation.forbidden');
+      }
+      const allowed = await ctx.resolveScopes({
+        partition: ctx.partition,
+        actorId: ctx.actorId,
+        clientId,
+      });
+      if (allowed === RESOLVER_OUTAGE) {
+        throw syncError(
+          'operation.forbidden',
+          'live scope authorization is unavailable for this command',
+        );
+      }
+      const resolved: ResolvedScopes = { ok: true, allowed };
+      const schema = compileSchema(ctx.schema);
+      await ctx.storage.ensureSchema(schema);
+      const processed = await processPushOperationsWithTrace(
+        ctx,
+        schema,
+        resolved,
+        `command:${clientId}`,
+        `${descriptor.id}:${requestId}`,
+        async (tx) =>
+          commandOperations(
+            await options.run(commandContext(ctx, tx, resolved, schema), input),
+            schema,
+          ),
+      );
+      return {
+        revision: 1,
+        kind: 'command',
+        operationId: descriptor.id,
+        requestId,
+        status: processed.frame.status,
+        ...(processed.frame.commitSeq !== undefined
+          ? { commitSeq: processed.frame.commitSeq }
+          : {}),
+        results: processed.frame.results,
+      };
+    },
+  };
+}
+
+export class RemoteOperationRegistry {
+  readonly #operations = new Map<string, RegisteredRemoteOperation>();
+
+  constructor(operations: readonly RegisteredRemoteOperation[]) {
+    for (const operation of operations) {
+      if (this.#operations.has(operation.id)) {
+        throw new Error('duplicate remote operation id');
+      }
+      this.#operations.set(operation.id, operation);
+    }
+  }
+
+  get(id: string): RegisteredRemoteOperation | undefined {
+    return this.#operations.get(id);
+  }
+}
+
+export async function handleRemoteOperation(
+  bytes: Uint8Array,
+  ctx: SyncRequestContext,
+  registry: RemoteOperationRegistry,
+): Promise<Uint8Array> {
+  try {
+    const request = decodeRemoteOperationRequest(bytes);
+    if (
+      request.revision !== 1 ||
+      (request.kind !== 'query' && request.kind !== 'command') ||
+      typeof request.clientId !== 'string' ||
+      typeof request.operationId !== 'string' ||
+      request.clientId.length === 0 ||
+      request.operationId.length === 0
+    ) {
+      throw syncError('operation.invalid_request');
+    }
+    if (
+      request.kind === 'command' &&
+      (typeof request.requestId !== 'string' || request.requestId.length === 0)
+    ) {
+      throw syncError('operation.invalid_request');
+    }
+    const operation = registry.get(request.operationId);
+    if (operation === undefined) {
+      throw syncError('operation.unknown');
+    }
+    if (request.kind === 'query') {
+      if (operation.kind !== 'query') throw syncError('operation.unknown');
+      return encodeRemoteOperationResponse(
+        await operation.run(ctx, request.clientId, request.params),
+      );
+    }
+    if (operation.kind !== 'command') throw syncError('operation.unknown');
+    return encodeRemoteOperationResponse(
+      await operation.run(
+        ctx,
+        request.clientId,
+        request.requestId,
+        request.params,
+      ),
+    );
+  } catch (error) {
+    const sync =
+      error instanceof SyncError
+        ? error
+        : syncError(
+            'operation.invalid_request',
+            'invalid remote operation request',
+          );
+    return encodeRemoteOperationResponse({
+      revision: 1,
+      kind: 'error',
+      code: sync.code,
+      message: sync.message,
+      retryable: sync.retryable,
+    });
+  }
+}

--- a/packages/server/src/postgres-storage.ts
+++ b/packages/server/src/postgres-storage.ts
@@ -36,6 +36,11 @@
  * does not tolerate). Cross-partition pushes never contend.
  */
 import type { PushOperationResult } from '@syncular/core';
+import {
+  bindAuthoritativePartition,
+  postgresPlaceholders,
+  prepareAuthoritativeQuery,
+} from './authoritative-query';
 import { syncError } from './errors';
 import {
   asBytes,
@@ -68,6 +73,8 @@ import {
 import type { CompiledSchema, CompiledTable } from './schema';
 import { matchesEffective } from './scopes';
 import type {
+  AuthoritativeQueryRequest,
+  AuthoritativeQueryResult,
   ClientCursorInfo,
   ClientRecord,
   ClientSubscription,
@@ -1038,6 +1045,46 @@ export class PostgresServerStorage implements ServerStorage {
       [partition],
     );
     return rows[0] === undefined ? 0 : asNumber(rows[0].max_commit_seq);
+  }
+
+  async queryAuthoritative(
+    partition: string,
+    query: AuthoritativeQueryRequest,
+  ): Promise<AuthoritativeQueryResult> {
+    if (this.#tables === undefined) {
+      throw new Error(
+        'ensureSchema(schema) must run before registered queries',
+      );
+    }
+    const prepared = bindAuthoritativePartition(
+      prepareAuthoritativeQuery(
+        query.sql,
+        query.params,
+        query.tables,
+        this.#tables,
+      ),
+      partition,
+    );
+    return this.#exec.transaction(async (client) => {
+      await client.query(
+        'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY',
+      );
+      const result = await client.query<Readonly<Record<string, unknown>>>(
+        postgresPlaceholders(prepared.sql),
+        prepared.params,
+      );
+      const cursor = await client.query<{ max_commit_seq: unknown }>(
+        'SELECT max_commit_seq FROM sync_partitions WHERE partition=$1',
+        [partition],
+      );
+      return {
+        rows: result.rows,
+        maxCommitSeq:
+          cursor.rows[0] === undefined
+            ? 0
+            : asNumber(cursor.rows[0].max_commit_seq),
+      };
+    });
   }
 
   async getHorizonSeq(partition: string): Promise<number> {

--- a/packages/server/src/postgres-storage.ts
+++ b/packages/server/src/postgres-storage.ts
@@ -74,8 +74,16 @@ import type {
   CommitMetadata,
   CommitMetadataQuery,
   CommitWindowQuery,
+  DurableJsonValue,
   IndexRowScanQuery,
   NewCommit,
+  NewReaction,
+  PrunedReactionCounts,
+  ReactionClaimQuery,
+  ReactionFailure,
+  ReactionFailureUpdate,
+  ReactionListQuery,
+  ReactionPruneQuery,
   RowScanQuery,
   ScopeActivityQuery,
   ScopeCommitActivity,
@@ -84,6 +92,7 @@ import type {
   StoredChange,
   StoredCommit,
   StoredPushResult,
+  StoredReaction,
   StoredRow,
 } from './storage';
 import {
@@ -151,6 +160,26 @@ CREATE TABLE IF NOT EXISTS sync_push_results(
   client_commit_id TEXT NOT NULL, result JSONB NOT NULL,
   PRIMARY KEY(partition, client_id, client_commit_id)
 );
+CREATE TABLE IF NOT EXISTS sync_reactions(
+  partition TEXT NOT NULL, idempotency_key TEXT NOT NULL,
+  type TEXT NOT NULL, version INTEGER NOT NULL, payload JSONB NOT NULL,
+  source_client_id TEXT NOT NULL, source_client_commit_id TEXT NOT NULL,
+  source_commit_seq BIGINT NOT NULL, created_at_ms BIGINT NOT NULL,
+  available_at_ms BIGINT NOT NULL, status TEXT NOT NULL,
+  attempts INTEGER NOT NULL, max_attempts INTEGER NOT NULL,
+  lease_owner TEXT, lease_expires_at_ms BIGINT, completed_at_ms BIGINT,
+  last_failure JSONB,
+  PRIMARY KEY(partition, idempotency_key),
+  CHECK(status IN ('pending', 'leased', 'completed', 'dead-letter'))
+);
+CREATE INDEX IF NOT EXISTS sync_reactions_due
+  ON sync_reactions(partition, status, available_at_ms, created_at_ms, idempotency_key);
+CREATE INDEX IF NOT EXISTS sync_reactions_lease
+  ON sync_reactions(partition, status, lease_expires_at_ms);
+CREATE INDEX IF NOT EXISTS sync_reactions_completed
+  ON sync_reactions(partition, status, completed_at_ms, idempotency_key);
+CREATE INDEX IF NOT EXISTS sync_reactions_dead_letter
+  ON sync_reactions(partition, status, available_at_ms, idempotency_key);
 CREATE TABLE IF NOT EXISTS sync_clients(
   partition TEXT NOT NULL, client_id TEXT NOT NULL, actor_id TEXT NOT NULL,
   cursor BIGINT NOT NULL, subscriptions JSONB NOT NULL,
@@ -183,6 +212,52 @@ function toBase64(bytes: Uint8Array): string {
 
 function fromBase64(text: string): Uint8Array {
   return new Uint8Array(Buffer.from(text, 'base64'));
+}
+
+interface PostgresReactionRecord {
+  idempotency_key: string;
+  type: string;
+  version: unknown;
+  payload: unknown;
+  source_client_id: string;
+  source_client_commit_id: string;
+  source_commit_seq: unknown;
+  created_at_ms: unknown;
+  available_at_ms: unknown;
+  status: StoredReaction['status'];
+  attempts: unknown;
+  max_attempts: unknown;
+  lease_owner: string | null;
+  lease_expires_at_ms: unknown | null;
+  completed_at_ms: unknown | null;
+  last_failure: unknown | null;
+}
+
+function toStoredReaction(record: PostgresReactionRecord): StoredReaction {
+  return {
+    idempotencyKey: record.idempotency_key,
+    type: record.type,
+    version: asNumber(record.version),
+    payload: asJson(record.payload) as DurableJsonValue,
+    sourceClientId: record.source_client_id,
+    sourceClientCommitId: record.source_client_commit_id,
+    sourceCommitSeq: asNumber(record.source_commit_seq),
+    createdAtMs: asNumber(record.created_at_ms),
+    maxAttempts: asNumber(record.max_attempts),
+    status: record.status,
+    attempts: asNumber(record.attempts),
+    availableAtMs: asNumber(record.available_at_ms),
+    ...(record.lease_owner !== null ? { leaseOwner: record.lease_owner } : {}),
+    ...(record.lease_expires_at_ms !== null
+      ? { leaseExpiresAtMs: asNumber(record.lease_expires_at_ms) }
+      : {}),
+    ...(record.completed_at_ms !== null
+      ? { completedAtMs: asNumber(record.completed_at_ms) }
+      : {}),
+    ...(record.last_failure !== null
+      ? { lastFailure: asJson(record.last_failure) as ReactionFailure }
+      : {}),
+  };
 }
 
 /**
@@ -719,6 +794,31 @@ class PostgresTransaction implements StorageTransaction {
     );
   }
 
+  async enqueueReactions(reactions: readonly NewReaction[]): Promise<void> {
+    this.#assertOpen();
+    for (const reaction of reactions) {
+      await this.#client.query(
+        `INSERT INTO sync_reactions(
+           partition, idempotency_key, type, version, payload,
+           source_client_id, source_client_commit_id, source_commit_seq,
+           created_at_ms, available_at_ms, status, attempts, max_attempts
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9,'pending',0,$10)`,
+        [
+          this.#partition,
+          reaction.idempotencyKey,
+          reaction.type,
+          reaction.version,
+          JSON.stringify(reaction.payload),
+          reaction.sourceClientId,
+          reaction.sourceClientCommitId,
+          reaction.sourceCommitSeq,
+          reaction.createdAtMs,
+          reaction.maxAttempts,
+        ],
+      );
+    }
+  }
+
   async commit(): Promise<void> {
     this.#assertOpen();
     this.#open = false;
@@ -998,6 +1098,210 @@ export class PostgresServerStorage implements ServerStorage {
     clientCommitId: string,
   ): Promise<StoredPushResult | undefined> {
     return getPushResultOn(this.#exec, partition, clientId, clientCommitId);
+  }
+
+  async claimReactions(
+    partition: string,
+    query: ReactionClaimQuery,
+  ): Promise<StoredReaction[]> {
+    if (query.types.length === 0 || query.limit <= 0) return [];
+    const typeParams = query.types.map((_, index) => `$${index + 2}`).join(',');
+    const nowParam = query.types.length + 2;
+    const limitParam = nowParam + 1;
+    const workerParam = limitParam + 1;
+    const expiresParam = workerParam + 1;
+    const { rows } = await this.#exec.query<PostgresReactionRecord>(
+      `WITH due AS (
+         SELECT partition, idempotency_key
+           FROM sync_reactions
+          WHERE partition=$1 AND type IN (${typeParams})
+            AND ((status='pending' AND available_at_ms<=$${nowParam})
+              OR (status='leased' AND lease_expires_at_ms<=$${nowParam}))
+          ORDER BY CASE WHEN status='leased' THEN lease_expires_at_ms
+                        ELSE available_at_ms END,
+                   created_at_ms, idempotency_key
+          FOR UPDATE SKIP LOCKED
+          LIMIT $${limitParam}
+       )
+       UPDATE sync_reactions AS reaction
+          SET status='leased', attempts=reaction.attempts+1,
+              lease_owner=$${workerParam}, lease_expires_at_ms=$${expiresParam},
+              completed_at_ms=NULL
+         FROM due
+        WHERE reaction.partition=due.partition
+          AND reaction.idempotency_key=due.idempotency_key
+      RETURNING reaction.*`,
+      [
+        partition,
+        ...query.types,
+        query.nowMs,
+        query.limit,
+        query.leaseOwner,
+        Math.min(Number.MAX_SAFE_INTEGER, query.nowMs + query.leaseDurationMs),
+      ],
+    );
+    return rows
+      .map(toStoredReaction)
+      .sort(
+        (a, b) =>
+          a.createdAtMs - b.createdAtMs ||
+          a.idempotencyKey.localeCompare(b.idempotencyKey),
+      );
+  }
+
+  async completeReaction(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    completedAtMs: number,
+  ): Promise<boolean> {
+    const result = await this.#exec.query(
+      `UPDATE sync_reactions
+          SET status='completed', completed_at_ms=$4,
+              lease_owner=NULL, lease_expires_at_ms=NULL
+        WHERE partition=$1 AND idempotency_key=$2
+          AND status='leased' AND lease_owner=$3`,
+      [partition, idempotencyKey, leaseOwner, completedAtMs],
+    );
+    return result.rowCount === 1;
+  }
+
+  async extendReactionLease(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    leaseExpiresAtMs: number,
+  ): Promise<boolean> {
+    const result = await this.#exec.query(
+      `UPDATE sync_reactions SET lease_expires_at_ms=$4
+        WHERE partition=$1 AND idempotency_key=$2
+          AND status='leased' AND lease_owner=$3`,
+      [partition, idempotencyKey, leaseOwner, leaseExpiresAtMs],
+    );
+    return result.rowCount === 1;
+  }
+
+  async failReaction(
+    partition: string,
+    idempotencyKey: string,
+    update: ReactionFailureUpdate,
+  ): Promise<boolean> {
+    const result = await this.#exec.query(
+      `UPDATE sync_reactions
+          SET status=$4, available_at_ms=$5, last_failure=$6,
+              lease_owner=NULL, lease_expires_at_ms=NULL
+        WHERE partition=$1 AND idempotency_key=$2
+          AND status='leased' AND lease_owner=$3`,
+      [
+        partition,
+        idempotencyKey,
+        update.leaseOwner,
+        update.retryAtMs === undefined ? 'dead-letter' : 'pending',
+        update.retryAtMs ?? update.failure.atMs,
+        JSON.stringify(update.failure),
+      ],
+    );
+    return result.rowCount === 1;
+  }
+
+  async retryReaction(
+    partition: string,
+    idempotencyKey: string,
+    nowMs: number,
+  ): Promise<boolean> {
+    const result = await this.#exec.query(
+      `UPDATE sync_reactions
+          SET status='pending', attempts=0, available_at_ms=$3,
+              last_failure=NULL, lease_owner=NULL, lease_expires_at_ms=NULL,
+              completed_at_ms=NULL
+        WHERE partition=$1 AND idempotency_key=$2 AND status='dead-letter'`,
+      [partition, idempotencyKey, nowMs],
+    );
+    return result.rowCount === 1;
+  }
+
+  async getReaction(
+    partition: string,
+    idempotencyKey: string,
+  ): Promise<StoredReaction | undefined> {
+    const { rows } = await this.#exec.query<PostgresReactionRecord>(
+      'SELECT * FROM sync_reactions WHERE partition=$1 AND idempotency_key=$2',
+      [partition, idempotencyKey],
+    );
+    return rows[0] === undefined ? undefined : toStoredReaction(rows[0]);
+  }
+
+  async listReactions(
+    partition: string,
+    query: ReactionListQuery,
+  ): Promise<StoredReaction[]> {
+    const where = ['partition=$1'];
+    const params: unknown[] = [partition];
+    if (query.statuses !== undefined && query.statuses.length > 0) {
+      const placeholders = query.statuses.map(
+        (_, index) => `$${params.length + index + 1}`,
+      );
+      where.push(`status IN (${placeholders.join(',')})`);
+      params.push(...query.statuses);
+    }
+    if (query.types !== undefined && query.types.length > 0) {
+      const placeholders = query.types.map(
+        (_, index) => `$${params.length + index + 1}`,
+      );
+      where.push(`type IN (${placeholders.join(',')})`);
+      params.push(...query.types);
+    }
+    params.push(query.limit);
+    const { rows } = await this.#exec.query<PostgresReactionRecord>(
+      `SELECT * FROM sync_reactions WHERE ${where.join(' AND ')}
+        ORDER BY created_at_ms DESC, idempotency_key DESC LIMIT $${params.length}`,
+      params,
+    );
+    return rows.map(toStoredReaction);
+  }
+
+  async pruneReactions(
+    partition: string,
+    query: ReactionPruneQuery,
+  ): Promise<PrunedReactionCounts> {
+    if (query.limit <= 0) return { completed: 0, deadLetter: 0 };
+    const { rows } = await this.#exec.query<{
+      status: 'completed' | 'dead-letter';
+    }>(
+      `WITH targets AS (
+         SELECT partition, idempotency_key
+           FROM sync_reactions
+          WHERE partition=$1
+            AND ((status='completed' AND completed_at_ms IS NOT NULL
+                  AND completed_at_ms<$2)
+              OR (status='dead-letter' AND available_at_ms<$3))
+          ORDER BY CASE WHEN status='completed' THEN completed_at_ms
+                        ELSE available_at_ms END,
+                   idempotency_key
+          FOR UPDATE SKIP LOCKED
+          LIMIT $4
+       )
+       DELETE FROM sync_reactions AS reaction
+        USING targets
+        WHERE reaction.partition=targets.partition
+          AND reaction.idempotency_key=targets.idempotency_key
+          AND ((reaction.status='completed'
+                AND reaction.completed_at_ms IS NOT NULL
+                AND reaction.completed_at_ms<$2)
+            OR (reaction.status='dead-letter'
+                AND reaction.available_at_ms<$3))
+      RETURNING reaction.status`,
+      [
+        partition,
+        query.completedBeforeMs,
+        query.deadLetterBeforeMs,
+        query.limit,
+      ],
+    );
+    return {
+      completed: rows.filter((row) => row.status === 'completed').length,
+      deadLetter: rows.filter((row) => row.status === 'dead-letter').length,
+    };
   }
 
   async readCommitWindow(

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -844,13 +844,38 @@ export async function processPushCommitWithTrace(
   clientId: string,
   frame: PushCommitFrame,
 ): Promise<ProcessedPushCommit> {
+  return processPushOperationsWithTrace(
+    ctx,
+    schema,
+    resolved,
+    clientId,
+    frame.clientCommitId,
+    async () => frame.operations,
+  );
+}
+
+/**
+ * Shared serialized apply path for SSP2 commits and authoritative commands.
+ * The builder runs after the partition lock and idempotency re-check, so its
+ * reads and the returned operations share the transaction that is committed.
+ */
+export async function processPushOperationsWithTrace(
+  ctx: SyncRequestContext,
+  schema: CompiledSchema,
+  resolved: ResolvedScopes,
+  clientId: string,
+  clientCommitId: string,
+  buildOperations: (
+    tx: StorageTransaction,
+  ) => Promise<readonly PushOperation[]>,
+): Promise<ProcessedPushCommit> {
   const { storage, partition } = ctx;
   let persisted: StoredPushResult | undefined;
   try {
     persisted = await storage.getPushResult(
       partition,
       clientId,
-      frame.clientCommitId,
+      clientCommitId,
     );
   } catch (error) {
     if (
@@ -860,14 +885,14 @@ export async function processPushCommitWithTrace(
       // §6.3: answer the retryable cache-miss for this commit rather than
       // re-applying. Not persisted — a retry may find a readable record.
       return {
-        frame: idempotencyCacheMissFrame(frame.clientCommitId, error),
+        frame: idempotencyCacheMissFrame(clientCommitId, error),
         replayed: false,
       };
     }
     throw error;
   }
   if (persisted !== undefined) {
-    return processedPushCommit(frame.clientCommitId, persisted, true);
+    return processedPushCommit(clientCommitId, persisted, true);
   }
 
   const createdAtMs = clockOf(ctx)();
@@ -903,19 +928,11 @@ export async function processPushCommitWithTrace(
     try {
       const serializedPersisted =
         tx.getPushResult !== undefined
-          ? await tx.getPushResult(clientId, frame.clientCommitId)
-          : await storage.getPushResult(
-              partition,
-              clientId,
-              frame.clientCommitId,
-            );
+          ? await tx.getPushResult(clientId, clientCommitId)
+          : await storage.getPushResult(partition, clientId, clientCommitId);
       if (serializedPersisted !== undefined) {
         await tx.rollback();
-        return processedPushCommit(
-          frame.clientCommitId,
-          serializedPersisted,
-          true,
-        );
+        return processedPushCommit(clientCommitId, serializedPersisted, true);
       }
     } catch (error) {
       if (
@@ -924,7 +941,7 @@ export async function processPushCommitWithTrace(
       ) {
         await tx.rollback();
         return {
-          frame: idempotencyCacheMissFrame(frame.clientCommitId, error),
+          frame: idempotencyCacheMissFrame(clientCommitId, error),
           replayed: false,
         };
       }
@@ -934,8 +951,9 @@ export async function processPushCommitWithTrace(
     const changes: NewChange[] = [];
     const validatedOperations: ValidateCommitOperation[] = [];
     let terminated: PushOperationResult | undefined;
-    for (let opIndex = 0; opIndex < frame.operations.length; opIndex++) {
-      const op = frame.operations[opIndex];
+    const operations = await buildOperations(tx);
+    for (let opIndex = 0; opIndex < operations.length; opIndex++) {
+      const op = operations[opIndex];
       if (op === undefined) continue;
       const outcome = await applyOperation(
         tx,
@@ -964,7 +982,7 @@ export async function processPushCommitWithTrace(
         tx,
         schema,
         clientId,
-        frame.clientCommitId,
+        clientCommitId,
         ctx.actorId,
         partition,
         validatedOperations,
@@ -978,7 +996,7 @@ export async function processPushCommitWithTrace(
     if (terminated === undefined && reactionPlanner !== undefined) {
       preparedReactions = await prepareReactions(reactionPlanner, {
         clientId,
-        clientCommitId: frame.clientCommitId,
+        clientCommitId,
         actorId: ctx.actorId,
         partition,
         operations: validatedOperations,
@@ -995,11 +1013,11 @@ export async function processPushCommitWithTrace(
       });
       // Discard candidates and persist the rejection while retaining the same
       // partition lock. There is no unlock gap in which a duplicate can rerun.
-      await commitRejectedPushResult(clientId, frame.clientCommitId, stored);
+      await commitRejectedPushResult(clientId, clientCommitId, stored);
       const canonical = await storage.getPushResult(
         partition,
         clientId,
-        frame.clientCommitId,
+        clientCommitId,
       );
       if (canonical === undefined) {
         throw new Error(
@@ -1007,7 +1025,7 @@ export async function processPushCommitWithTrace(
         );
       }
       return processedPushCommit(
-        frame.clientCommitId,
+        clientCommitId,
         canonical,
         canonical.cacheIdentity !== stored.cacheIdentity,
       );
@@ -1015,14 +1033,14 @@ export async function processPushCommitWithTrace(
 
     const commitSeq = await tx.appendCommit({
       clientId,
-      clientCommitId: frame.clientCommitId,
+      clientCommitId,
       actorId: ctx.actorId,
       createdAtMs,
       changes,
     });
     const newReactions = toNewReactions(preparedReactions, {
       clientId,
-      clientCommitId: frame.clientCommitId,
+      clientCommitId,
       commitSeq,
       createdAtMs,
     });
@@ -1038,7 +1056,7 @@ export async function processPushCommitWithTrace(
       commitSeq,
       results,
     });
-    await tx.putPushResult(clientId, frame.clientCommitId, stored);
+    await tx.putPushResult(clientId, clientCommitId, stored);
     await tx.commit();
     if (ctx.events !== undefined) {
       const atMs = clockOf(ctx)();
@@ -1049,7 +1067,7 @@ export async function processPushCommitWithTrace(
           partition,
           actorId: ctx.actorId,
           clientId,
-          clientCommitId: frame.clientCommitId,
+          clientCommitId,
           commitSeq,
           idempotencyKey: reaction.idempotencyKey,
           reactionType: reaction.type,
@@ -1065,7 +1083,7 @@ export async function processPushCommitWithTrace(
         changes,
       });
     }
-    return processedPushCommit(frame.clientCommitId, stored, false);
+    return processedPushCommit(clientCommitId, stored, false);
   } catch (error) {
     if (error instanceof StorageConstraintError) {
       const stored = newStoredPushResult(createdAtMs, {
@@ -1087,11 +1105,11 @@ export async function processPushCommitWithTrace(
         );
       }
       try {
-        await commitRejectedPushResult(clientId, frame.clientCommitId, stored);
+        await commitRejectedPushResult(clientId, clientCommitId, stored);
         const canonical = await storage.getPushResult(
           partition,
           clientId,
-          frame.clientCommitId,
+          clientCommitId,
         );
         if (canonical === undefined) {
           throw new Error(
@@ -1099,7 +1117,7 @@ export async function processPushCommitWithTrace(
           );
         }
         return processedPushCommit(
-          frame.clientCommitId,
+          clientCommitId,
           canonical,
           canonical.cacheIdentity !== stored.cacheIdentity,
         );

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -33,6 +33,12 @@ import type { SyncRequestContext } from './context';
 import { clockOf } from './context';
 import type { CrdtMergerRegistry } from './crdt-merger';
 import { SyncError } from './errors';
+import { emitEvent } from './events';
+import {
+  prepareReactions,
+  type PreparedReaction,
+  toNewReactions,
+} from './reactions';
 import type { CompiledSchema, CompiledTable } from './schema';
 import type { ResolvedScopes } from './scopes';
 import { authorizeWrite, renderScopeValue, storedScopesForRow } from './scopes';
@@ -869,6 +875,7 @@ export async function processPushCommitWithTrace(
   const crdtMergers = ctx.crdtMergers;
   const validators = ctx.validators;
   const commitValidator = ctx.commitValidator;
+  const reactionPlanner = ctx.reactionPlanner;
   const tx = await storage.begin(partition);
   const lockPartitionForPush =
     tx.lockPartitionForPush?.bind(tx) ??
@@ -877,10 +884,11 @@ export async function processPushCommitWithTrace(
   try {
     if (
       lockPartitionForPush === undefined ||
-      commitRejectedPushResult === undefined
+      commitRejectedPushResult === undefined ||
+      (reactionPlanner !== undefined && tx.enqueueReactions === undefined)
     ) {
       throw new Error(
-        'storage transaction does not support serialized push apply and atomic rejection finalization',
+        'storage transaction does not support serialized push apply, atomic rejection finalization, and configured durable reactions',
       );
     }
     await lockPartitionForPush();
@@ -966,6 +974,18 @@ export async function processPushCommitWithTrace(
       }
     }
 
+    let preparedReactions: PreparedReaction[] = [];
+    if (terminated === undefined && reactionPlanner !== undefined) {
+      preparedReactions = await prepareReactions(reactionPlanner, {
+        clientId,
+        clientCommitId: frame.clientCommitId,
+        actorId: ctx.actorId,
+        partition,
+        operations: validatedOperations,
+        read: commitValidationReader(tx, schema),
+      });
+    }
+
     if (terminated !== undefined) {
       // §6.3 rejected: only the terminating operation's record; §6.4:
       // every write of the commit rolls back.
@@ -1000,6 +1020,19 @@ export async function processPushCommitWithTrace(
       createdAtMs,
       changes,
     });
+    const newReactions = toNewReactions(preparedReactions, {
+      clientId,
+      clientCommitId: frame.clientCommitId,
+      commitSeq,
+      createdAtMs,
+    });
+    if (newReactions.length > 0) {
+      const enqueueReactions = tx.enqueueReactions;
+      if (enqueueReactions === undefined) {
+        throw new Error('storage lost durable reaction enqueue support');
+      }
+      await enqueueReactions.call(tx, newReactions);
+    }
     const stored = newStoredPushResult(createdAtMs, {
       status: 'applied',
       commitSeq,
@@ -1007,6 +1040,23 @@ export async function processPushCommitWithTrace(
     });
     await tx.putPushResult(clientId, frame.clientCommitId, stored);
     await tx.commit();
+    if (ctx.events !== undefined) {
+      const atMs = clockOf(ctx)();
+      for (const reaction of newReactions) {
+        emitEvent(ctx.events, {
+          type: 'reaction.queued',
+          atMs,
+          partition,
+          actorId: ctx.actorId,
+          clientId,
+          clientCommitId: frame.clientCommitId,
+          commitSeq,
+          idempotencyKey: reaction.idempotencyKey,
+          reactionType: reaction.type,
+          version: reaction.version,
+        });
+      }
+    }
     if (ctx.realtime !== undefined && changes.length > 0) {
       await ctx.realtime.notifyCommit(partition, {
         commitSeq,

--- a/packages/server/src/reactions.ts
+++ b/packages/server/src/reactions.ts
@@ -1,0 +1,741 @@
+/**
+ * Durable post-commit reactions. Planning runs inside the authoritative push
+ * transaction and may only produce bounded data. Delivery runs later under a
+ * lease and is at-least-once, so handlers receive the stable idempotency key.
+ */
+import type { SyncularServerEvents } from './events';
+import { emitEvent } from './events';
+import type {
+  DurableJsonValue,
+  NewReaction,
+  ReactionFailure,
+  ServerStorage,
+} from './storage';
+import type {
+  CommitValidationReader,
+  ValidateCommitOperation,
+} from './validate';
+
+export const MAX_REACTIONS_PER_COMMIT = 100;
+export const MAX_REACTION_PAYLOAD_BYTES = 64 * 1024;
+export const MAX_REACTION_FAILURE_DETAILS_BYTES = 8 * 1024;
+export const DEFAULT_REACTION_MAX_ATTEMPTS = 10;
+export const DEFAULT_REACTION_LEASE_MS = 30_000;
+export const DEFAULT_REACTION_INITIAL_BACKOFF_MS = 1_000;
+export const DEFAULT_REACTION_MAX_BACKOFF_MS = 5 * 60_000;
+
+export interface ReactionRetentionPolicy {
+  /** Keep completed rows for at least this duration (default 30 days). */
+  readonly completedRetentionMs: number;
+  /** Keep dead letters for at least this duration (default 90 days). */
+  readonly deadLetterRetentionMs: number;
+  /** Maximum terminal rows removed by one pass (default 1000). */
+  readonly batchSize: number;
+}
+
+export const DEFAULT_REACTION_RETENTION: ReactionRetentionPolicy = {
+  completedRetentionMs: 30 * 24 * 60 * 60 * 1000,
+  deadLetterRetentionMs: 90 * 24 * 60 * 60 * 1000,
+  batchSize: 1_000,
+};
+
+export type ReactionTypeMap = Readonly<Record<string, DurableJsonValue>>;
+
+export interface ReactionPlan {
+  /** Unique within the source client commit. */
+  readonly key: string;
+  readonly type: string;
+  readonly version: number;
+  readonly payload: DurableJsonValue;
+  readonly maxAttempts?: number;
+}
+
+export type PlannedReaction<
+  Reactions extends ReactionTypeMap = ReactionTypeMap,
+> = {
+  [Type in keyof Reactions & string]: {
+    /** Unique within the source client commit. */
+    readonly key: string;
+    readonly type: Type;
+    readonly version: number;
+    readonly payload: Reactions[Type];
+    readonly maxAttempts?: number;
+  };
+}[keyof Reactions & string];
+
+export interface ReactionPlannerInput {
+  readonly clientId: string;
+  readonly clientCommitId: string;
+  readonly actorId: string;
+  readonly partition: string;
+  readonly operations: readonly ValidateCommitOperation[];
+  /** Candidate-state reads from the still-open authoritative transaction. */
+  readonly read: CommitValidationReader;
+}
+
+/**
+ * A pure planner over an accepted candidate commit. It may read candidate
+ * state and return durable data. It must not execute user-visible side effects.
+ */
+export type ReactionPlanner<
+  Reactions extends ReactionTypeMap = ReactionTypeMap,
+> = (
+  input: ReactionPlannerInput,
+) =>
+  | readonly PlannedReaction<Reactions>[]
+  | Promise<readonly PlannedReaction<Reactions>[]>;
+
+/** Erased planner shape stored on non-generic server configuration. */
+export type AnyReactionPlanner = (
+  input: ReactionPlannerInput,
+) => readonly ReactionPlan[] | Promise<readonly ReactionPlan[]>;
+
+export interface ReactionHandlerInput<Payload extends DurableJsonValue> {
+  readonly partition: string;
+  readonly idempotencyKey: string;
+  readonly type: string;
+  readonly version: number;
+  readonly payload: Payload;
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  readonly sourceClientId: string;
+  readonly sourceClientCommitId: string;
+  readonly sourceCommitSeq: number;
+  /** Extend a long-running handler's lease; throws after ownership is lost. */
+  readonly extendLease: () => Promise<void>;
+}
+
+export type ReactionHandler<Payload extends DurableJsonValue> = (
+  input: ReactionHandlerInput<Payload>,
+) => void | Promise<void>;
+
+export type ReactionHandlers<
+  Reactions extends ReactionTypeMap = ReactionTypeMap,
+> = {
+  readonly [Type in keyof Reactions & string]: ReactionHandler<Reactions[Type]>;
+};
+
+function normalizedJson(
+  value: unknown,
+  path: string,
+  depth = 0,
+): DurableJsonValue {
+  if (depth > 16) throw new Error(`${path} exceeds the maximum JSON depth`);
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'string'
+  ) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error(`${path} must be finite`);
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const key of Reflect.ownKeys(value)) {
+      if (key === 'length') continue;
+      if (
+        typeof key !== 'string' ||
+        !/^(?:0|[1-9][0-9]*)$/.test(key) ||
+        Number(key) >= value.length
+      ) {
+        throw new Error(`${path} arrays cannot carry extra properties`);
+      }
+    }
+    const output: DurableJsonValue[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (descriptor === undefined || !('value' in descriptor)) {
+        throw new Error(`${path}[${index}] must be a plain JSON value`);
+      }
+      output.push(
+        normalizedJson(descriptor.value, `${path}[${index}]`, depth + 1),
+      );
+    }
+    return output;
+  }
+  if (typeof value !== 'object') {
+    throw new Error(`${path} must contain only JSON values`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${path} must contain only plain JSON objects`);
+  }
+  const output: Record<string, DurableJsonValue> = {};
+  const entries: [string, unknown][] = [];
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string') {
+      throw new Error(`${path} cannot contain symbol keys`);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (
+      descriptor === undefined ||
+      !descriptor.enumerable ||
+      !('value' in descriptor)
+    ) {
+      throw new Error(`${path}.${key} must be an enumerable data property`);
+    }
+    entries.push([key, descriptor.value]);
+  }
+  for (const [key, entry] of entries.sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    Object.defineProperty(output, key, {
+      value: normalizedJson(entry, `${path}.${key}`, depth + 1),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return output;
+}
+
+function boundedJson(
+  value: unknown,
+  path: string,
+  maxBytes: number,
+): DurableJsonValue {
+  const normalized = normalizedJson(value, path);
+  if (
+    new TextEncoder().encode(JSON.stringify(normalized)).byteLength > maxBytes
+  ) {
+    throw new Error(`${path} exceeds ${maxBytes} persisted bytes`);
+  }
+  return normalized;
+}
+
+function assertName(value: string, field: string, maxBytes: number): void {
+  if (
+    !/^[A-Za-z][A-Za-z0-9._:-]*$/.test(value) ||
+    new TextEncoder().encode(value).byteLength > maxBytes
+  ) {
+    throw new Error(
+      `${field} must be a code-like string no longer than ${maxBytes} bytes`,
+    );
+  }
+}
+
+/** Stable handler idempotency key for one planned item in a client commit. */
+export function reactionIdempotencyKey(
+  partition: string,
+  clientId: string,
+  clientCommitId: string,
+  plannerKey: string,
+): string {
+  return JSON.stringify([partition, clientId, clientCommitId, plannerKey]);
+}
+
+export interface PreparedReaction {
+  readonly idempotencyKey: string;
+  readonly type: string;
+  readonly version: number;
+  readonly payload: DurableJsonValue;
+  readonly maxAttempts: number;
+}
+
+/** Internal push seam, exported for focused planner tests and custom hosts. */
+export async function prepareReactions(
+  planner: AnyReactionPlanner,
+  input: ReactionPlannerInput,
+): Promise<PreparedReaction[]> {
+  const planned = await planner(input);
+  if (!Array.isArray(planned)) {
+    throw new Error('reaction planner must return an array');
+  }
+  if (planned.length > MAX_REACTIONS_PER_COMMIT) {
+    throw new Error(
+      `reaction planner returned more than ${MAX_REACTIONS_PER_COMMIT} records`,
+    );
+  }
+  const keys = new Set<string>();
+  return planned.map((reaction, index) => {
+    assertName(reaction.type, `reaction[${index}].type`, 128);
+    if (
+      reaction.key.length === 0 ||
+      new TextEncoder().encode(reaction.key).byteLength > 256
+    ) {
+      throw new Error(
+        `reaction[${index}].key must be non-empty and no longer than 256 bytes`,
+      );
+    }
+    if (keys.has(reaction.key)) {
+      throw new Error(
+        `reaction planner returned duplicate key at index ${index}`,
+      );
+    }
+    keys.add(reaction.key);
+    if (
+      !Number.isSafeInteger(reaction.version) ||
+      reaction.version < 1 ||
+      reaction.version > 2_147_483_647
+    ) {
+      throw new Error(`reaction[${index}].version must be a positive int32`);
+    }
+    const maxAttempts = reaction.maxAttempts ?? DEFAULT_REACTION_MAX_ATTEMPTS;
+    if (
+      !Number.isSafeInteger(maxAttempts) ||
+      maxAttempts < 1 ||
+      maxAttempts > 100
+    ) {
+      throw new Error(
+        `reaction[${index}].maxAttempts must be from 1 through 100`,
+      );
+    }
+    return {
+      idempotencyKey: reactionIdempotencyKey(
+        input.partition,
+        input.clientId,
+        input.clientCommitId,
+        reaction.key,
+      ),
+      type: reaction.type,
+      version: reaction.version,
+      payload: boundedJson(
+        reaction.payload,
+        `reaction[${index}].payload`,
+        MAX_REACTION_PAYLOAD_BYTES,
+      ),
+      maxAttempts,
+    };
+  });
+}
+
+class ReactionDeliveryError extends Error {
+  readonly code: string;
+  readonly details?: { readonly [key: string]: DurableJsonValue };
+
+  constructor(
+    name: string,
+    code: string,
+    details?: { readonly [key: string]: DurableJsonValue },
+  ) {
+    super(code);
+    this.name = name;
+    assertName(code, `${name}.code`, 128);
+    this.code = code;
+    if (details !== undefined) {
+      this.details = boundedJson(
+        details,
+        `${name}.details`,
+        MAX_REACTION_FAILURE_DETAILS_BYTES,
+      ) as { readonly [key: string]: DurableJsonValue };
+    }
+  }
+}
+
+/** A handler failure that should be retried until its attempt limit. */
+export class RetryableReactionError extends ReactionDeliveryError {
+  constructor(
+    code: string,
+    details?: { readonly [key: string]: DurableJsonValue },
+  ) {
+    super('RetryableReactionError', code, details);
+  }
+}
+
+/** A handler failure that should be dead-lettered immediately. */
+export class PermanentReactionError extends ReactionDeliveryError {
+  constructor(
+    code: string,
+    details?: { readonly [key: string]: DurableJsonValue },
+  ) {
+    super('PermanentReactionError', code, details);
+  }
+}
+
+export interface ReactionRunnerOptions<
+  Reactions extends ReactionTypeMap = ReactionTypeMap,
+> {
+  readonly storage: ServerStorage;
+  readonly partition: string;
+  readonly workerId: string;
+  readonly handlers: ReactionHandlers<Reactions>;
+  readonly events?: SyncularServerEvents;
+  readonly clock?: () => number;
+  readonly leaseDurationMs?: number;
+  readonly batchSize?: number;
+  readonly initialBackoffMs?: number;
+  readonly maxBackoffMs?: number;
+}
+
+export interface ReactionRunResult {
+  readonly claimed: number;
+  readonly completed: number;
+  readonly retried: number;
+  readonly deadLettered: number;
+  /** Lease ownership changed before this worker could persist its outcome. */
+  readonly lostLeases: number;
+}
+
+export interface PruneReactionsOptions {
+  readonly storage: ServerStorage;
+  readonly partition: string;
+  readonly nowMs: number;
+  readonly retention?: Partial<ReactionRetentionPolicy>;
+  readonly events?: SyncularServerEvents;
+}
+
+export interface ReactionPruneResult {
+  readonly completedBeforeMs: number;
+  readonly deadLetterBeforeMs: number;
+  readonly removedCompleted: number;
+  readonly removedDeadLetter: number;
+  /** True when the bounded pass filled its batch and another pass may help. */
+  readonly mayHaveMore: boolean;
+}
+
+function requiredLifecycle(storage: ServerStorage): void {
+  if (
+    storage.claimReactions === undefined ||
+    storage.completeReaction === undefined ||
+    storage.extendReactionLease === undefined ||
+    storage.failReaction === undefined
+  ) {
+    throw new Error('storage does not implement durable reaction delivery');
+  }
+}
+
+/** Host-driven worker. Call `runOnce` from the host scheduler or queue wake. */
+export class ReactionRunner<
+  Reactions extends ReactionTypeMap = ReactionTypeMap,
+> {
+  readonly #options: ReactionRunnerOptions<Reactions>;
+  readonly #types: string[];
+  readonly #clock: () => number;
+  readonly #leaseDurationMs: number;
+  readonly #batchSize: number;
+  readonly #initialBackoffMs: number;
+  readonly #maxBackoffMs: number;
+
+  constructor(options: ReactionRunnerOptions<Reactions>) {
+    requiredLifecycle(options.storage);
+    assertName(options.workerId, 'workerId', 128);
+    this.#types = Object.keys(options.handlers).sort();
+    if (this.#types.length === 0 || this.#types.length > 64) {
+      throw new Error('reaction runner requires from 1 through 64 handlers');
+    }
+    for (const type of this.#types) assertName(type, 'handler type', 128);
+    this.#leaseDurationMs =
+      options.leaseDurationMs ?? DEFAULT_REACTION_LEASE_MS;
+    this.#batchSize = options.batchSize ?? 10;
+    this.#initialBackoffMs =
+      options.initialBackoffMs ?? DEFAULT_REACTION_INITIAL_BACKOFF_MS;
+    this.#maxBackoffMs =
+      options.maxBackoffMs ?? DEFAULT_REACTION_MAX_BACKOFF_MS;
+    for (const [name, value] of [
+      ['leaseDurationMs', this.#leaseDurationMs],
+      ['batchSize', this.#batchSize],
+      ['initialBackoffMs', this.#initialBackoffMs],
+      ['maxBackoffMs', this.#maxBackoffMs],
+    ] as const) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new Error(`${name} must be a positive safe integer`);
+      }
+    }
+    if (this.#batchSize > 100) throw new Error('batchSize cannot exceed 100');
+    if (this.#initialBackoffMs > this.#maxBackoffMs) {
+      throw new Error('initialBackoffMs cannot exceed maxBackoffMs');
+    }
+    this.#options = options;
+    this.#clock = options.clock ?? Date.now;
+  }
+
+  async runOnce(): Promise<ReactionRunResult> {
+    const claim = this.#options.storage.claimReactions;
+    const complete = this.#options.storage.completeReaction;
+    const extend = this.#options.storage.extendReactionLease;
+    const fail = this.#options.storage.failReaction;
+    if (
+      claim === undefined ||
+      complete === undefined ||
+      extend === undefined ||
+      fail === undefined
+    ) {
+      throw new Error('storage lost durable reaction delivery support');
+    }
+    const leaseOwner = `${this.#options.workerId}:${crypto.randomUUID()}`;
+    const reactions = await claim.call(
+      this.#options.storage,
+      this.#options.partition,
+      {
+        leaseOwner,
+        types: this.#types,
+        nowMs: this.#clock(),
+        leaseDurationMs: this.#leaseDurationMs,
+        limit: this.#batchSize,
+      },
+    );
+    let completed = 0;
+    let retried = 0;
+    let deadLettered = 0;
+    let lostLeases = 0;
+    for (const reaction of reactions) {
+      const events = this.#options.events;
+      const startedAtMs = this.#clock();
+      const stillOwned = await extend.call(
+        this.#options.storage,
+        this.#options.partition,
+        reaction.idempotencyKey,
+        leaseOwner,
+        Math.min(Number.MAX_SAFE_INTEGER, startedAtMs + this.#leaseDurationMs),
+      );
+      if (!stillOwned) {
+        lostLeases += 1;
+        continue;
+      }
+      if (events !== undefined) {
+        emitEvent(events, {
+          type: 'reaction.started',
+          atMs: startedAtMs,
+          partition: this.#options.partition,
+          workerId: this.#options.workerId,
+          idempotencyKey: reaction.idempotencyKey,
+          reactionType: reaction.type,
+          version: reaction.version,
+          attempt: reaction.attempts,
+        });
+      }
+      let handlerFailed = false;
+      let handlerError: unknown;
+      try {
+        const handler = this.#options.handlers[reaction.type];
+        if (handler === undefined) {
+          throw new PermanentReactionError('reaction.handler_missing');
+        }
+        await handler({
+          partition: this.#options.partition,
+          idempotencyKey: reaction.idempotencyKey,
+          type: reaction.type,
+          version: reaction.version,
+          payload: reaction.payload as Reactions[string],
+          attempt: reaction.attempts,
+          maxAttempts: reaction.maxAttempts,
+          sourceClientId: reaction.sourceClientId,
+          sourceClientCommitId: reaction.sourceClientCommitId,
+          sourceCommitSeq: reaction.sourceCommitSeq,
+          extendLease: async () => {
+            const renewed = await extend.call(
+              this.#options.storage,
+              this.#options.partition,
+              reaction.idempotencyKey,
+              leaseOwner,
+              Math.min(
+                Number.MAX_SAFE_INTEGER,
+                this.#clock() + this.#leaseDurationMs,
+              ),
+            );
+            if (!renewed) throw new Error('reaction lease ownership lost');
+          },
+        });
+      } catch (error) {
+        handlerFailed = true;
+        handlerError = error;
+      }
+      if (!handlerFailed) {
+        const atMs = this.#clock();
+        const acknowledged = await complete.call(
+          this.#options.storage,
+          this.#options.partition,
+          reaction.idempotencyKey,
+          leaseOwner,
+          atMs,
+        );
+        if (!acknowledged) {
+          lostLeases += 1;
+          continue;
+        }
+        completed += 1;
+        if (events !== undefined) {
+          emitEvent(events, {
+            type: 'reaction.completed',
+            atMs,
+            partition: this.#options.partition,
+            workerId: this.#options.workerId,
+            idempotencyKey: reaction.idempotencyKey,
+            reactionType: reaction.type,
+            version: reaction.version,
+            attempt: reaction.attempts,
+          });
+        }
+        continue;
+      }
+      const atMs = this.#clock();
+      const permanent = handlerError instanceof PermanentReactionError;
+      const failure: ReactionFailure = {
+        code:
+          handlerError instanceof ReactionDeliveryError
+            ? handlerError.code
+            : 'reaction.handler_failed',
+        atMs,
+        ...(handlerError instanceof ReactionDeliveryError &&
+        handlerError.details !== undefined
+          ? { details: handlerError.details }
+          : {}),
+      };
+      const deadLetter = permanent || reaction.attempts >= reaction.maxAttempts;
+      const retryAtMs = deadLetter
+        ? undefined
+        : Math.min(
+            Number.MAX_SAFE_INTEGER,
+            atMs +
+              Math.min(
+                this.#maxBackoffMs,
+                this.#initialBackoffMs *
+                  2 ** Math.min(30, reaction.attempts - 1),
+              ),
+          );
+      const recorded = await fail.call(
+        this.#options.storage,
+        this.#options.partition,
+        reaction.idempotencyKey,
+        {
+          leaseOwner,
+          failure,
+          ...(retryAtMs !== undefined ? { retryAtMs } : {}),
+        },
+      );
+      if (!recorded) {
+        lostLeases += 1;
+        continue;
+      }
+      if (retryAtMs !== undefined) {
+        retried += 1;
+        if (events !== undefined) {
+          emitEvent(events, {
+            type: 'reaction.retried',
+            atMs,
+            partition: this.#options.partition,
+            workerId: this.#options.workerId,
+            idempotencyKey: reaction.idempotencyKey,
+            reactionType: reaction.type,
+            version: reaction.version,
+            attempt: reaction.attempts,
+            nextAttemptAtMs: retryAtMs,
+            errorCode: failure.code,
+          });
+        }
+      } else {
+        deadLettered += 1;
+        if (events !== undefined) {
+          emitEvent(events, {
+            type: 'reaction.dead_lettered',
+            atMs,
+            partition: this.#options.partition,
+            workerId: this.#options.workerId,
+            idempotencyKey: reaction.idempotencyKey,
+            reactionType: reaction.type,
+            version: reaction.version,
+            attempt: reaction.attempts,
+            errorCode: failure.code,
+          });
+        }
+      }
+    }
+    return {
+      claimed: reactions.length,
+      completed,
+      retried,
+      deadLettered,
+      lostLeases,
+    };
+  }
+}
+
+/** Explicit operator action for a dead-lettered reaction. */
+export async function retryDeadLetterReaction(options: {
+  readonly storage: ServerStorage;
+  readonly partition: string;
+  readonly idempotencyKey: string;
+  readonly nowMs?: number;
+}): Promise<boolean> {
+  if (options.storage.retryReaction === undefined) {
+    throw new Error('storage does not implement durable reaction retry');
+  }
+  return options.storage.retryReaction(
+    options.partition,
+    options.idempotencyKey,
+    options.nowMs ?? Date.now(),
+  );
+}
+
+/** Delete one bounded batch of aged completed and dead-lettered rows. */
+export async function pruneReactions(
+  options: PruneReactionsOptions,
+): Promise<ReactionPruneResult> {
+  const retention = {
+    ...DEFAULT_REACTION_RETENTION,
+    ...options.retention,
+  };
+  if (!Number.isSafeInteger(options.nowMs)) {
+    throw new Error('nowMs must be a safe integer');
+  }
+  for (const [name, value] of [
+    ['completedRetentionMs', retention.completedRetentionMs],
+    ['deadLetterRetentionMs', retention.deadLetterRetentionMs],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`${name} must be a non-negative safe integer`);
+    }
+  }
+  if (
+    !Number.isSafeInteger(retention.batchSize) ||
+    retention.batchSize < 1 ||
+    retention.batchSize > 10_000
+  ) {
+    throw new Error('batchSize must be from 1 through 10000');
+  }
+  const prune = options.storage.pruneReactions;
+  if (prune === undefined) {
+    throw new Error('storage does not implement durable reaction pruning');
+  }
+  const completedBeforeMs = Math.max(
+    Number.MIN_SAFE_INTEGER,
+    options.nowMs - retention.completedRetentionMs,
+  );
+  const deadLetterBeforeMs = Math.max(
+    Number.MIN_SAFE_INTEGER,
+    options.nowMs - retention.deadLetterRetentionMs,
+  );
+  const removed = await prune.call(options.storage, options.partition, {
+    completedBeforeMs,
+    deadLetterBeforeMs,
+    limit: retention.batchSize,
+  });
+  const result: ReactionPruneResult = {
+    completedBeforeMs,
+    deadLetterBeforeMs,
+    removedCompleted: removed.completed,
+    removedDeadLetter: removed.deadLetter,
+    mayHaveMore: removed.completed + removed.deadLetter === retention.batchSize,
+  };
+  if (options.events !== undefined) {
+    emitEvent(options.events, {
+      type: 'reaction.prune_completed',
+      atMs: options.nowMs,
+      partition: options.partition,
+      limit: retention.batchSize,
+      ...result,
+    });
+  }
+  return result;
+}
+
+/** Helper used by the push path after commit sequence allocation. */
+export function toNewReactions(
+  prepared: readonly PreparedReaction[],
+  source: {
+    readonly clientId: string;
+    readonly clientCommitId: string;
+    readonly commitSeq: number;
+    readonly createdAtMs: number;
+  },
+): NewReaction[] {
+  return prepared.map((reaction) => ({
+    ...reaction,
+    sourceClientId: source.clientId,
+    sourceClientCommitId: source.clientCommitId,
+    sourceCommitSeq: source.commitSeq,
+    createdAtMs: source.createdAtMs,
+  }));
+}

--- a/packages/server/src/realtime.ts
+++ b/packages/server/src/realtime.ts
@@ -31,7 +31,7 @@ import {
   type WakeReason,
 } from '@syncular/core';
 import type { SyncRequestContext, SyncServerConfig } from './context';
-import { RESOLVER_OUTAGE } from './context';
+import { REMOTE_COMMAND_CLIENT_ID_PREFIX, RESOLVER_OUTAGE } from './context';
 import { SyncError, syncError } from './errors';
 import { emitEvent, type SyncularServerEvents } from './events';
 import { createSyncResponseStream } from './handler';
@@ -963,6 +963,12 @@ export class RealtimeHub {
   async connect(options: RealtimeConnectOptions): Promise<RealtimeSession> {
     const { storage } = this.#config;
     const clock = this.#config.clock ?? Date.now;
+    if (options.clientId.startsWith(REMOTE_COMMAND_CLIENT_ID_PREFIX)) {
+      throw syncError(
+        'sync.invalid_client_id',
+        'clientId uses a reserved server-command namespace (§1.5)',
+      );
+    }
     const record = await storage.getClientRecord(
       options.partition,
       options.clientId,

--- a/packages/server/src/sqlite-dialect.ts
+++ b/packages/server/src/sqlite-dialect.ts
@@ -74,6 +74,26 @@ CREATE TABLE IF NOT EXISTS sync_push_results(
   client_commit_id TEXT NOT NULL, result TEXT NOT NULL,
   PRIMARY KEY(partition, client_id, client_commit_id)
 );
+CREATE TABLE IF NOT EXISTS sync_reactions(
+  partition TEXT NOT NULL, idempotency_key TEXT NOT NULL,
+  type TEXT NOT NULL, version INTEGER NOT NULL, payload TEXT NOT NULL,
+  source_client_id TEXT NOT NULL, source_client_commit_id TEXT NOT NULL,
+  source_commit_seq INTEGER NOT NULL, created_at_ms INTEGER NOT NULL,
+  available_at_ms INTEGER NOT NULL, status TEXT NOT NULL,
+  attempts INTEGER NOT NULL, max_attempts INTEGER NOT NULL,
+  lease_owner TEXT, lease_expires_at_ms INTEGER, completed_at_ms INTEGER,
+  last_failure TEXT,
+  PRIMARY KEY(partition, idempotency_key),
+  CHECK(status IN ('pending', 'leased', 'completed', 'dead-letter'))
+);
+CREATE INDEX IF NOT EXISTS sync_reactions_due
+  ON sync_reactions(partition, status, available_at_ms, created_at_ms, idempotency_key);
+CREATE INDEX IF NOT EXISTS sync_reactions_lease
+  ON sync_reactions(partition, status, lease_expires_at_ms);
+CREATE INDEX IF NOT EXISTS sync_reactions_completed
+  ON sync_reactions(partition, status, completed_at_ms, idempotency_key);
+CREATE INDEX IF NOT EXISTS sync_reactions_dead_letter
+  ON sync_reactions(partition, status, available_at_ms, idempotency_key);
 CREATE TABLE IF NOT EXISTS sync_clients(
   partition TEXT NOT NULL, client_id TEXT NOT NULL, actor_id TEXT NOT NULL,
   cursor INTEGER NOT NULL, subscriptions TEXT NOT NULL,

--- a/packages/server/src/sqlite-storage.ts
+++ b/packages/server/src/sqlite-storage.ts
@@ -48,8 +48,16 @@ import type {
   CommitMetadata,
   CommitMetadataQuery,
   CommitWindowQuery,
+  DurableJsonValue,
   IndexRowScanQuery,
   NewCommit,
+  NewReaction,
+  PrunedReactionCounts,
+  ReactionClaimQuery,
+  ReactionFailure,
+  ReactionFailureUpdate,
+  ReactionListQuery,
+  ReactionPruneQuery,
   RowScanQuery,
   ScopeActivityQuery,
   ScopeCommitActivity,
@@ -57,6 +65,7 @@ import type {
   StorageTransaction,
   StoredCommit,
   StoredPushResult,
+  StoredReaction,
   StoredRow,
 } from './storage';
 import {
@@ -64,6 +73,53 @@ import {
   StorageConstraintError,
 } from './storage-errors';
 import { assertScopeIndexedScan, resolveIndexRowScan } from './storage-query';
+
+interface SqliteReactionRecord {
+  partition: string;
+  idempotency_key: string;
+  type: string;
+  version: number;
+  payload: string;
+  source_client_id: string;
+  source_client_commit_id: string;
+  source_commit_seq: number;
+  created_at_ms: number;
+  available_at_ms: number;
+  status: StoredReaction['status'];
+  attempts: number;
+  max_attempts: number;
+  lease_owner: string | null;
+  lease_expires_at_ms: number | null;
+  completed_at_ms: number | null;
+  last_failure: string | null;
+}
+
+function toStoredReaction(record: SqliteReactionRecord): StoredReaction {
+  return {
+    idempotencyKey: record.idempotency_key,
+    type: record.type,
+    version: record.version,
+    payload: JSON.parse(record.payload) as DurableJsonValue,
+    sourceClientId: record.source_client_id,
+    sourceClientCommitId: record.source_client_commit_id,
+    sourceCommitSeq: record.source_commit_seq,
+    createdAtMs: record.created_at_ms,
+    maxAttempts: record.max_attempts,
+    status: record.status,
+    attempts: record.attempts,
+    availableAtMs: record.available_at_ms,
+    ...(record.lease_owner !== null ? { leaseOwner: record.lease_owner } : {}),
+    ...(record.lease_expires_at_ms !== null
+      ? { leaseExpiresAtMs: record.lease_expires_at_ms }
+      : {}),
+    ...(record.completed_at_ms !== null
+      ? { completedAtMs: record.completed_at_ms }
+      : {}),
+    ...(record.last_failure !== null
+      ? { lastFailure: JSON.parse(record.last_failure) as ReactionFailure }
+      : {}),
+  };
+}
 
 class SqliteTransaction implements StorageTransaction {
   #storage: SqliteServerStorage;
@@ -256,6 +312,32 @@ class SqliteTransaction implements StorageTransaction {
       );
   }
 
+  async enqueueReactions(reactions: readonly NewReaction[]): Promise<void> {
+    this.#assertOpen();
+    const statement = this.#storage.db.query(
+      `INSERT INTO sync_reactions(
+         partition, idempotency_key, type, version, payload,
+         source_client_id, source_client_commit_id, source_commit_seq,
+         created_at_ms, available_at_ms, status, attempts, max_attempts
+       ) VALUES (?,?,?,?,?,?,?,?,?,?,'pending',0,?)`,
+    );
+    for (const reaction of reactions) {
+      statement.run(
+        this.#partition,
+        reaction.idempotencyKey,
+        reaction.type,
+        reaction.version,
+        JSON.stringify(reaction.payload),
+        reaction.sourceClientId,
+        reaction.sourceClientCommitId,
+        reaction.sourceCommitSeq,
+        reaction.createdAtMs,
+        reaction.createdAtMs,
+        reaction.maxAttempts,
+      );
+    }
+  }
+
   async commit(): Promise<void> {
     this.#assertOpen();
     try {
@@ -296,6 +378,20 @@ export class SqliteServerStorage implements ServerStorage {
   /** Set by `ensureSchema`: app-table lookup for the relational row store. */
   #tables: ReadonlyMap<string, CompiledTable> | undefined;
   #schemaVersion: number | undefined;
+
+  async #serializeReactionWrite<T>(operation: () => T): Promise<T> {
+    const previous = this.#transactionTail;
+    let release!: () => void;
+    this.#transactionTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return operation();
+    } finally {
+      release();
+    }
+  }
 
   constructor(db: Database | string = ':memory:') {
     this.db = typeof db === 'string' ? new Database(db) : db;
@@ -573,6 +669,219 @@ export class SqliteServerStorage implements ServerStorage {
         'persisted push result unreadable (§6.3)',
       );
     }
+  }
+
+  async claimReactions(
+    partition: string,
+    query: ReactionClaimQuery,
+  ): Promise<StoredReaction[]> {
+    if (query.types.length === 0 || query.limit <= 0) return [];
+    return this.#serializeReactionWrite(() => {
+      const typeParams = query.types.map(() => '?').join(',');
+      const records = this.db
+        .query<SqliteReactionRecord, (string | number)[]>(
+          `UPDATE sync_reactions
+            SET status='leased', attempts=attempts+1,
+                lease_owner=?, lease_expires_at_ms=?, completed_at_ms=NULL
+          WHERE (partition, idempotency_key) IN (
+            SELECT partition, idempotency_key
+              FROM sync_reactions
+             WHERE partition=? AND type IN (${typeParams})
+               AND ((status='pending' AND available_at_ms<=?)
+                 OR (status='leased' AND lease_expires_at_ms<=?))
+             ORDER BY CASE WHEN status='leased' THEN lease_expires_at_ms
+                           ELSE available_at_ms END,
+                      created_at_ms, idempotency_key
+             LIMIT ?
+          )
+        RETURNING *`,
+        )
+        .all(
+          query.leaseOwner,
+          Math.min(
+            Number.MAX_SAFE_INTEGER,
+            query.nowMs + query.leaseDurationMs,
+          ),
+          partition,
+          ...query.types,
+          query.nowMs,
+          query.nowMs,
+          query.limit,
+        );
+      return records
+        .map(toStoredReaction)
+        .sort(
+          (a, b) =>
+            a.createdAtMs - b.createdAtMs ||
+            a.idempotencyKey.localeCompare(b.idempotencyKey),
+        );
+    });
+  }
+
+  async completeReaction(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    completedAtMs: number,
+  ): Promise<boolean> {
+    return this.#serializeReactionWrite(() => {
+      const result = this.db
+        .query(
+          `UPDATE sync_reactions
+            SET status='completed', completed_at_ms=?,
+                lease_owner=NULL, lease_expires_at_ms=NULL
+          WHERE partition=? AND idempotency_key=?
+            AND status='leased' AND lease_owner=?`,
+        )
+        .run(completedAtMs, partition, idempotencyKey, leaseOwner);
+      return Number(result.changes) === 1;
+    });
+  }
+
+  async extendReactionLease(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    leaseExpiresAtMs: number,
+  ): Promise<boolean> {
+    return this.#serializeReactionWrite(() => {
+      const result = this.db
+        .query(
+          `UPDATE sync_reactions SET lease_expires_at_ms=?
+          WHERE partition=? AND idempotency_key=?
+            AND status='leased' AND lease_owner=?`,
+        )
+        .run(leaseExpiresAtMs, partition, idempotencyKey, leaseOwner);
+      return Number(result.changes) === 1;
+    });
+  }
+
+  async failReaction(
+    partition: string,
+    idempotencyKey: string,
+    update: ReactionFailureUpdate,
+  ): Promise<boolean> {
+    const retry = update.retryAtMs !== undefined;
+    return this.#serializeReactionWrite(() => {
+      const result = this.db
+        .query(
+          `UPDATE sync_reactions
+            SET status=?, available_at_ms=?, last_failure=?,
+                lease_owner=NULL, lease_expires_at_ms=NULL
+          WHERE partition=? AND idempotency_key=?
+            AND status='leased' AND lease_owner=?`,
+        )
+        .run(
+          retry ? 'pending' : 'dead-letter',
+          update.retryAtMs ?? update.failure.atMs,
+          JSON.stringify(update.failure),
+          partition,
+          idempotencyKey,
+          update.leaseOwner,
+        );
+      return Number(result.changes) === 1;
+    });
+  }
+
+  async retryReaction(
+    partition: string,
+    idempotencyKey: string,
+    nowMs: number,
+  ): Promise<boolean> {
+    return this.#serializeReactionWrite(() => {
+      const result = this.db
+        .query(
+          `UPDATE sync_reactions
+            SET status='pending', attempts=0, available_at_ms=?,
+                last_failure=NULL, lease_owner=NULL, lease_expires_at_ms=NULL,
+                completed_at_ms=NULL
+          WHERE partition=? AND idempotency_key=? AND status='dead-letter'`,
+        )
+        .run(nowMs, partition, idempotencyKey);
+      return Number(result.changes) === 1;
+    });
+  }
+
+  async getReaction(
+    partition: string,
+    idempotencyKey: string,
+  ): Promise<StoredReaction | undefined> {
+    const record = this.db
+      .query<SqliteReactionRecord, [string, string]>(
+        'SELECT * FROM sync_reactions WHERE partition=? AND idempotency_key=?',
+      )
+      .get(partition, idempotencyKey);
+    return record === null ? undefined : toStoredReaction(record);
+  }
+
+  async listReactions(
+    partition: string,
+    query: ReactionListQuery,
+  ): Promise<StoredReaction[]> {
+    const where = ['partition=?'];
+    const params: (string | number)[] = [partition];
+    if (query.statuses !== undefined && query.statuses.length > 0) {
+      where.push(`status IN (${query.statuses.map(() => '?').join(',')})`);
+      params.push(...query.statuses);
+    }
+    if (query.types !== undefined && query.types.length > 0) {
+      where.push(`type IN (${query.types.map(() => '?').join(',')})`);
+      params.push(...query.types);
+    }
+    params.push(query.limit);
+    const records = this.db
+      .query<SqliteReactionRecord, (string | number)[]>(
+        `SELECT * FROM sync_reactions WHERE ${where.join(' AND ')}
+          ORDER BY created_at_ms DESC, idempotency_key DESC LIMIT ?`,
+      )
+      .all(...params);
+    return records.map(toStoredReaction);
+  }
+
+  async pruneReactions(
+    partition: string,
+    query: ReactionPruneQuery,
+  ): Promise<PrunedReactionCounts> {
+    if (query.limit <= 0) return { completed: 0, deadLetter: 0 };
+    return this.#serializeReactionWrite(() => {
+      const records = this.db
+        .query<
+          { status: 'completed' | 'dead-letter' },
+          [string, string, number, number, number, number, number]
+        >(
+          `DELETE FROM sync_reactions
+            WHERE partition=? AND idempotency_key IN (
+              SELECT idempotency_key FROM sync_reactions
+               WHERE partition=?
+                 AND ((status='completed' AND completed_at_ms IS NOT NULL
+                       AND completed_at_ms<?)
+                   OR (status='dead-letter' AND available_at_ms<?))
+               ORDER BY CASE WHEN status='completed' THEN completed_at_ms
+                             ELSE available_at_ms END,
+                        idempotency_key
+               LIMIT ?
+            )
+              AND ((status='completed' AND completed_at_ms IS NOT NULL
+                    AND completed_at_ms<?)
+                OR (status='dead-letter' AND available_at_ms<?))
+          RETURNING status`,
+        )
+        .all(
+          partition,
+          partition,
+          query.completedBeforeMs,
+          query.deadLetterBeforeMs,
+          query.limit,
+          query.completedBeforeMs,
+          query.deadLetterBeforeMs,
+        );
+      return {
+        completed: records.filter((record) => record.status === 'completed')
+          .length,
+        deadLetter: records.filter((record) => record.status === 'dead-letter')
+          .length,
+      };
+    });
   }
 
   async readCommitWindow(

--- a/packages/server/src/sqlite-storage.ts
+++ b/packages/server/src/sqlite-storage.ts
@@ -7,6 +7,10 @@
  * match against the stored scope map — never a log scan.
  */
 import { Database } from 'bun:sqlite';
+import {
+  bindAuthoritativePartition,
+  prepareAuthoritativeQuery,
+} from './authoritative-query';
 import { syncError } from './errors';
 import {
   commitWindowPageSql,
@@ -42,6 +46,9 @@ import {
   toStoredRow,
 } from './sqlite-dialect';
 import type {
+  AuthoritativeQueryRequest,
+  AuthoritativeQueryResult,
+  AuthoritativeQueryValue,
   ClientCursorInfo,
   ClientRecord,
   ClientSubscription,
@@ -590,6 +597,55 @@ export class SqliteServerStorage implements ServerStorage {
       )
       .get(partition);
     return row?.max_commit_seq ?? 0;
+  }
+
+  async queryAuthoritative(
+    partition: string,
+    query: AuthoritativeQueryRequest,
+  ): Promise<AuthoritativeQueryResult> {
+    if (this.#tables === undefined) {
+      throw new Error(
+        'ensureSchema(schema) must run before registered queries',
+      );
+    }
+    const prepared = bindAuthoritativePartition(
+      prepareAuthoritativeQuery(
+        query.sql,
+        query.params,
+        query.tables,
+        this.#tables,
+      ),
+      partition,
+    );
+    const previous = this.#transactionTail;
+    let release!: () => void;
+    this.#transactionTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    let open = false;
+    try {
+      this.db.exec('BEGIN');
+      open = true;
+      const rows = this.db
+        .query<Readonly<Record<string, unknown>>, AuthoritativeQueryValue[]>(
+          prepared.sql,
+        )
+        .all(...prepared.params);
+      const cursor = this.db
+        .query<{ max_commit_seq: number }, [string]>(
+          'SELECT max_commit_seq FROM sync_partitions WHERE partition=?',
+        )
+        .get(partition);
+      this.db.exec('COMMIT');
+      open = false;
+      return { rows, maxCommitSeq: cursor?.max_commit_seq ?? 0 };
+    } catch (error) {
+      if (open) this.db.exec('ROLLBACK');
+      throw error;
+    } finally {
+      release();
+    }
   }
 
   async getHorizonSeq(partition: string): Promise<number> {

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -65,6 +65,83 @@ export interface StoredCommit {
   readonly changes: readonly StoredChange[];
 }
 
+/** JSON values accepted by the durable reaction payload/failure store. */
+export type DurableJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly DurableJsonValue[]
+  | { readonly [key: string]: DurableJsonValue };
+
+export type ReactionStatus = 'pending' | 'leased' | 'completed' | 'dead-letter';
+
+export interface ReactionFailure {
+  /** Stable application or Syncular error identity. */
+  readonly code: string;
+  readonly atMs: number;
+  /** Bounded JSON metadata. Diagnostic exception text is never persisted. */
+  readonly details?: { readonly [key: string]: DurableJsonValue };
+}
+
+/** A validated reaction row written with its source commit. */
+export interface NewReaction {
+  readonly idempotencyKey: string;
+  readonly type: string;
+  readonly version: number;
+  readonly payload: DurableJsonValue;
+  readonly sourceClientId: string;
+  readonly sourceClientCommitId: string;
+  readonly sourceCommitSeq: number;
+  readonly createdAtMs: number;
+  readonly maxAttempts: number;
+}
+
+/** Durable reaction state returned to workers and administrative readers. */
+export interface StoredReaction extends NewReaction {
+  readonly status: ReactionStatus;
+  /** Incremented atomically when a worker claims the reaction. */
+  readonly attempts: number;
+  readonly availableAtMs: number;
+  readonly leaseOwner?: string;
+  readonly leaseExpiresAtMs?: number;
+  readonly completedAtMs?: number;
+  readonly lastFailure?: ReactionFailure;
+}
+
+export interface ReactionClaimQuery {
+  /** Opaque token unique to this claim operation. */
+  readonly leaseOwner: string;
+  readonly types: readonly string[];
+  readonly nowMs: number;
+  readonly leaseDurationMs: number;
+  readonly limit: number;
+}
+
+export interface ReactionListQuery {
+  readonly statuses?: readonly ReactionStatus[];
+  readonly types?: readonly string[];
+  readonly limit: number;
+}
+
+export interface ReactionFailureUpdate {
+  readonly leaseOwner: string;
+  readonly failure: ReactionFailure;
+  /** Present for retry; absent moves the row to the dead-letter state. */
+  readonly retryAtMs?: number;
+}
+
+export interface ReactionPruneQuery {
+  readonly completedBeforeMs: number;
+  readonly deadLetterBeforeMs: number;
+  readonly limit: number;
+}
+
+export interface PrunedReactionCounts {
+  readonly completed: number;
+  readonly deadLetter: number;
+}
+
 /** Persisted push outcome for idempotent replay (§2.3, §6.3). */
 export interface StoredPushResult {
   readonly status: 'applied' | 'rejected';
@@ -249,6 +326,12 @@ export interface StorageTransaction {
   /** Allocates the next per-partition commitSeq and appends the commit. */
   appendCommit(commit: NewCommit): Promise<number>;
   /**
+   * Persist reaction rows in this authoritative transaction. Required when
+   * the host configures a reaction planner. Reactions survive commit-log
+   * pruning because they live outside the commit/change tables.
+   */
+  enqueueReactions?(reactions: readonly NewReaction[]): Promise<void>;
+  /**
    * Persist an idempotency outcome only when the key is still absent. The
    * first writer wins; callers read the canonical value after commit.
    */
@@ -322,6 +405,55 @@ export interface ServerStorage {
     clientId: string,
     clientCommitId: string,
   ): Promise<StoredPushResult | undefined>;
+
+  /**
+   * Atomically lease due or expired-lease reactions for one worker. Optional
+   * for compatibility with custom storages; reaction runners fail closed when
+   * any lifecycle method is absent.
+   */
+  claimReactions?(
+    partition: string,
+    query: ReactionClaimQuery,
+  ): Promise<StoredReaction[]>;
+  /** Acknowledge only while `leaseOwner` still owns the lease. */
+  completeReaction?(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    completedAtMs: number,
+  ): Promise<boolean>;
+  /** Extend only while `leaseOwner` still owns the active lease. */
+  extendReactionLease?(
+    partition: string,
+    idempotencyKey: string,
+    leaseOwner: string,
+    leaseExpiresAtMs: number,
+  ): Promise<boolean>;
+  /** Retry or dead-letter only while `leaseOwner` still owns the lease. */
+  failReaction?(
+    partition: string,
+    idempotencyKey: string,
+    update: ReactionFailureUpdate,
+  ): Promise<boolean>;
+  /** Reset a dead-lettered row for an explicit operator retry. */
+  retryReaction?(
+    partition: string,
+    idempotencyKey: string,
+    nowMs: number,
+  ): Promise<boolean>;
+  getReaction?(
+    partition: string,
+    idempotencyKey: string,
+  ): Promise<StoredReaction | undefined>;
+  listReactions?(
+    partition: string,
+    query: ReactionListQuery,
+  ): Promise<StoredReaction[]>;
+  /** Delete a bounded set of aged terminal rows. Never deletes active work. */
+  pruneReactions?(
+    partition: string,
+    query: ReactionPruneQuery,
+  ): Promise<PrunedReactionCounts>;
 
   /**
    * Matching commits in the window, oldest first, each carrying only its

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -260,6 +260,29 @@ export interface ScopeActivityQuery {
   readonly limit: number;
 }
 
+/** A registered SELECT executed against the authoritative row projection. */
+export type AuthoritativeQueryValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Uint8Array
+  | null;
+
+export interface AuthoritativeQueryRequest {
+  /** Generated, positional SQLite-family SQL. It never comes from the request. */
+  readonly sql: string;
+  readonly params: readonly AuthoritativeQueryValue[];
+  /** Generated dependency set, used to validate and partition every relation. */
+  readonly tables: readonly string[];
+}
+
+/** One transactionally consistent authoritative query snapshot. */
+export interface AuthoritativeQueryResult {
+  readonly rows: readonly Readonly<Record<string, unknown>>[];
+  readonly maxCommitSeq: number;
+}
+
 /**
  * One transaction per push commit (§6.4): all row writes, the appended
  * commit (with its scope-index entries), and the idempotency record either
@@ -467,6 +490,16 @@ export interface ServerStorage {
 
   /** Scope-filtered snapshot scan, ordered by rowId (bootstrap paging). */
   scanRows(partition: string, query: RowScanQuery): Promise<StoredRow[]>;
+
+  /**
+   * Optional registered-query capability. The implementation MUST replace
+   * every generated app-table relation with a partition-filtered relation and
+   * return rows plus maxCommitSeq from one consistent database snapshot.
+   */
+  queryAuthoritative?(
+    partition: string,
+    query: AuthoritativeQueryRequest,
+  ): Promise<AuthoritativeQueryResult>;
 
   /**
    * Optional trusted-host exact lookup through a declared relational index.

--- a/packages/server/src/validate.ts
+++ b/packages/server/src/validate.ts
@@ -32,6 +32,7 @@ import {
 export const RESERVED_VALIDATION_CODE_PREFIXES: readonly string[] = [
   'sync.',
   'blob.',
+  'operation.',
   'presence.',
   'client.',
 ];

--- a/packages/server/test/authoritative-query.test.ts
+++ b/packages/server/test/authoritative-query.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
+import { encodeRow, type RowColumn } from '@syncular/core';
+import {
+  bindAuthoritativePartition,
+  compileSchema,
+  D1ServerStorage,
+  PostgresServerStorage,
+  postgresPlaceholders,
+  prepareAuthoritativeQuery,
+  type ServerSchema,
+  type ServerStorage,
+  SqliteServerStorage,
+} from '@syncular/server';
+import { pgliteExecutor } from '@syncular/server/pglite';
+import { D1DatabaseDouble } from './d1-double';
+
+const COLUMNS: readonly RowColumn[] = [
+  { name: 'id', type: 'string', nullable: false },
+  { name: 'project_id', type: 'string', nullable: false },
+  { name: 'title', type: 'string', nullable: false },
+];
+const SCHEMA: ServerSchema = {
+  version: 1,
+  tables: [
+    {
+      name: 'tasks',
+      columns: COLUMNS,
+      primaryKey: 'id',
+      scopes: ['project:{project_id}'],
+    },
+  ],
+};
+
+async function seed(storage: ServerStorage, partition: string, title: string) {
+  const tx = await storage.begin(partition);
+  await tx.upsertRow('tasks', {
+    rowId: 'task-1',
+    serverVersion: 1,
+    scopes: { project_id: 'p1' },
+    payload: encodeRow(COLUMNS, ['task-1', 'p1', title]),
+  });
+  await tx.appendCommit({
+    clientId: 'seed',
+    clientCommitId: `seed-${partition}`,
+    actorId: 'seed',
+    createdAtMs: 1,
+    changes: [],
+  });
+  await tx.commit();
+}
+
+describe('authoritative query partition rewriting', () => {
+  test('keeps literals and expands numbered binds deterministically', () => {
+    const schema = compileSchema(SCHEMA);
+    const prepared = bindAuthoritativePartition(
+      prepareAuthoritativeQuery(
+        "SELECT '?; FROM tasks' AS marker, id FROM tasks /* ? FROM tasks */ WHERE project_id=?1 OR project_id=?1 -- ?\n",
+        ['p1'],
+        ['tasks'],
+        schema.tables,
+      ),
+      'part-1',
+    );
+
+    expect(prepared.sql).toContain(
+      'FROM (SELECT "id", "project_id", "title" FROM "tasks" WHERE "_sync_partition"=?) AS "tasks"',
+    );
+    expect(prepared.sql).toContain("SELECT '?; FROM tasks' AS marker");
+    expect(prepared.params).toEqual(['part-1', 'p1', 'p1']);
+    expect(
+      postgresPlaceholders(
+        'SELECT \'?\' AS marker, "?" AS quoted, ? AS value /* ? */ -- ?\n',
+      ),
+    ).toBe('SELECT \'?\' AS marker, "?" AS quoted, $1 AS value /* ? */ -- ?\n');
+  });
+
+  for (const backend of ['SQLite', 'Postgres', 'D1'] as const) {
+    test(`${backend} returns one partition and its snapshot cursor`, async () => {
+      const db = backend === 'Postgres' ? await PGlite.create() : undefined;
+      const storage =
+        backend === 'SQLite'
+          ? new SqliteServerStorage()
+          : backend === 'D1'
+            ? new D1ServerStorage(new D1DatabaseDouble(), {
+                pushApplySerialized: true,
+              })
+            : new PostgresServerStorage(pgliteExecutor(db as PGlite));
+      await storage.ensureSchema(compileSchema(SCHEMA));
+      await seed(storage, 'part-1', 'one');
+      await seed(storage, 'part-2', 'two');
+
+      const result = await storage.queryAuthoritative?.('part-1', {
+        sql: 'SELECT id, title FROM tasks WHERE project_id=? ORDER BY id',
+        params: ['p1'],
+        tables: ['tasks'],
+      });
+
+      expect(result).toEqual({
+        rows: [{ id: 'task-1', title: 'one' }],
+        maxCommitSeq: 1,
+      });
+      if (storage instanceof SqliteServerStorage) storage.db.close();
+      else await db?.close();
+    });
+  }
+});

--- a/packages/server/test/d1-double.ts
+++ b/packages/server/test/d1-double.ts
@@ -81,6 +81,15 @@ class DoublePreparedStatement implements D1PreparedStatement {
   _apply(): void {
     this.#db.query(this.#sql).run(...(this.#params as never[]));
   }
+
+  _batchResult(): unknown {
+    if (/^\s*(?:SELECT|WITH)\b/i.test(this.#sql)) {
+      const rows = this.#db.query(this.#sql).all(...(this.#params as never[]));
+      return { results: rows.map((row) => normalizeRow(row)) };
+    }
+    this._apply();
+    return {};
+  }
 }
 
 export class D1DatabaseDouble implements D1Database {
@@ -99,15 +108,15 @@ export class D1DatabaseDouble implements D1Database {
     // all-or-nothing semantics with BEGIN … COMMIT/ROLLBACK.
     this.#db.exec('BEGIN IMMEDIATE');
     try {
-      for (const statement of statements) {
-        (statement as DoublePreparedStatement)._apply();
-      }
+      const results = statements.map((statement) =>
+        (statement as DoublePreparedStatement)._batchResult(),
+      );
       this.#db.exec('COMMIT');
+      return results;
     } catch (error) {
       this.#db.exec('ROLLBACK');
       throw error;
     }
-    return statements.map(() => ({}));
   }
 
   async exec(query: string): Promise<unknown> {

--- a/packages/server/test/reactions.test.ts
+++ b/packages/server/test/reactions.test.ts
@@ -1,0 +1,670 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  PermanentReactionError,
+  pruneReactions,
+  ReactionRunner,
+  reactionIdempotencyKey,
+  retryDeadLetterReaction,
+  RetryableReactionError,
+  type ReactionPlanner,
+  type ServerStorage,
+  type StorageTransaction,
+  type SyncularServerEvent,
+} from '@syncular/server';
+import {
+  makeContext,
+  overlapAfterTwoOptimisticMisses,
+  pushCommit,
+  pushResults,
+  seedTask,
+  sync,
+  taskRow,
+  upsert,
+} from './helpers';
+
+type TestReactions = {
+  'email.send': { readonly taskId: string };
+};
+
+const planner: ReactionPlanner<TestReactions> = ({ operations }) =>
+  operations
+    .filter((operation) => operation.op === 'upsert')
+    .map((operation) => ({
+      key: `task:${operation.rowId}`,
+      type: 'email.send',
+      version: 1,
+      payload: { taskId: operation.rowId },
+      maxAttempts: 3,
+    }));
+
+describe('durable reaction planning', () => {
+  test('handler idempotency keys isolate partitions and tuple boundaries', () => {
+    expect(
+      reactionIdempotencyKey('part-1', 'client', 'commit', 'work'),
+    ).not.toBe(reactionIdempotencyKey('part-2', 'client', 'commit', 'work'));
+    expect(reactionIdempotencyKey('p', 'a:b', 'c', 'd')).not.toBe(
+      reactionIdempotencyKey('p', 'a', 'b:c', 'd'),
+    );
+  });
+
+  test('accepted commit and reaction enqueue land atomically', async () => {
+    const events: SyncularServerEvent[] = [];
+    const t = makeContext({
+      reactionPlanner: planner,
+      events: { emit: (event) => events.push(event) },
+    });
+    const result = await sync(t, [
+      pushCommit('commit-1', [
+        upsert('tasks', 'task-1', taskRow('task-1', 'p1')),
+      ]),
+    ]);
+    expect(pushResults(result)[0]?.status).toBe('applied');
+    expect(
+      await t.storage.getReaction?.(
+        'part-1',
+        reactionIdempotencyKey('part-1', 'client-1', 'commit-1', 'task:task-1'),
+      ),
+    ).toMatchObject({
+      status: 'pending',
+      sourceCommitSeq: 1,
+      payload: { taskId: 'task-1' },
+    });
+    expect(events.filter((event) => event.type === 'reaction.queued')).toEqual([
+      expect.objectContaining({
+        commitSeq: 1,
+        reactionType: 'email.send',
+      }),
+    ]);
+  });
+
+  test('enqueue failure rolls back the row, commit log, and reaction', async () => {
+    const base = makeContext({ reactionPlanner: planner });
+    const storage = new Proxy(base.storage, {
+      get(target, property) {
+        if (property === 'begin') {
+          return async (partition: string): Promise<StorageTransaction> => {
+            const tx = await target.begin(partition);
+            return new Proxy(tx, {
+              get(txTarget, txProperty) {
+                if (txProperty === 'enqueueReactions') {
+                  return async () => {
+                    throw new Error('injected enqueue failure');
+                  };
+                }
+                const value = Reflect.get(txTarget, txProperty, txTarget);
+                return typeof value === 'function'
+                  ? value.bind(txTarget)
+                  : value;
+              },
+            });
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const t = { ...base, ctx: { ...base.ctx, storage } };
+    await expect(
+      sync(t, [
+        pushCommit('commit-fails', [
+          upsert('tasks', 'task-fails', taskRow('task-fails', 'p1')),
+        ]),
+      ]),
+    ).rejects.toThrow('injected enqueue failure');
+    expect(
+      await base.storage.getRow('part-1', 'tasks', 'task-fails'),
+    ).toBeUndefined();
+    expect(await base.storage.getMaxCommitSeq('part-1')).toBe(0);
+    expect(await base.storage.listReactions?.('part-1', { limit: 10 })).toEqual(
+      [],
+    );
+  });
+
+  test('rejected commits do not call the planner or enqueue', async () => {
+    let plannerCalls = 0;
+    const t = makeContext({
+      reactionPlanner: (input) => {
+        plannerCalls += 1;
+        return planner(input);
+      },
+    });
+    const result = await sync(t, [
+      pushCommit('rejected', [
+        upsert('tasks', 'forbidden', taskRow('forbidden', 'p9')),
+      ]),
+    ]);
+    expect(pushResults(result)[0]?.status).toBe('rejected');
+    expect(plannerCalls).toBe(0);
+    expect(await t.storage.listReactions?.('part-1', { limit: 10 })).toEqual(
+      [],
+    );
+  });
+
+  test('conflicted commits do not call the planner or enqueue', async () => {
+    const base = makeContext();
+    await seedTask(base, 'seed', 'task-1', 'p1');
+    let plannerCalls = 0;
+    const t = {
+      ...base,
+      ctx: {
+        ...base.ctx,
+        reactionPlanner: (input: Parameters<typeof planner>[0]) => {
+          plannerCalls += 1;
+          return planner(input);
+        },
+      },
+    };
+    const result = await sync(t, [
+      pushCommit('conflict', [
+        upsert('tasks', 'task-1', taskRow('task-1', 'p1'), 0),
+      ]),
+    ]);
+    expect(pushResults(result)[0]?.results[0]?.status).toBe('conflict');
+    expect(plannerCalls).toBe(0);
+    expect(await base.storage.listReactions?.('part-1', { limit: 10 })).toEqual(
+      [],
+    );
+  });
+
+  test('idempotency replay neither replans nor enqueues twice', async () => {
+    let plannerCalls = 0;
+    const t = makeContext({
+      reactionPlanner: (input) => {
+        plannerCalls += 1;
+        return planner(input);
+      },
+    });
+    const commit = pushCommit('duplicate', [
+      upsert('tasks', 'task-1', taskRow('task-1', 'p1')),
+    ]);
+    expect(pushResults(await sync(t, [commit]))[0]?.status).toBe('applied');
+    expect(pushResults(await sync(t, [commit]))[0]?.status).toBe('cached');
+    expect(plannerCalls).toBe(1);
+    expect(
+      await t.storage.listReactions?.('part-1', { limit: 10 }),
+    ).toHaveLength(1);
+  });
+
+  test('overlapping duplicate deliveries plan and enqueue once', async () => {
+    let plannerCalls = 0;
+    const base = makeContext({
+      reactionPlanner: (input) => {
+        plannerCalls += 1;
+        return planner(input);
+      },
+    });
+    const storage = overlapAfterTwoOptimisticMisses(base.storage);
+    const t = { ...base, ctx: { ...base.ctx, storage } };
+    const commit = pushCommit('overlapping', [
+      upsert('tasks', 'task-1', taskRow('task-1', 'p1')),
+    ]);
+    const results = await Promise.all([sync(t, [commit]), sync(t, [commit])]);
+    expect(
+      results.map((result) => pushResults(result)[0]?.status).sort(),
+    ).toEqual(['applied', 'cached']);
+    expect(plannerCalls).toBe(1);
+    expect(
+      await base.storage.listReactions?.('part-1', { limit: 10 }),
+    ).toHaveLength(1);
+  });
+
+  test('planner candidate reads observe the accepted staged state', async () => {
+    let observedTitle: unknown;
+    const t = makeContext({
+      reactionPlanner: async ({ read }) => {
+        observedTitle = (await read.getRow('tasks', 'task-1'))?.row.title;
+        return [];
+      },
+    });
+    await sync(t, [
+      pushCommit('candidate', [
+        upsert('tasks', 'task-1', taskRow('task-1', 'p1', 'candidate')),
+      ]),
+    ]);
+    expect(observedTitle).toBe('candidate');
+  });
+
+  test('oversized planner payload fails before the source commit lands', async () => {
+    const t = makeContext({
+      reactionPlanner: () => [
+        {
+          key: 'oversized',
+          type: 'email.send',
+          version: 1,
+          payload: { body: 'x'.repeat(65_536) },
+        },
+      ],
+    });
+    await expect(
+      sync(t, [
+        pushCommit('oversized', [
+          upsert('tasks', 'task-1', taskRow('task-1', 'p1')),
+        ]),
+      ]),
+    ).rejects.toThrow('exceeds 65536 persisted bytes');
+    expect(await t.storage.getMaxCommitSeq('part-1')).toBe(0);
+    expect(await t.storage.getRow('part-1', 'tasks', 'task-1')).toBeUndefined();
+  });
+});
+
+describe('reaction delivery', () => {
+  test('SQLite claims wait outside an open authoritative push transaction', async () => {
+    const base = makeContext();
+    const seed = await base.storage.begin('part-1');
+    await seed.enqueueReactions?.([
+      {
+        idempotencyKey: '["seed","seed","task:queued"]',
+        type: 'email.send',
+        version: 1,
+        payload: { taskId: 'queued' },
+        sourceClientId: 'seed',
+        sourceClientCommitId: 'seed',
+        sourceCommitSeq: 0,
+        createdAtMs: base.now.ms,
+        maxAttempts: 3,
+      },
+    ]);
+    await seed.commit();
+    let enteredPlanner!: () => void;
+    const plannerEntered = new Promise<void>((resolve) => {
+      enteredPlanner = resolve;
+    });
+    let releasePlanner!: () => void;
+    const plannerGate = new Promise<void>((resolve) => {
+      releasePlanner = resolve;
+    });
+    const t = {
+      ...base,
+      ctx: {
+        ...base.ctx,
+        reactionPlanner: async () => {
+          enteredPlanner();
+          await plannerGate;
+          return [];
+        },
+      },
+    };
+    const push = sync(t, [
+      pushCommit('open-push', [
+        upsert('tasks', 'task-1', taskRow('task-1', 'p1')),
+      ]),
+    ]);
+    await plannerEntered;
+    let deliveries = 0;
+    const runner = new ReactionRunner<TestReactions>({
+      storage: base.storage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': () => {
+          deliveries += 1;
+        },
+      },
+      clock: () => base.now.ms,
+    });
+    const delivery = runner.runOnce();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deliveries).toBe(0);
+    releasePlanner();
+    await push;
+    expect((await delivery).completed).toBe(1);
+    expect(deliveries).toBe(1);
+  });
+
+  test('handler success acknowledges the reaction and emits lifecycle events', async () => {
+    const events: SyncularServerEvent[] = [];
+    const t = makeContext({ reactionPlanner: planner });
+    await seedTask(t, 'commit-1', 'task-1', 'p1');
+    const handled: string[] = [];
+    const runner = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': async ({ idempotencyKey, extendLease }) => {
+          await extendLease();
+          handled.push(idempotencyKey);
+        },
+      },
+      events: { emit: (event) => events.push(event) },
+      clock: () => t.now.ms,
+    });
+    expect(await runner.runOnce()).toEqual({
+      claimed: 1,
+      completed: 1,
+      retried: 0,
+      deadLettered: 0,
+      lostLeases: 0,
+    });
+    expect(handled).toEqual([
+      reactionIdempotencyKey('part-1', 'client-1', 'commit-1', 'task:task-1'),
+    ]);
+    expect(events.map((event) => event.type)).toEqual([
+      'reaction.started',
+      'reaction.completed',
+    ]);
+    expect(
+      await t.storage.getReaction?.('part-1', handled[0] ?? ''),
+    ).toMatchObject({ status: 'completed', attempts: 1 });
+  });
+
+  test('retryable failure uses bounded backoff and later succeeds', async () => {
+    const t = makeContext({ reactionPlanner: planner });
+    await seedTask(t, 'commit-1', 'task-1', 'p1');
+    let calls = 0;
+    const runner = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': () => {
+          calls += 1;
+          if (calls === 1)
+            throw new RetryableReactionError('email.unavailable');
+        },
+      },
+      clock: () => t.now.ms,
+      initialBackoffMs: 100,
+      maxBackoffMs: 250,
+    });
+    expect((await runner.runOnce()).retried).toBe(1);
+    const key = reactionIdempotencyKey(
+      'part-1',
+      'client-1',
+      'commit-1',
+      'task:task-1',
+    );
+    expect(await t.storage.getReaction?.('part-1', key)).toMatchObject({
+      status: 'pending',
+      availableAtMs: t.now.ms + 100,
+      lastFailure: { code: 'email.unavailable' },
+    });
+    expect((await runner.runOnce()).claimed).toBe(0);
+    t.now.ms += 100;
+    expect((await runner.runOnce()).completed).toBe(1);
+    expect(await t.storage.getReaction?.('part-1', key)).toMatchObject({
+      status: 'completed',
+      attempts: 2,
+    });
+  });
+
+  test('permanent failure is dead-lettered with bounded failure information', async () => {
+    const t = makeContext({ reactionPlanner: planner });
+    await seedTask(t, 'commit-1', 'task-1', 'p1');
+    const runner = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': () => {
+          throw new PermanentReactionError('email.invalid_recipient', {
+            reason: 'invalid_address',
+          });
+        },
+      },
+      clock: () => t.now.ms,
+    });
+    expect((await runner.runOnce()).deadLettered).toBe(1);
+    expect(
+      await t.storage.getReaction?.(
+        'part-1',
+        reactionIdempotencyKey('part-1', 'client-1', 'commit-1', 'task:task-1'),
+      ),
+    ).toMatchObject({
+      status: 'dead-letter',
+      lastFailure: {
+        code: 'email.invalid_recipient',
+        details: { reason: 'invalid_address' },
+      },
+    });
+    expect(
+      await retryDeadLetterReaction({
+        storage: t.storage,
+        partition: 'part-1',
+        idempotencyKey: reactionIdempotencyKey(
+          'part-1',
+          'client-1',
+          'commit-1',
+          'task:task-1',
+        ),
+        nowMs: t.now.ms + 1,
+      }),
+    ).toBe(true);
+    expect(
+      await t.storage.getReaction?.(
+        'part-1',
+        reactionIdempotencyKey('part-1', 'client-1', 'commit-1', 'task:task-1'),
+      ),
+    ).toMatchObject({ status: 'pending', attempts: 0 });
+  });
+
+  test('crash after side effect and before acknowledgement redelivers with the same key', async () => {
+    const t = makeContext({ reactionPlanner: planner });
+    await seedTask(t, 'commit-1', 'task-1', 'p1');
+    const deliveries: string[] = [];
+    const crashingStorage = new Proxy<ServerStorage>(t.storage, {
+      get(target, property) {
+        if (property === 'completeReaction' || property === 'failReaction') {
+          return async () => {
+            throw new Error('worker crashed before acknowledgement');
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const first = new ReactionRunner<TestReactions>({
+      storage: crashingStorage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': ({ idempotencyKey }) => {
+          deliveries.push(idempotencyKey);
+        },
+      },
+      clock: () => t.now.ms,
+      leaseDurationMs: 100,
+    });
+    await expect(first.runOnce()).rejects.toThrow(
+      'worker crashed before acknowledgement',
+    );
+    t.now.ms += 100;
+    const second = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-2',
+      handlers: {
+        'email.send': ({ idempotencyKey }) => {
+          deliveries.push(idempotencyKey);
+        },
+      },
+      clock: () => t.now.ms,
+      leaseDurationMs: 100,
+    });
+    expect((await second.runOnce()).completed).toBe(1);
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries[0]).toBe(deliveries[1]);
+  });
+
+  test('concurrent workers do not normally execute one lease concurrently', async () => {
+    const t = makeContext({ reactionPlanner: planner });
+    await seedTask(t, 'commit-1', 'task-1', 'p1');
+    let deliveries = 0;
+    const makeRunner = (workerId: string) =>
+      new ReactionRunner<TestReactions>({
+        storage: t.storage,
+        partition: 'part-1',
+        workerId,
+        handlers: {
+          'email.send': () => {
+            deliveries += 1;
+          },
+        },
+        clock: () => t.now.ms,
+      });
+    const results = await Promise.all([
+      makeRunner('worker-1').runOnce(),
+      makeRunner('worker-2').runOnce(),
+    ]);
+    expect(results[0].claimed + results[1].claimed).toBe(1);
+    expect(deliveries).toBe(1);
+  });
+
+  test('a stale member of a claimed batch is skipped after another worker reclaims it', async () => {
+    const t = makeContext({ reactionPlanner: planner });
+    await sync(t, [
+      pushCommit('commit-1', [
+        upsert('tasks', 'task-1', taskRow('task-1', 'p1')),
+        upsert('tasks', 'task-2', taskRow('task-2', 'p1')),
+      ]),
+    ]);
+    let firstStarted!: () => void;
+    const firstIsRunning = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const deliveries: string[] = [];
+    const first = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': async ({ payload, extendLease }) => {
+          deliveries.push(`worker-1:${payload.taskId}`);
+          if (payload.taskId === 'task-1') {
+            t.now.ms += 100;
+            await extendLease();
+            firstStarted();
+            await firstGate;
+          }
+        },
+      },
+      clock: () => t.now.ms,
+      leaseDurationMs: 100,
+    });
+    const firstRun = first.runOnce();
+    await firstIsRunning;
+    const second = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-2',
+      handlers: {
+        'email.send': ({ payload }) => {
+          deliveries.push(`worker-2:${payload.taskId}`);
+        },
+      },
+      clock: () => t.now.ms,
+      leaseDurationMs: 100,
+    });
+    expect(await second.runOnce()).toMatchObject({ claimed: 1, completed: 1 });
+    releaseFirst();
+    expect(await firstRun).toMatchObject({
+      claimed: 2,
+      completed: 1,
+      lostLeases: 1,
+    });
+    expect(deliveries).toEqual(['worker-1:task-1', 'worker-2:task-2']);
+  });
+});
+
+describe('reaction retention', () => {
+  test('prunes completed and dead-lettered rows on separate retention floors', async () => {
+    const events: SyncularServerEvent[] = [];
+    const t = makeContext({ reactionPlanner: planner });
+    await seedTask(t, 'commit-1', 'task-1', 'p1');
+    await seedTask(t, 'commit-2', 'task-2', 'p1');
+    const runner = new ReactionRunner<TestReactions>({
+      storage: t.storage,
+      partition: 'part-1',
+      workerId: 'worker-1',
+      handlers: {
+        'email.send': ({ payload }) => {
+          if (payload.taskId === 'task-2') {
+            throw new PermanentReactionError('email.invalid_recipient');
+          }
+        },
+      },
+      clock: () => t.now.ms,
+    });
+    expect(await runner.runOnce()).toMatchObject({
+      completed: 1,
+      deadLettered: 1,
+    });
+
+    t.now.ms += 31 * 24 * 60 * 60 * 1000;
+    expect(
+      await pruneReactions({
+        storage: t.storage,
+        partition: 'part-1',
+        nowMs: t.now.ms,
+        events: { emit: (event) => events.push(event) },
+      }),
+    ).toMatchObject({
+      removedCompleted: 1,
+      removedDeadLetter: 0,
+      mayHaveMore: false,
+    });
+    expect(
+      await t.storage.getReaction?.(
+        'part-1',
+        reactionIdempotencyKey('part-1', 'client-1', 'commit-1', 'task:task-1'),
+      ),
+    ).toBeUndefined();
+    expect(
+      await t.storage.getReaction?.(
+        'part-1',
+        reactionIdempotencyKey('part-1', 'client-1', 'commit-2', 'task:task-2'),
+      ),
+    ).toMatchObject({ status: 'dead-letter' });
+
+    t.now.ms += 60 * 24 * 60 * 60 * 1000;
+    expect(
+      await pruneReactions({
+        storage: t.storage,
+        partition: 'part-1',
+        nowMs: t.now.ms,
+        events: { emit: (event) => events.push(event) },
+      }),
+    ).toMatchObject({ removedCompleted: 0, removedDeadLetter: 1 });
+    expect(
+      events.filter((event) => event.type === 'reaction.prune_completed'),
+    ).toEqual([
+      expect.objectContaining({
+        partition: 'part-1',
+        limit: 1_000,
+        removedCompleted: 1,
+        removedDeadLetter: 0,
+        mayHaveMore: false,
+      }),
+      expect.objectContaining({
+        partition: 'part-1',
+        limit: 1_000,
+        removedCompleted: 0,
+        removedDeadLetter: 1,
+        mayHaveMore: false,
+      }),
+    ]);
+  });
+
+  test('fails closed when storage lacks terminal reaction pruning', async () => {
+    const t = makeContext();
+    const storage = new Proxy<ServerStorage>(t.storage, {
+      get(target, property) {
+        if (property === 'pruneReactions') return undefined;
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    await expect(
+      pruneReactions({
+        storage,
+        partition: 'part-1',
+        nowMs: t.now.ms,
+      }),
+    ).rejects.toThrow('storage does not implement durable reaction pruning');
+  });
+});

--- a/packages/server/test/storage-contract.ts
+++ b/packages/server/test/storage-contract.ts
@@ -16,6 +16,7 @@ import { encodeRow, type RowColumn } from '@syncular/core';
 import {
   type ClientRecord,
   compileSchema,
+  type NewReaction,
   type ServerSchema,
   type ServerStorage,
   StorageQueryError,
@@ -28,6 +29,23 @@ const NOW = 1_750_000_000_000;
 
 function bytes(...values: number[]): Uint8Array {
   return new Uint8Array(values);
+}
+
+function reaction(
+  sourceCommitSeq: number,
+  idempotencyKey = '["c1","commit-1","email"]',
+): NewReaction {
+  return {
+    idempotencyKey,
+    type: 'email.send',
+    version: 1,
+    payload: { messageId: 'message-1' },
+    sourceClientId: 'c1',
+    sourceClientCommitId: 'commit-1',
+    sourceCommitSeq,
+    createdAtMs: NOW,
+    maxAttempts: 3,
+  };
 }
 
 /**
@@ -387,6 +405,292 @@ export function runStorageContract(
       expect(
         await storage.getPushResult(PARTITION, 'c1', 'first-writer'),
       ).toEqual(first);
+    });
+
+    test('reaction enqueue commits and rolls back with the source transaction', async () => {
+      const storage = await make();
+      const committed = await storage.begin(PARTITION);
+      expect(committed.enqueueReactions).toBeDefined();
+      const commitSeq = await committed.appendCommit({
+        clientId: 'c1',
+        clientCommitId: 'commit-1',
+        actorId: 'a1',
+        createdAtMs: NOW,
+        changes: [],
+      });
+      await committed.enqueueReactions?.([reaction(commitSeq)]);
+      await committed.commit();
+      expect(
+        await storage.getReaction?.(PARTITION, '["c1","commit-1","email"]'),
+      ).toMatchObject({ status: 'pending', sourceCommitSeq: 1, attempts: 0 });
+      expect(
+        await storage.listReactions?.(PARTITION, {
+          statuses: ['pending'],
+          types: ['email.send'],
+          limit: 10,
+        }),
+      ).toHaveLength(1);
+
+      const rolledBack = await storage.begin(PARTITION);
+      const rolledBackSeq = await rolledBack.appendCommit({
+        clientId: 'c1',
+        clientCommitId: 'commit-2',
+        actorId: 'a1',
+        createdAtMs: NOW + 1,
+        changes: [],
+      });
+      await rolledBack.enqueueReactions?.([
+        reaction(rolledBackSeq, '["c1","commit-2","email"]'),
+      ]);
+      await rolledBack.rollback();
+      expect(
+        await storage.getReaction?.(PARTITION, '["c1","commit-2","email"]'),
+      ).toBeUndefined();
+      expect(await storage.getMaxCommitSeq(PARTITION)).toBe(1);
+    });
+
+    test('concurrent claimers lease one reaction to one worker', async () => {
+      const storage = await make();
+      const tx = await storage.begin(PARTITION);
+      await tx.enqueueReactions?.([reaction(1)]);
+      await tx.commit();
+      const [left, right] = await Promise.all([
+        storage.claimReactions?.(PARTITION, {
+          leaseOwner: 'lease-1',
+          types: ['email.send'],
+          nowMs: NOW,
+          leaseDurationMs: 100,
+          limit: 1,
+        }),
+        storage.claimReactions?.(PARTITION, {
+          leaseOwner: 'lease-2',
+          types: ['email.send'],
+          nowMs: NOW,
+          leaseDurationMs: 100,
+          limit: 1,
+        }),
+      ]);
+      expect((left?.length ?? 0) + (right?.length ?? 0)).toBe(1);
+      const claimed = [...(left ?? []), ...(right ?? [])][0];
+      expect(claimed?.status).toBe('leased');
+      expect(claimed?.attempts).toBe(1);
+    });
+
+    test('expired leases are reclaimed and stale owners cannot acknowledge', async () => {
+      const storage = await make();
+      const tx = await storage.begin(PARTITION);
+      await tx.enqueueReactions?.([reaction(1)]);
+      await tx.commit();
+      const first = await storage.claimReactions?.(PARTITION, {
+        leaseOwner: 'lease-1',
+        types: ['email.send'],
+        nowMs: NOW,
+        leaseDurationMs: 100,
+        limit: 1,
+      });
+      expect(first).toHaveLength(1);
+      expect(
+        await storage.extendReactionLease?.(
+          PARTITION,
+          reaction(1).idempotencyKey,
+          'lease-1',
+          NOW + 200,
+        ),
+      ).toBe(true);
+      expect(
+        await storage.claimReactions?.(PARTITION, {
+          leaseOwner: 'lease-2',
+          types: ['email.send'],
+          nowMs: NOW + 199,
+          leaseDurationMs: 100,
+          limit: 1,
+        }),
+      ).toHaveLength(0);
+      const reclaimed = await storage.claimReactions?.(PARTITION, {
+        leaseOwner: 'lease-2',
+        types: ['email.send'],
+        nowMs: NOW + 200,
+        leaseDurationMs: 100,
+        limit: 1,
+      });
+      expect(reclaimed?.[0]).toMatchObject({
+        leaseOwner: 'lease-2',
+        attempts: 2,
+      });
+      expect(
+        await storage.completeReaction?.(
+          PARTITION,
+          reaction(1).idempotencyKey,
+          'lease-1',
+          NOW + 201,
+        ),
+      ).toBe(false);
+      expect(
+        await storage.completeReaction?.(
+          PARTITION,
+          reaction(1).idempotencyKey,
+          'lease-2',
+          NOW + 201,
+        ),
+      ).toBe(true);
+    });
+
+    test('retry, dead-letter, and manual retry state round-trip', async () => {
+      const storage = await make();
+      const tx = await storage.begin(PARTITION);
+      await tx.enqueueReactions?.([reaction(1)]);
+      await tx.commit();
+      await storage.claimReactions?.(PARTITION, {
+        leaseOwner: 'lease-1',
+        types: ['email.send'],
+        nowMs: NOW,
+        leaseDurationMs: 100,
+        limit: 1,
+      });
+      expect(
+        await storage.failReaction?.(PARTITION, reaction(1).idempotencyKey, {
+          leaseOwner: 'lease-1',
+          failure: { code: 'email.unavailable', atMs: NOW + 1 },
+          retryAtMs: NOW + 50,
+        }),
+      ).toBe(true);
+      expect(
+        await storage.getReaction?.(PARTITION, reaction(1).idempotencyKey),
+      ).toMatchObject({ status: 'pending', availableAtMs: NOW + 50 });
+      await storage.claimReactions?.(PARTITION, {
+        leaseOwner: 'lease-1',
+        types: ['email.send'],
+        nowMs: NOW + 50,
+        leaseDurationMs: 100,
+        limit: 1,
+      });
+      expect(
+        await storage.failReaction?.(PARTITION, reaction(1).idempotencyKey, {
+          leaseOwner: 'lease-1',
+          failure: { code: 'email.invalid', atMs: NOW + 51 },
+        }),
+      ).toBe(true);
+      expect(
+        await storage.getReaction?.(PARTITION, reaction(1).idempotencyKey),
+      ).toMatchObject({ status: 'dead-letter', attempts: 2 });
+      expect(
+        await storage.retryReaction?.(
+          PARTITION,
+          reaction(1).idempotencyKey,
+          NOW + 60,
+        ),
+      ).toBe(true);
+      expect(
+        await storage.getReaction?.(PARTITION, reaction(1).idempotencyKey),
+      ).toMatchObject({ status: 'pending', attempts: 0 });
+    });
+
+    test('reaction pruning is bounded and deletes only aged terminal rows', async () => {
+      const storage = await make();
+      const tx = await storage.begin(PARTITION);
+      await tx.enqueueReactions?.([
+        { ...reaction(0, 'pending'), type: 'reaction.pending' },
+        { ...reaction(0, 'leased'), type: 'reaction.leased' },
+        { ...reaction(0, 'a-completed-old'), type: 'reaction.completed-old' },
+        {
+          ...reaction(0, 'completed-boundary'),
+          type: 'reaction.completed-boundary',
+        },
+        { ...reaction(0, 'b-dead-old'), type: 'reaction.dead-old' },
+        {
+          ...reaction(0, 'dead-boundary'),
+          type: 'reaction.dead-boundary',
+        },
+      ]);
+      await tx.commit();
+      const claim = async (type: string, leaseOwner: string) => {
+        const claimed = await storage.claimReactions?.(PARTITION, {
+          leaseOwner,
+          types: [type],
+          nowMs: NOW,
+          leaseDurationMs: 100,
+          limit: 1,
+        });
+        expect(claimed).toHaveLength(1);
+      };
+      await claim('reaction.leased', 'leased-owner');
+      await claim('reaction.completed-old', 'completed-old-owner');
+      expect(
+        await storage.completeReaction?.(
+          PARTITION,
+          'a-completed-old',
+          'completed-old-owner',
+          NOW + 10,
+        ),
+      ).toBe(true);
+      await claim('reaction.completed-boundary', 'completed-boundary-owner');
+      expect(
+        await storage.completeReaction?.(
+          PARTITION,
+          'completed-boundary',
+          'completed-boundary-owner',
+          NOW + 200,
+        ),
+      ).toBe(true);
+      await claim('reaction.dead-old', 'dead-old-owner');
+      expect(
+        await storage.failReaction?.(PARTITION, 'b-dead-old', {
+          leaseOwner: 'dead-old-owner',
+          failure: { code: 'reaction.dead_old', atMs: NOW + 20 },
+        }),
+      ).toBe(true);
+      await claim('reaction.dead-boundary', 'dead-boundary-owner');
+      expect(
+        await storage.failReaction?.(PARTITION, 'dead-boundary', {
+          leaseOwner: 'dead-boundary-owner',
+          failure: { code: 'reaction.dead_boundary', atMs: NOW + 200 },
+        }),
+      ).toBe(true);
+
+      expect(
+        await storage.pruneReactions?.(PARTITION, {
+          completedBeforeMs: NOW + 200,
+          deadLetterBeforeMs: NOW + 200,
+          limit: 1,
+        }),
+      ).toEqual({ completed: 1, deadLetter: 0 });
+      expect(
+        await storage.pruneReactions?.(PARTITION, {
+          completedBeforeMs: NOW + 200,
+          deadLetterBeforeMs: NOW + 200,
+          limit: 10,
+        }),
+      ).toEqual({ completed: 0, deadLetter: 1 });
+      expect(await storage.getReaction?.(PARTITION, 'pending')).toMatchObject({
+        status: 'pending',
+      });
+      expect(await storage.getReaction?.(PARTITION, 'leased')).toMatchObject({
+        status: 'leased',
+      });
+      expect(
+        await storage.getReaction?.(PARTITION, 'completed-boundary'),
+      ).toMatchObject({ status: 'completed' });
+      expect(
+        await storage.getReaction?.(PARTITION, 'dead-boundary'),
+      ).toMatchObject({ status: 'dead-letter' });
+    });
+
+    test('commit-log pruning never deletes pending reactions', async () => {
+      const storage = await make();
+      const tx = await storage.begin(PARTITION);
+      const commitSeq = await tx.appendCommit({
+        clientId: 'c1',
+        clientCommitId: 'commit-1',
+        actorId: 'a1',
+        createdAtMs: NOW,
+        changes: [],
+      });
+      await tx.enqueueReactions?.([reaction(commitSeq)]);
+      await tx.commit();
+      expect(await storage.pruneCommitsThrough(PARTITION, commitSeq)).toBe(1);
+      expect(
+        await storage.getReaction?.(PARTITION, reaction(1).idempotencyKey),
+      ).toMatchObject({ status: 'pending', sourceCommitSeq: 1 });
     });
 
     test('conflict push-result bytes round-trip', async () => {

--- a/packages/server/test/validation.test.ts
+++ b/packages/server/test/validation.test.ts
@@ -114,6 +114,20 @@ describe('request validation (§1.7)', () => {
     expect(error.recommendedAction).toBe('resetClientId');
   });
 
+  test('ordinary clients cannot use the remote command idempotency namespace', async () => {
+    const t = makeContext();
+    const bytes = requestBytes(
+      [pushCommit('request-1', [upsert('tasks', 't1', taskRow('t1', 'p1'))])],
+      '["remote-command","service"]',
+    );
+
+    await expectSyncError(
+      handleSyncRequest(bytes, t.ctx),
+      'sync.invalid_client_id',
+    );
+    expect(await t.storage.getMaxCommitSeq('part-1')).toBe(0);
+  });
+
   test('undecodable bytes fail with the DecodeError code', async () => {
     const t = makeContext();
     await expectSyncError(
@@ -220,6 +234,11 @@ describe('error catalog (§10.2)', () => {
       retryable: false,
       recommendedAction: 'inspectServer',
     });
-    expect(Object.keys(ERROR_CATALOG)).toHaveLength(34);
+    expect(ERROR_CATALOG['operation.execution_failed']).toMatchObject({
+      category: 'internal',
+      retryable: false,
+      recommendedAction: 'inspectServer',
+    });
+    expect(Object.keys(ERROR_CATALOG)).toHaveLength(35);
   });
 });

--- a/packages/server/test/validation.test.ts
+++ b/packages/server/test/validation.test.ts
@@ -210,6 +210,16 @@ describe('error catalog (§10.2)', () => {
       retryable: true,
       recommendedAction: 'refreshAuth',
     });
-    expect(Object.keys(ERROR_CATALOG)).toHaveLength(28);
+    expect(ERROR_CATALOG['operation.forbidden']).toMatchObject({
+      category: 'forbidden',
+      retryable: false,
+      recommendedAction: 'checkPermissions',
+    });
+    expect(ERROR_CATALOG['operation.query_failed']).toMatchObject({
+      category: 'internal',
+      retryable: false,
+      recommendedAction: 'inspectServer',
+    });
+    expect(Object.keys(ERROR_CATALOG)).toHaveLength(34);
   });
 });

--- a/packages/typegen/src/emit-queries.ts
+++ b/packages/typegen/src/emit-queries.ts
@@ -399,6 +399,9 @@ function emitSyqlQuery(query: AnalyzedQuery, hash: string): string {
     );
   }
   lines.push(`  tables: ${query.name}Tables,`);
+  lines.push(
+    `  resultColumns: [${query.columns.map((column) => `{ name: ${quote(column.langName)}, type: ${quote(column.type)}, nullable: ${column.nullable} }`).join(', ')}],`,
+  );
   const reactiveUsesParams = query.reactive.dependencies.some((dependency) =>
     dependency.scopes.some((scope) => scope.params.length > 0),
   );
@@ -537,6 +540,9 @@ function emitQuery(query: AnalyzedQuery, hash: string): string {
   lines.push(`  sql: ${sqlConst},`);
   lines.push(`  mapRow: ${query.name}MapRow,`);
   lines.push(`  tables: ${query.name}Tables,`);
+  lines.push(
+    `  resultColumns: [${query.columns.map((column) => `{ name: ${quote(column.langName)}, type: ${quote(column.type)}, nullable: ${column.nullable} }`).join(', ')}],`,
+  );
   const reactiveUsesParams = query.reactive.dependencies.some((dependency) =>
     dependency.scopes.some((scope) => scope.params.length > 0),
   );
@@ -683,6 +689,7 @@ export function emitQueriesModule(
       '  readonly sql: string;',
       '  readonly mapRow: (row: Readonly<Record<string, unknown>>) => Row;',
       '  readonly tables: readonly string[];',
+      '  readonly resultColumns: readonly QueryResultColumn[];',
       '  readonly bind: (params: Params) => readonly QueryValue[];',
       '  readonly sqlFor?: (params: Params) => string;',
       '  readonly dependencies: (params: Params) => readonly QueryDependency[];',
@@ -695,6 +702,12 @@ export function emitQueriesModule(
       'export interface QueryDependency {',
       '  readonly table: string;',
       '  readonly scopeKeys?: readonly string[];',
+      '}',
+      '',
+      'export interface QueryResultColumn {',
+      '  readonly name: string;',
+      "  readonly type: 'string' | 'integer' | 'float' | 'boolean' | 'json' | 'bytes' | 'blob_ref' | 'crdt';",
+      '  readonly nullable: boolean;',
       '}',
       '',
       'export interface WindowCoverage {',

--- a/packages/typegen/test/fixtures/basic/syncular.queries.ts
+++ b/packages/typegen/test/fixtures/basic/syncular.queries.ts
@@ -71,6 +71,7 @@ export interface NamedQuery<Row, Params = undefined> {
   readonly sql: string;
   readonly mapRow: (row: Readonly<Record<string, unknown>>) => Row;
   readonly tables: readonly string[];
+  readonly resultColumns: readonly QueryResultColumn[];
   readonly bind: (params: Params) => readonly QueryValue[];
   readonly sqlFor?: (params: Params) => string;
   readonly dependencies: (params: Params) => readonly QueryDependency[];
@@ -83,6 +84,12 @@ export interface NamedQuery<Row, Params = undefined> {
 export interface QueryDependency {
   readonly table: string;
   readonly scopeKeys?: readonly string[];
+}
+
+export interface QueryResultColumn {
+  readonly name: string;
+  readonly type: 'string' | 'integer' | 'float' | 'boolean' | 'json' | 'bytes' | 'blob_ref' | 'crdt';
+  readonly nullable: boolean;
 }
 
 export interface WindowCoverage {
@@ -129,6 +136,7 @@ export const booleanResultsQuery: NamedQuery<BooleanResultsRow, undefined> = {
   sql: booleanResultsSql,
   mapRow: booleanResultsMapRow,
   tables: booleanResultsTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'isDone', type: 'boolean', nullable: false }, { name: 'maybeDone', type: 'boolean', nullable: true }],
   dependencies: () => [
     { table: 'docs' },
     { table: 'tasks' },
@@ -172,6 +180,7 @@ export const findDocByOrgQuery: NamedQuery<FindDocByOrgRow, FindDocByOrgParams> 
   sql: findDocByOrgSql,
   mapRow: findDocByOrgMapRow,
   tables: findDocByOrgTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'body', type: 'string', nullable: false }],
   dependencies: (params) => [
     { table: 'docs', scopeKeys: ['org:' + String(params.orgId) + ''] },
   ],
@@ -217,6 +226,7 @@ export const docValueTypesQuery: NamedQuery<DocValueTypesRow, DocValueTypesParam
   sql: docValueTypesSql,
   mapRow: docValueTypesMapRow,
   tables: docValueTypesTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'attachment', type: 'bytes', nullable: true }, { name: 'bodyDoc', type: 'crdt', nullable: true }, { name: 'remoteBlob', type: 'blob_ref', nullable: true }],
   dependencies: () => [
     { table: 'docs' },
   ],
@@ -261,6 +271,7 @@ export const docWithBodyQuery: NamedQuery<DocWithBodyRow, DocWithBodyParams> = {
   sql: docWithBodySql,
   mapRow: docWithBodyMapRow,
   tables: docWithBodyTables,
+  resultColumns: [{ name: 'docId', type: 'string', nullable: false }, { name: 'body', type: 'string', nullable: false }, { name: 'taskTitle', type: 'string', nullable: false }],
   dependencies: (params) => [
     { table: 'docs', scopeKeys: ['org:' + String(params.orgId) + ''] },
     { table: 'tasks' },
@@ -305,6 +316,7 @@ export const docsInProjectQuery: NamedQuery<DocsInProjectRow, DocsInProjectParam
   sql: docsInProjectSql,
   mapRow: docsInProjectMapRow,
   tables: docsInProjectTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'body', type: 'string', nullable: false }],
   dependencies: (params) => [
     { table: 'docs', scopeKeys: ['org:' + String(params.orgId) + '', 'project:' + String(params.projectId) + ''] },
   ],
@@ -352,6 +364,7 @@ export const hostBooleanQuery: NamedQuery<HostBooleanRow, HostBooleanParams> = {
   sql: hostBooleanSql,
   mapRow: hostBooleanMapRow,
   tables: hostBooleanTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
   ],
@@ -402,6 +415,7 @@ export const listProjectTasksQuery: NamedQuery<ListProjectTasksRow, ListProjectT
   sql: listProjectTasksSql,
   mapRow: listProjectTasksMapRow,
   tables: listProjectTasksTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }, { name: 'priority', type: 'integer', nullable: true }, { name: 'estimate', type: 'float', nullable: true }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
   ],
@@ -447,6 +461,7 @@ export const outerJoinValuesQuery: NamedQuery<OuterJoinValuesRow, OuterJoinValue
   sql: outerJoinValuesSql,
   mapRow: outerJoinValuesMapRow,
   tables: outerJoinValuesTables,
+  resultColumns: [{ name: 'taskId', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'docBody', type: 'string', nullable: true }],
   dependencies: () => [
     { table: 'docs' },
     { table: 'tasks' },
@@ -485,6 +500,7 @@ export const projectDocCountQuery: NamedQuery<ProjectDocCountRow, undefined> = {
   sql: projectDocCountSql,
   mapRow: projectDocCountMapRow,
   tables: projectDocCountTables,
+  resultColumns: [{ name: 'projectId', type: 'string', nullable: false }, { name: 'docCount', type: 'float', nullable: true }],
   dependencies: () => [
     { table: 'docs' },
   ],
@@ -528,6 +544,7 @@ export const reportingTasksByPriorityQuery: NamedQuery<ReportingTasksByPriorityR
   sql: reportingTasksByPrioritySql,
   mapRow: reportingTasksByPriorityMapRow,
   tables: reportingTasksByPriorityTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'priority', type: 'integer', nullable: true }],
   dependencies: () => [
     { table: 'tasks' },
   ],
@@ -575,6 +592,7 @@ export const reportOpenTasksQuery: NamedQuery<ReportOpenTasksRow, ReportOpenTask
   sql: reportOpenTasksSql,
   mapRow: reportOpenTasksMapRow,
   tables: reportOpenTasksTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
   ],
@@ -620,6 +638,7 @@ export const reportDocScoresQuery: NamedQuery<ReportDocScoresRow, ReportDocScore
   sql: reportDocScoresSql,
   mapRow: reportDocScoresMapRow,
   tables: reportDocScoresTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'orgId', type: 'string', nullable: false }, { name: 'score', type: 'float', nullable: true }],
   dependencies: () => [
     { table: 'docs' },
   ],
@@ -658,6 +677,7 @@ export const taskTitlesQuery: NamedQuery<TaskTitlesRow, undefined> = {
   sql: taskTitlesSql,
   mapRow: taskTitlesMapRow,
   tables: taskTitlesTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }],
   dependencies: () => [
     { table: 'tasks' },
   ],
@@ -707,6 +727,7 @@ export const taskValueTypesQuery: NamedQuery<TaskValueTypesRow, TaskValueTypesPa
   sql: taskValueTypesSql,
   mapRow: taskValueTypesMapRow,
   tables: taskValueTypesTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }, { name: 'priority', type: 'integer', nullable: true }, { name: 'estimate', type: 'float', nullable: true }, { name: 'meta', type: 'json', nullable: true }],
   dependencies: () => [
     { table: 'tasks' },
   ],
@@ -751,6 +772,7 @@ export const tasksInProjectsQuery: NamedQuery<TasksInProjectsRow, TasksInProject
   sql: tasksInProjectsSql,
   mapRow: tasksInProjectsMapRow,
   tables: tasksInProjectsTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.first) + '', 'project:' + String(params.second) + ''] },
   ],
@@ -795,6 +817,7 @@ export const tasksSinceQuery: NamedQuery<TasksSinceRow, TasksSinceParams> = {
   sql: tasksSinceSql,
   mapRow: tasksSinceMapRow,
   tables: tasksSinceTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }],
   dependencies: () => [
     { table: 'tasks' },
   ],
@@ -864,6 +887,7 @@ export const joinedSyncCoverageQuery: NamedQuery<JoinedSyncCoverageRow, JoinedSy
   mapRow: joinedSyncCoverageMapRow,
   sqlFor: (params: JoinedSyncCoverageParams) => joinedSyncCoverageSelect(params).sql,
   tables: joinedSyncCoverageTables,
+  resultColumns: [{ name: 'taskId', type: 'string', nullable: false }, { name: 'docId', type: 'string', nullable: false }, { name: 'body', type: 'string', nullable: false }],
   dependencies: (params) => [
     { table: 'docs', scopeKeys: ['org:' + String(params.orgId) + '', 'project:' + String(params.projectId) + ''] },
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
@@ -936,6 +960,7 @@ export const taskMetaFilterQuery: NamedQuery<TaskMetaFilterRow, TaskMetaFilterPa
   mapRow: taskMetaFilterMapRow,
   sqlFor: (params: TaskMetaFilterParams) => taskMetaFilterSelect(params).sql,
   tables: taskMetaFilterTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'meta', type: 'json', nullable: true }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
   ],
@@ -1022,6 +1047,7 @@ export const searchTasksQuery: NamedQuery<SearchTasksRow, SearchTasksParams> = {
   mapRow: searchTasksMapRow,
   sqlFor: (params: SearchTasksParams) => searchTasksSelect(params).sql,
   tables: searchTasksTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'done', type: 'boolean', nullable: false }, { name: 'priority', type: 'integer', nullable: true }, { name: 'estimatedAt', type: 'integer', nullable: true }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
   ],
@@ -1103,6 +1129,7 @@ export const taskEstimateRangeQuery: NamedQuery<TaskEstimateRangeRow, TaskEstima
   mapRow: taskEstimateRangeMapRow,
   sqlFor: (params: TaskEstimateRangeParams) => taskEstimateRangeSelect(params).sql,
   tables: taskEstimateRangeTables,
+  resultColumns: [{ name: 'id', type: 'string', nullable: false }, { name: 'title', type: 'string', nullable: false }, { name: 'estimate', type: 'float', nullable: true }],
   dependencies: (params) => [
     { table: 'tasks', scopeKeys: ['project:' + String(params.projectId) + ''] },
   ],

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -3,9 +3,9 @@
 The TypeScript client protocol core (SPEC.md §§3–8, client side) plus its
 browser platform bindings.
 
-The normal `SyncClient` also runs headlessly in a CLI or background service.
+The normal `SyncClient` also runs in a CLI or background service.
 Use `openBunDatabase(path)` or `openNodeDatabase(path)` for a persistent local
-replica. See the [headless client guide](https://syncular.dev/guide-headless-clients/).
+replica. See the [server-side sync client guide](https://syncular.dev/guide-server-clients/).
 
 `SyncRemoteClient` is the database-less server client. It sends ordinary
 push-only commits through `/sync` and can call registered typed queries,

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -3,6 +3,17 @@
 The TypeScript client protocol core (SPEC.md §§3–8, client side) plus its
 browser platform bindings.
 
+The normal `SyncClient` also runs headlessly in a CLI or background service.
+Use `openBunDatabase(path)` or `openNodeDatabase(path)` for a persistent local
+replica. See the [headless client guide](https://syncular.dev/guide-headless-clients/).
+
+`SyncRemoteClient` is the database-less server client. It sends ordinary
+push-only commits through `/sync` and can call registered typed queries,
+server-authoritative commands, and live query watches through the remote
+operation transport. See [remote server operations](https://syncular.dev/guide-remote-operations/).
+Its schema and sync transport are optional for query-only or command-only
+processes.
+
 ## Client-local FTS5 projections
 
 Generated schemas may attach `ftsIndexes` to a synced table. The

--- a/packages/web-client/src/http.ts
+++ b/packages/web-client/src/http.ts
@@ -9,6 +9,8 @@ import { SSP2_CONTENT_TYPE } from './content-type';
 import { ClientSyncError } from './errors';
 import type {
   RealtimeConnector,
+  RemoteOperationTransport,
+  RemoteOperationRealtimeConnector,
   SegmentDownloader,
   SyncTransport,
 } from './transport';
@@ -55,6 +57,57 @@ export function httpSyncTransport(
     if (!response.ok) await throwHttpError(response);
     return new Uint8Array(await response.arrayBuffer());
   };
+}
+
+/** POST one registered authoritative operation to `<mount>/operations`. */
+export function httpRemoteOperationTransport(
+  operationsUrl: string,
+  options?: HttpTransportOptions,
+): RemoteOperationTransport {
+  const doFetch = options?.fetch ?? fetch;
+  return async (request) => {
+    const response = await doFetch(operationsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.syncular.operations.v1+json',
+        ...options?.headers,
+      },
+      body: request.slice().buffer as ArrayBuffer,
+    });
+    if (!response.ok) await throwHttpError(response);
+    return new Uint8Array(await response.arrayBuffer());
+  };
+}
+
+/** WebSocket connector for registered query snapshots. */
+export function webSocketRemoteOperationConnector(
+  realtimeUrl: string,
+): RemoteOperationRealtimeConnector {
+  return (handlers) =>
+    new Promise((resolve, reject) => {
+      const socket = new WebSocket(realtimeUrl);
+      socket.binaryType = 'arraybuffer';
+      socket.onopen = () => {
+        resolve({
+          send: (bytes) => socket.send(bytes.slice().buffer as ArrayBuffer),
+          close: () => socket.close(),
+        });
+      };
+      socket.onmessage = (event) => {
+        if (event.data instanceof ArrayBuffer) {
+          handlers.onMessage(new Uint8Array(event.data));
+        }
+      };
+      socket.onerror = () =>
+        reject(
+          new ClientSyncError(
+            'sync.transport_failed',
+            'remote operation realtime socket failed to connect',
+            true,
+          ),
+        );
+      socket.onclose = () => handlers.onClose?.();
+    });
 }
 
 /**

--- a/packages/web-client/src/http.ts
+++ b/packages/web-client/src/http.ts
@@ -86,8 +86,10 @@ export function webSocketRemoteOperationConnector(
   return (handlers) =>
     new Promise((resolve, reject) => {
       const socket = new WebSocket(realtimeUrl);
+      let opened = false;
       socket.binaryType = 'arraybuffer';
       socket.onopen = () => {
+        opened = true;
         resolve({
           send: (bytes) => socket.send(bytes.slice().buffer as ArrayBuffer),
           close: () => socket.close(),
@@ -98,15 +100,34 @@ export function webSocketRemoteOperationConnector(
           handlers.onMessage(new Uint8Array(event.data));
         }
       };
-      socket.onerror = () =>
-        reject(
-          new ClientSyncError(
-            'sync.transport_failed',
-            'remote operation realtime socket failed to connect',
-            true,
-          ),
-        );
-      socket.onclose = () => handlers.onClose?.();
+      socket.onerror = () => {
+        if (!opened) {
+          reject(
+            new ClientSyncError(
+              'sync.transport_failed',
+              'remote operation realtime socket failed to connect',
+              true,
+            ),
+          );
+        }
+        try {
+          socket.close();
+        } catch {
+          handlers.onClose?.();
+        }
+      };
+      socket.onclose = () => {
+        if (!opened) {
+          reject(
+            new ClientSyncError(
+              'sync.transport_failed',
+              'remote operation realtime socket closed while connecting',
+              true,
+            ),
+          );
+        }
+        handlers.onClose?.();
+      };
     });
 }
 
@@ -277,8 +298,10 @@ export function webSocketRealtimeConnector(
   return (handlers) =>
     new Promise((resolve, reject) => {
       const socket = new WebSocket(realtimeUrl);
+      let opened = false;
       socket.binaryType = 'arraybuffer';
       socket.onopen = () => {
+        opened = true;
         resolve({
           send: (text) => socket.send(text),
           sendBytes: (bytes) => {
@@ -292,15 +315,31 @@ export function webSocketRealtimeConnector(
         else handlers.onBinary(new Uint8Array(event.data as ArrayBuffer));
       };
       socket.onerror = () => {
-        reject(
-          new ClientSyncError(
-            'sync.transport_failed',
-            'realtime socket failed to connect',
-            true,
-          ),
-        );
+        if (!opened) {
+          reject(
+            new ClientSyncError(
+              'sync.transport_failed',
+              'realtime socket failed to connect',
+              true,
+            ),
+          );
+        }
+        try {
+          socket.close();
+        } catch {
+          handlers.onClose?.();
+        }
       };
       socket.onclose = () => {
+        if (!opened) {
+          reject(
+            new ClientSyncError(
+              'sync.transport_failed',
+              'realtime socket closed while connecting',
+              true,
+            ),
+          );
+        }
         handlers.onClose?.();
       };
     });

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -30,6 +30,7 @@ export * from './outbox';
 export * from './outcomes';
 export * from './query-guard';
 export * from './reactive-store';
+export * from './remote';
 export * from './realtime-supervisor';
 export * from './schema';
 export * from './sql-tag';

--- a/packages/web-client/src/remote.ts
+++ b/packages/web-client/src/remote.ts
@@ -1,5 +1,5 @@
 /**
- * Database-less SSP2 producer (§6.9). It prepares and sends ordinary commits
+ * Database-less SSP2 producer (§6.10). It prepares and sends ordinary commits
  * through the existing push path without creating a local replica or outbox.
  */
 import {
@@ -116,6 +116,16 @@ function operationResponse(bytes: Uint8Array): RemoteOperationResponse {
       'remote operation response is malformed',
     );
   }
+  if (
+    typeof response !== 'object' ||
+    response === null ||
+    Array.isArray(response)
+  ) {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote operation response is malformed',
+    );
+  }
   if (response.revision !== 1) {
     throw new ClientSyncError(
       'client.invalid_host_response',
@@ -137,7 +147,11 @@ function operationResponse(bytes: Uint8Array): RemoteOperationResponse {
     response.kind === 'query' &&
     (typeof response.operationId !== 'string' ||
       !Array.isArray(response.rows) ||
-      !Number.isSafeInteger(response.maxCommitSeq))
+      response.rows.some(
+        (row) => typeof row !== 'object' || row === null || Array.isArray(row),
+      ) ||
+      !Number.isSafeInteger(response.maxCommitSeq) ||
+      response.maxCommitSeq < 0)
   ) {
     throw new ClientSyncError(
       'client.invalid_host_response',
@@ -151,7 +165,7 @@ function operationResponse(bytes: Uint8Array): RemoteOperationResponse {
       !['applied', 'cached', 'rejected'].includes(response.status) ||
       !Array.isArray(response.results) ||
       (response.commitSeq !== undefined &&
-        !Number.isSafeInteger(response.commitSeq)))
+        (!Number.isSafeInteger(response.commitSeq) || response.commitSeq < 1)))
   ) {
     throw new ClientSyncError(
       'client.invalid_host_response',
@@ -179,6 +193,7 @@ export class SyncRemoteClient {
   readonly #operationRealtime: RemoteOperationRealtimeConnector | undefined;
   #operationSocket: RemoteOperationRealtimeSocket | undefined;
   #operationSocketPromise: Promise<RemoteOperationRealtimeSocket> | undefined;
+  #operationSocketGeneration = 0;
   readonly #watches = new Map<
     string,
     {
@@ -373,10 +388,17 @@ export class SyncRemoteClient {
         'remote query returned a mismatched response',
       );
     }
-    return {
-      rows: response.rows.map((row) => descriptor.mapRow(row)),
-      maxCommitSeq: response.maxCommitSeq,
-    };
+    try {
+      return {
+        rows: response.rows.map((row) => descriptor.mapRow(row)),
+        maxCommitSeq: response.maxCommitSeq,
+      };
+    } catch {
+      throw new ClientSyncError(
+        'client.invalid_host_response',
+        'remote query row is malformed',
+      );
+    }
   }
 
   async command<Input = undefined>(
@@ -449,26 +471,64 @@ export class SyncRemoteClient {
       mapRow: descriptor.mapRow,
       handlers: handlers as RemoteQueryWatchHandlers<unknown>,
     });
-    const socket = await this.#operationRealtimeSocket();
-    socket.send(
-      encodeRemoteOperationRealtimeMessage({
-        revision: 1,
-        kind: 'watch',
-        watchId,
-        clientId: this.#clientId,
-        operationId: descriptor.id,
-        params,
-      }),
-    );
-    return () => {
-      if (!this.#watches.delete(watchId)) return;
-      this.#operationSocket?.send(
+    let socket: RemoteOperationRealtimeSocket;
+    try {
+      socket = await this.#operationRealtimeSocket();
+    } catch (error) {
+      this.#watches.delete(watchId);
+      throw error;
+    }
+    if (!this.#watches.has(watchId)) {
+      throw new ClientSyncError(
+        'client.remote_realtime_cancelled',
+        'remote operation watch was cancelled before registration',
+      );
+    }
+    try {
+      socket.send(
         encodeRemoteOperationRealtimeMessage({
           revision: 1,
-          kind: 'unwatch',
+          kind: 'watch',
           watchId,
+          clientId: this.#clientId,
+          operationId: descriptor.id,
+          params: params ?? null,
         }),
       );
+    } catch {
+      const error = new ClientSyncError(
+        'client.remote_realtime_closed',
+        'remote operation realtime connection closed while registering a watch',
+        true,
+      );
+      this.#disconnectOperationRealtime(
+        this.#operationSocketGeneration,
+        error,
+        true,
+      );
+      throw error;
+    }
+    return () => {
+      if (!this.#watches.delete(watchId)) return;
+      try {
+        this.#operationSocket?.send(
+          encodeRemoteOperationRealtimeMessage({
+            revision: 1,
+            kind: 'unwatch',
+            watchId,
+          }),
+        );
+      } catch {
+        this.#disconnectOperationRealtime(
+          this.#operationSocketGeneration,
+          new ClientSyncError(
+            'client.remote_realtime_closed',
+            'remote operation realtime connection closed while removing a watch',
+            true,
+          ),
+          true,
+        );
+      }
     };
   }
 
@@ -484,57 +544,181 @@ export class SyncRemoteClient {
         'SyncRemoteClient has no remote operation realtime connector',
       );
     }
-    this.#operationSocketPromise = Promise.resolve(
+    const generation = this.#operationSocketGeneration;
+    const pending = Promise.resolve(
       connector({
         onMessage: (bytes) => {
-          const message = decodeRemoteOperationRealtimeMessage(bytes);
-          if (message.kind !== 'snapshot' && message.kind !== 'watch_error') {
+          if (generation !== this.#operationSocketGeneration) return;
+          let message;
+          try {
+            message = decodeRemoteOperationRealtimeMessage(bytes);
+            if (
+              typeof message !== 'object' ||
+              message === null ||
+              message.revision !== 1 ||
+              (message.kind !== 'snapshot' && message.kind !== 'watch_error') ||
+              typeof message.watchId !== 'string'
+            ) {
+              throw new Error('invalid remote operation realtime message');
+            }
+          } catch {
+            this.#disconnectOperationRealtime(
+              generation,
+              new ClientSyncError(
+                'client.invalid_host_response',
+                'remote operation realtime message is malformed',
+              ),
+              true,
+            );
             return;
           }
           const watch = this.#watches.get(message.watchId);
           if (watch === undefined) return;
           if (message.kind === 'watch_error') {
-            watch.handlers.onError?.(
+            if (
+              typeof message.code !== 'string' ||
+              typeof message.message !== 'string' ||
+              typeof message.retryable !== 'boolean'
+            ) {
+              this.#disconnectOperationRealtime(
+                generation,
+                new ClientSyncError(
+                  'client.invalid_host_response',
+                  'remote operation watch error is malformed',
+                ),
+                true,
+              );
+              return;
+            }
+            try {
+              watch.handlers.onError?.(
+                new ClientSyncError(
+                  message.code,
+                  message.message,
+                  message.retryable,
+                ),
+              );
+            } catch {
+              // An observer cannot alter the connection lifecycle.
+            }
+            return;
+          }
+          if (
+            message.operationId !== watch.operationId ||
+            !Array.isArray(message.rows) ||
+            message.rows.some(
+              (row) =>
+                typeof row !== 'object' || row === null || Array.isArray(row),
+            ) ||
+            !Number.isSafeInteger(message.maxCommitSeq) ||
+            message.maxCommitSeq < 0
+          ) {
+            this.#disconnectOperationRealtime(
+              generation,
               new ClientSyncError(
-                message.code,
-                message.message,
-                message.retryable,
+                'client.invalid_host_response',
+                'remote operation watch snapshot is malformed',
               ),
+              true,
             );
             return;
           }
-          if (message.operationId !== watch.operationId) return;
-          watch.handlers.onSnapshot({
-            rows: message.rows.map(watch.mapRow),
-            maxCommitSeq: message.maxCommitSeq,
-          });
-        },
-        onClose: () => {
-          this.#operationSocket = undefined;
-          this.#operationSocketPromise = undefined;
-          for (const watch of this.#watches.values()) {
-            watch.handlers.onError?.(
-              new ClientSyncError(
-                'client.remote_realtime_closed',
-                'remote operation realtime connection closed',
-                true,
-              ),
-            );
+          let rows: unknown[];
+          try {
+            rows = message.rows.map(watch.mapRow);
+          } catch {
+            try {
+              watch.handlers.onError?.(
+                new ClientSyncError(
+                  'client.invalid_host_response',
+                  'remote operation watch row is malformed',
+                ),
+              );
+            } catch {
+              // An observer cannot alter the connection lifecycle.
+            }
+            return;
+          }
+          try {
+            watch.handlers.onSnapshot({
+              rows,
+              maxCommitSeq: message.maxCommitSeq,
+            });
+          } catch {
+            // An observer cannot alter the connection lifecycle.
           }
         },
+        onClose: () => {
+          this.#disconnectOperationRealtime(
+            generation,
+            new ClientSyncError(
+              'client.remote_realtime_closed',
+              'remote operation realtime connection closed',
+              true,
+            ),
+            false,
+          );
+        },
       }),
-    ).then((socket) => {
-      this.#operationSocket = socket;
-      this.#operationSocketPromise = undefined;
-      return socket;
-    });
-    return this.#operationSocketPromise;
+    )
+      .then((socket) => {
+        if (generation !== this.#operationSocketGeneration) {
+          try {
+            socket.close();
+          } catch {
+            // The cancelled socket cannot affect the replacement generation.
+          }
+          throw new ClientSyncError(
+            'client.remote_realtime_cancelled',
+            'remote operation realtime connection was cancelled',
+          );
+        }
+        this.#operationSocket = socket;
+        return socket;
+      })
+      .finally(() => {
+        if (this.#operationSocketPromise === pending) {
+          this.#operationSocketPromise = undefined;
+        }
+      });
+    this.#operationSocketPromise = pending;
+    return pending;
+  }
+
+  #disconnectOperationRealtime(
+    generation: number,
+    error: ClientSyncError | undefined,
+    closeSocket: boolean,
+  ): void {
+    if (generation !== this.#operationSocketGeneration) return;
+    this.#operationSocketGeneration += 1;
+    const socket = this.#operationSocket;
+    this.#operationSocket = undefined;
+    this.#operationSocketPromise = undefined;
+    const watches = [...this.#watches.values()];
+    this.#watches.clear();
+    if (closeSocket) {
+      try {
+        socket?.close();
+      } catch {
+        // Local state is already disconnected.
+      }
+    }
+    if (error === undefined) return;
+    for (const watch of watches) {
+      try {
+        watch.handlers.onError?.(error);
+      } catch {
+        // An observer cannot alter the connection lifecycle.
+      }
+    }
   }
 
   close(): void {
-    this.#operationSocket?.close();
-    this.#operationSocket = undefined;
-    this.#operationSocketPromise = undefined;
-    this.#watches.clear();
+    this.#disconnectOperationRealtime(
+      this.#operationSocketGeneration,
+      undefined,
+      true,
+    );
   }
 }

--- a/packages/web-client/src/remote.ts
+++ b/packages/web-client/src/remote.ts
@@ -1,0 +1,540 @@
+/**
+ * Database-less SSP2 producer (§6.9). It prepares and sends ordinary commits
+ * through the existing push path without creating a local replica or outbox.
+ */
+import {
+  decodeMessage,
+  decodeRemoteOperationResponse,
+  decodeRemoteOperationRealtimeMessage,
+  encodeMessage,
+  encodeRemoteOperationRequest,
+  encodeRemoteOperationRealtimeMessage,
+  encodeRow,
+  PROTOCOL_WIRE_VERSION,
+  type PushOperation,
+  type PushOperationResult,
+  type PushResultDetailsFrame,
+  type PushResultFrame,
+  type RemoteOperationResponse,
+} from '@syncular/core';
+import type { MutationInput } from './client';
+import type { EncryptionConfig } from './encryption';
+import { encryptRowValues } from './encryption';
+import { ClientSyncError } from './errors';
+import {
+  compileClientSchema,
+  type ClientSchema,
+  recordToRowValues,
+} from './schema';
+import type { SyncTransport } from './transport';
+import type {
+  RemoteOperationRealtimeConnector,
+  RemoteOperationRealtimeSocket,
+  RemoteOperationTransport,
+} from './transport';
+
+export interface SyncRemoteClientConfig {
+  /** Required only for ordinary row commits. */
+  readonly schema?: ClientSchema;
+  readonly clientId: string;
+  /** Required only for ordinary row commits. */
+  readonly transport?: SyncTransport;
+  readonly operations?: RemoteOperationTransport;
+  readonly operationRealtime?: RemoteOperationRealtimeConnector;
+  readonly encryption?: EncryptionConfig;
+}
+
+export interface RemoteCommitInput {
+  /** Stable caller-owned idempotency identity for this logical commit. */
+  readonly requestId: string;
+  readonly mutations: readonly MutationInput[];
+}
+
+/**
+ * Prepared bytes are the retry unit. Persist them when a process must retry
+ * across restart, especially when encryption uses randomized nonces.
+ */
+export interface PreparedRemoteCommit {
+  readonly requestId: string;
+  readonly bytes: Uint8Array;
+}
+
+export interface RemoteCommitResult {
+  readonly requestId: string;
+  readonly status: PushResultFrame['status'];
+  readonly commitSeq?: number;
+  readonly results: readonly PushOperationResult[];
+}
+
+export interface RemoteQueryDescriptor<Row, Params = undefined> {
+  readonly id: string;
+  readonly mapRow: (row: Readonly<Record<string, unknown>>) => Row;
+  readonly __row?: Row;
+  readonly __params?: Params;
+}
+
+export interface RemoteQueryResult<Row> {
+  readonly rows: readonly Row[];
+  readonly maxCommitSeq: number;
+}
+
+export interface RemoteQueryWatchHandlers<Row> {
+  onSnapshot(result: RemoteQueryResult<Row>): void;
+  onError?(error: ClientSyncError): void;
+}
+
+export interface RemoteCommandDescriptor<Input = undefined> {
+  readonly id: string;
+  readonly __input?: Input;
+}
+
+export function remoteCommand<Input = undefined>(
+  id: string,
+): RemoteCommandDescriptor<Input> {
+  if (id.length === 0) throw invalid('remote command id must be non-empty');
+  return { id };
+}
+
+export interface RemoteCommandResult {
+  readonly requestId: string;
+  readonly status: 'applied' | 'cached' | 'rejected';
+  readonly commitSeq?: number;
+  readonly results: readonly unknown[];
+}
+
+function invalid(message: string): ClientSyncError {
+  return new ClientSyncError('sync.invalid_request', message);
+}
+
+function operationResponse(bytes: Uint8Array): RemoteOperationResponse {
+  let response: RemoteOperationResponse;
+  try {
+    response = decodeRemoteOperationResponse(bytes);
+  } catch {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote operation response is malformed',
+    );
+  }
+  if (response.revision !== 1) {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote operation response has an unsupported revision',
+    );
+  }
+  if (
+    response.kind === 'error' &&
+    (typeof response.code !== 'string' ||
+      typeof response.message !== 'string' ||
+      typeof response.retryable !== 'boolean')
+  ) {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote operation error response is malformed',
+    );
+  }
+  if (
+    response.kind === 'query' &&
+    (typeof response.operationId !== 'string' ||
+      !Array.isArray(response.rows) ||
+      !Number.isSafeInteger(response.maxCommitSeq))
+  ) {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote query response is malformed',
+    );
+  }
+  if (
+    response.kind === 'command' &&
+    (typeof response.operationId !== 'string' ||
+      typeof response.requestId !== 'string' ||
+      !['applied', 'cached', 'rejected'].includes(response.status) ||
+      !Array.isArray(response.results) ||
+      (response.commitSeq !== undefined &&
+        !Number.isSafeInteger(response.commitSeq)))
+  ) {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote command response is malformed',
+    );
+  }
+  if (
+    response.kind !== 'error' &&
+    response.kind !== 'query' &&
+    response.kind !== 'command'
+  ) {
+    throw new ClientSyncError(
+      'client.invalid_host_response',
+      'remote operation response has an unknown kind',
+    );
+  }
+  return response;
+}
+
+export class SyncRemoteClient {
+  readonly #schema;
+  readonly #clientId: string;
+  readonly #transport: SyncTransport | undefined;
+  readonly #operations: RemoteOperationTransport | undefined;
+  readonly #operationRealtime: RemoteOperationRealtimeConnector | undefined;
+  #operationSocket: RemoteOperationRealtimeSocket | undefined;
+  #operationSocketPromise: Promise<RemoteOperationRealtimeSocket> | undefined;
+  readonly #watches = new Map<
+    string,
+    {
+      readonly operationId: string;
+      readonly mapRow: (row: Readonly<Record<string, unknown>>) => unknown;
+      readonly handlers: RemoteQueryWatchHandlers<unknown>;
+    }
+  >();
+  readonly #encryption: EncryptionConfig | undefined;
+
+  constructor(config: SyncRemoteClientConfig) {
+    if (config.clientId.length === 0) {
+      throw invalid('SyncRemoteClient clientId must be non-empty');
+    }
+    this.#schema =
+      config.schema === undefined
+        ? undefined
+        : compileClientSchema(config.schema);
+    this.#clientId = config.clientId;
+    this.#transport = config.transport;
+    this.#operations = config.operations;
+    this.#operationRealtime = config.operationRealtime;
+    this.#encryption = config.encryption;
+  }
+
+  async prepareCommit(input: RemoteCommitInput): Promise<PreparedRemoteCommit> {
+    const schema = this.#schema;
+    if (schema === undefined) {
+      throw new ClientSyncError(
+        'client.remote_schema_unconfigured',
+        'SyncRemoteClient needs a schema to prepare ordinary commits',
+      );
+    }
+    if (input.requestId.length === 0) {
+      throw invalid('remote commit requestId must be non-empty');
+    }
+    if (input.mutations.length === 0) {
+      throw new ClientSyncError(
+        'sync.empty_commit',
+        'a remote commit must carry at least one mutation (§6.1)',
+      );
+    }
+    const operations: PushOperation[] = [];
+    for (const mutation of input.mutations) {
+      const table = schema.tables.get(mutation.table);
+      if (table === undefined) {
+        throw invalid('remote commit targets an unknown table');
+      }
+      if (mutation.op === 'delete') {
+        if (mutation.rowId.length === 0) {
+          throw invalid('remote delete rowId must be non-empty');
+        }
+        operations.push({
+          table: mutation.table,
+          rowId: mutation.rowId,
+          op: 'delete',
+          ...(mutation.baseVersion !== undefined
+            ? { baseVersion: mutation.baseVersion }
+            : {}),
+        });
+        continue;
+      }
+      let values = recordToRowValues(table, mutation.values);
+      const rowId = values[table.primaryKeyIndex];
+      if (typeof rowId !== 'string' || rowId.length === 0) {
+        throw invalid('remote upsert requires a non-empty string primary key');
+      }
+      if (this.#encryption !== undefined && table.hasEncryptedColumns) {
+        values = await encryptRowValues(this.#encryption, table, rowId, values);
+      }
+      operations.push({
+        table: mutation.table,
+        rowId,
+        op: 'upsert',
+        ...(mutation.baseVersion !== undefined
+          ? { baseVersion: mutation.baseVersion }
+          : {}),
+        payload: encodeRow(table.columns, values),
+      });
+    }
+    return {
+      requestId: input.requestId,
+      bytes: encodeMessage({
+        wireVersion: PROTOCOL_WIRE_VERSION,
+        msgKind: 'request',
+        frames: [
+          {
+            type: 'REQ_HEADER',
+            clientId: this.#clientId,
+            schemaVersion: schema.version,
+          },
+          {
+            type: 'PUSH_COMMIT',
+            clientCommitId: input.requestId,
+            operations,
+          },
+        ],
+      }),
+    };
+  }
+
+  async sendCommit(
+    prepared: PreparedRemoteCommit,
+  ): Promise<RemoteCommitResult> {
+    if (this.#transport === undefined) {
+      throw new ClientSyncError(
+        'client.remote_sync_unconfigured',
+        'SyncRemoteClient has no sync transport for ordinary commits',
+      );
+    }
+    const response = decodeMessage(await this.#transport(prepared.bytes));
+    if (response.msgKind !== 'response') {
+      throw new ClientSyncError(
+        'client.invalid_host_response',
+        'remote commit transport returned a non-response SSP2 message',
+      );
+    }
+    const error = response.frames.find((frame) => frame.type === 'ERROR');
+    if (error?.type === 'ERROR') {
+      throw new ClientSyncError(error.code, error.message, error.retryable);
+    }
+    const result = response.frames.find(
+      (frame): frame is PushResultFrame =>
+        frame.type === 'PUSH_RESULT' &&
+        frame.clientCommitId === prepared.requestId,
+    );
+    if (result === undefined) {
+      throw new ClientSyncError(
+        'client.invalid_host_response',
+        'remote commit response carried no matching PUSH_RESULT',
+      );
+    }
+    const details = response.frames.find(
+      (frame): frame is PushResultDetailsFrame =>
+        frame.type === 'PUSH_RESULT_DETAILS' &&
+        frame.clientCommitId === prepared.requestId,
+    );
+    const detailsByIndex = new Map(
+      details?.entries.map((entry) => [entry.opIndex, entry.details]) ?? [],
+    );
+    return {
+      requestId: prepared.requestId,
+      status: result.status,
+      ...(result.commitSeq !== undefined
+        ? { commitSeq: result.commitSeq }
+        : {}),
+      results: result.results.map((operation) => {
+        if (operation.status !== 'error') return operation;
+        const operationDetails = detailsByIndex.get(operation.opIndex);
+        return operationDetails === undefined
+          ? operation
+          : { ...operation, details: operationDetails };
+      }),
+    };
+  }
+
+  async commit(input: RemoteCommitInput): Promise<RemoteCommitResult> {
+    return this.sendCommit(await this.prepareCommit(input));
+  }
+
+  async query<Row, Params = undefined>(
+    descriptor: RemoteQueryDescriptor<Row, Params>,
+    params?: Params,
+  ): Promise<RemoteQueryResult<Row>> {
+    if (this.#operations === undefined) {
+      throw new ClientSyncError(
+        'client.remote_operations_unconfigured',
+        'SyncRemoteClient has no remote operation transport',
+      );
+    }
+    const response = operationResponse(
+      await this.#operations(
+        encodeRemoteOperationRequest({
+          revision: 1,
+          kind: 'query',
+          clientId: this.#clientId,
+          operationId: descriptor.id,
+          params: params ?? null,
+        }),
+      ),
+    );
+    if (response.kind === 'error') {
+      throw new ClientSyncError(
+        response.code,
+        response.message,
+        response.retryable,
+      );
+    }
+    if (response.kind !== 'query' || response.operationId !== descriptor.id) {
+      throw new ClientSyncError(
+        'client.invalid_host_response',
+        'remote query returned a mismatched response',
+      );
+    }
+    return {
+      rows: response.rows.map((row) => descriptor.mapRow(row)),
+      maxCommitSeq: response.maxCommitSeq,
+    };
+  }
+
+  async command<Input = undefined>(
+    descriptor: RemoteCommandDescriptor<Input>,
+    requestId: string,
+    input?: Input,
+  ): Promise<RemoteCommandResult> {
+    if (this.#operations === undefined) {
+      throw new ClientSyncError(
+        'client.remote_operations_unconfigured',
+        'SyncRemoteClient has no remote operation transport',
+      );
+    }
+    if (requestId.length === 0) {
+      throw invalid('remote command requestId must be non-empty');
+    }
+    const response = operationResponse(
+      await this.#operations(
+        encodeRemoteOperationRequest({
+          revision: 1,
+          kind: 'command',
+          clientId: this.#clientId,
+          operationId: descriptor.id,
+          requestId,
+          params: input ?? null,
+        }),
+      ),
+    );
+    if (response.kind === 'error') {
+      throw new ClientSyncError(
+        response.code,
+        response.message,
+        response.retryable,
+      );
+    }
+    if (
+      response.kind !== 'command' ||
+      response.operationId !== descriptor.id ||
+      response.requestId !== requestId
+    ) {
+      throw new ClientSyncError(
+        'client.invalid_host_response',
+        'remote command returned a mismatched response',
+      );
+    }
+    return {
+      requestId,
+      status: response.status,
+      ...(response.commitSeq !== undefined
+        ? { commitSeq: response.commitSeq }
+        : {}),
+      results: response.results,
+    };
+  }
+
+  async watch<Row, Params = undefined>(
+    descriptor: RemoteQueryDescriptor<Row, Params>,
+    params: Params,
+    handlers: RemoteQueryWatchHandlers<Row>,
+  ): Promise<() => void> {
+    if (this.#operationRealtime === undefined) {
+      throw new ClientSyncError(
+        'client.remote_realtime_unconfigured',
+        'SyncRemoteClient has no remote operation realtime connector',
+      );
+    }
+    const watchId = crypto.randomUUID();
+    this.#watches.set(watchId, {
+      operationId: descriptor.id,
+      mapRow: descriptor.mapRow,
+      handlers: handlers as RemoteQueryWatchHandlers<unknown>,
+    });
+    const socket = await this.#operationRealtimeSocket();
+    socket.send(
+      encodeRemoteOperationRealtimeMessage({
+        revision: 1,
+        kind: 'watch',
+        watchId,
+        clientId: this.#clientId,
+        operationId: descriptor.id,
+        params,
+      }),
+    );
+    return () => {
+      if (!this.#watches.delete(watchId)) return;
+      this.#operationSocket?.send(
+        encodeRemoteOperationRealtimeMessage({
+          revision: 1,
+          kind: 'unwatch',
+          watchId,
+        }),
+      );
+    };
+  }
+
+  async #operationRealtimeSocket(): Promise<RemoteOperationRealtimeSocket> {
+    if (this.#operationSocket !== undefined) return this.#operationSocket;
+    if (this.#operationSocketPromise !== undefined) {
+      return this.#operationSocketPromise;
+    }
+    const connector = this.#operationRealtime;
+    if (connector === undefined) {
+      throw new ClientSyncError(
+        'client.remote_realtime_unconfigured',
+        'SyncRemoteClient has no remote operation realtime connector',
+      );
+    }
+    this.#operationSocketPromise = Promise.resolve(
+      connector({
+        onMessage: (bytes) => {
+          const message = decodeRemoteOperationRealtimeMessage(bytes);
+          if (message.kind !== 'snapshot' && message.kind !== 'watch_error') {
+            return;
+          }
+          const watch = this.#watches.get(message.watchId);
+          if (watch === undefined) return;
+          if (message.kind === 'watch_error') {
+            watch.handlers.onError?.(
+              new ClientSyncError(
+                message.code,
+                message.message,
+                message.retryable,
+              ),
+            );
+            return;
+          }
+          if (message.operationId !== watch.operationId) return;
+          watch.handlers.onSnapshot({
+            rows: message.rows.map(watch.mapRow),
+            maxCommitSeq: message.maxCommitSeq,
+          });
+        },
+        onClose: () => {
+          this.#operationSocket = undefined;
+          this.#operationSocketPromise = undefined;
+          for (const watch of this.#watches.values()) {
+            watch.handlers.onError?.(
+              new ClientSyncError(
+                'client.remote_realtime_closed',
+                'remote operation realtime connection closed',
+                true,
+              ),
+            );
+          }
+        },
+      }),
+    ).then((socket) => {
+      this.#operationSocket = socket;
+      this.#operationSocketPromise = undefined;
+      return socket;
+    });
+    return this.#operationSocketPromise;
+  }
+
+  close(): void {
+    this.#operationSocket?.close();
+    this.#operationSocket = undefined;
+    this.#operationSocketPromise = undefined;
+    this.#watches.clear();
+  }
+}

--- a/packages/web-client/src/transport.ts
+++ b/packages/web-client/src/transport.ts
@@ -8,6 +8,25 @@
 /** One combined push+pull round trip: SSP2 request bytes → response bytes. */
 export type SyncTransport = (request: Uint8Array) => Promise<Uint8Array>;
 
+/** One registered authoritative query or command request. */
+export type RemoteOperationTransport = (
+  request: Uint8Array,
+) => Promise<Uint8Array>;
+
+export interface RemoteOperationRealtimeHandlers {
+  onMessage(bytes: Uint8Array): void;
+  onClose?(): void;
+}
+
+export interface RemoteOperationRealtimeSocket {
+  send(bytes: Uint8Array): void;
+  close(): void;
+}
+
+export type RemoteOperationRealtimeConnector = (
+  handlers: RemoteOperationRealtimeHandlers,
+) => RemoteOperationRealtimeSocket | Promise<RemoteOperationRealtimeSocket>;
+
 export interface SegmentFetchRequest {
   readonly segmentId: string;
   readonly table: string;

--- a/packages/web-client/test/http.test.ts
+++ b/packages/web-client/test/http.test.ts
@@ -7,7 +7,12 @@
  * the client core).
  */
 import { describe, expect, test } from 'bun:test';
-import { ClientSyncError, httpSegmentDownloader } from '../src/index';
+import {
+  ClientSyncError,
+  httpSegmentDownloader,
+  webSocketRealtimeConnector,
+  webSocketRemoteOperationConnector,
+} from '../src/index';
 
 interface SeenRequest {
   readonly url: string;
@@ -74,5 +79,52 @@ describe('httpSegmentDownloader', () => {
     // Exactly one request: the downloader never touched the direct
     // endpoint on failure (§5.4 — descriptor invalidated, re-pull).
     expect(seen).toHaveLength(1);
+  });
+});
+
+describe('WebSocket connectors', () => {
+  test('reject a socket that closes before opening', async () => {
+    class ClosedBeforeOpenWebSocket {
+      static latest: ClosedBeforeOpenWebSocket | undefined;
+      binaryType = 'blob';
+      onclose: (() => void) | null = null;
+
+      constructor(_url: string) {
+        ClosedBeforeOpenWebSocket.latest = this;
+      }
+
+      send(): void {}
+      close(): void {}
+    }
+
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'WebSocket');
+    Object.defineProperty(globalThis, 'WebSocket', {
+      configurable: true,
+      value: ClosedBeforeOpenWebSocket,
+    });
+    try {
+      for (const connect of [
+        webSocketRealtimeConnector('wss://example.test/realtime'),
+        webSocketRemoteOperationConnector(
+          'wss://example.test/operations/realtime',
+        ),
+      ]) {
+        const pending = connect({
+          onText: () => undefined,
+          onBinary: () => undefined,
+          onMessage: () => undefined,
+        });
+        ClosedBeforeOpenWebSocket.latest?.onclose?.();
+        await expect(pending).rejects.toMatchObject({
+          code: 'sync.transport_failed',
+        });
+      }
+    } finally {
+      if (original === undefined) {
+        Reflect.deleteProperty(globalThis, 'WebSocket');
+      } else {
+        Object.defineProperty(globalThis, 'WebSocket', original);
+      }
+    }
   });
 });

--- a/packages/web-client/test/remote.test.ts
+++ b/packages/web-client/test/remote.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { decodeRow } from '@syncular/core';
+import {
+  decodeRow,
+  encodeRemoteOperationRealtimeMessage,
+  encodeRemoteOperationResponse,
+  type RemoteOperationResponse,
+} from '@syncular/core';
 import {
   composeRealtimeNotifiers,
   handleRemoteOperation,
@@ -10,7 +15,10 @@ import {
   RemoteOperationRegistry,
   RemoteOperationWatchHub,
 } from '@syncular/server';
-import { SyncRemoteClient } from '../src/index';
+import {
+  SyncRemoteClient,
+  type RemoteOperationRealtimeHandlers,
+} from '../src/index';
 import { CLIENT_SCHEMA, makeServer, PARTITION, TASK_COLUMNS } from './helpers';
 
 describe('SyncRemoteClient', () => {
@@ -238,6 +246,223 @@ describe('SyncRemoteClient', () => {
     server.storage.db.close();
   });
 
+  test('rejects scoped query metadata that omits a declared table scope', async () => {
+    const server = makeServer();
+    const descriptor = {
+      id: 'sha256:test/incompleteDocsCoverage',
+      hasParams: true,
+      sql: 'SELECT id FROM docs WHERE org_id = ? AND project_id = ?',
+      tables: ['docs'],
+      resultColumns: [{ name: 'id', type: 'string', nullable: false }] as const,
+      bind: (params: { orgId: string; projectId: string }) => [
+        params.orgId,
+        params.projectId,
+      ],
+      dependencies: () => [{ table: 'docs' }],
+      coverage: (params: { orgId: string }) => [
+        {
+          base: { table: 'docs', variable: 'org_id' },
+          units: [params.orgId],
+        },
+      ],
+      mapRow: (row: Readonly<Record<string, unknown>>) => ({
+        id: String(row.id),
+      }),
+    };
+    const registry = new RemoteOperationRegistry([
+      registerRemoteQuery(descriptor, {
+        maxRows: 10,
+        auth: { access: 'scoped' },
+      }),
+    ]);
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const client = new SyncRemoteClient({
+      clientId: 'query-worker',
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+
+    await expect(
+      client.query(descriptor, {
+        orgId: 'org-1',
+        projectId: 'project-1',
+      }),
+    ).rejects.toMatchObject({ code: 'operation.invalid_request' });
+    server.storage.db.close();
+  });
+
+  test('rejects registered query rows that violate generated result metadata', async () => {
+    const server = makeServer();
+    const descriptor = {
+      id: 'query/invalid-result',
+      hasParams: false,
+      sql: 'SELECT id, 1.5 AS estimate FROM tasks',
+      tables: ['tasks'],
+      resultColumns: [
+        { name: 'id', type: 'string', nullable: false },
+        { name: 'estimate', type: 'float', nullable: false },
+      ] as const,
+      bind: () => [],
+      dependencies: () => [{ table: 'tasks' }],
+      coverage: () => [],
+      mapRow: (row: Readonly<Record<string, unknown>>) => row,
+    };
+    const registry = new RemoteOperationRegistry([
+      registerRemoteQuery(descriptor, {
+        maxRows: 10,
+        auth: { access: 'privileged', authorize: () => true },
+      }),
+    ]);
+    server.storage.queryAuthoritative = async () => ({
+      rows: [{ id: null, estimate: 1.5 }],
+      maxCommitSeq: 0,
+    });
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const client = new SyncRemoteClient({
+      clientId: 'query-worker',
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+
+    await expect(client.query(descriptor)).rejects.toMatchObject({
+      code: 'operation.query_failed',
+    });
+    server.storage.queryAuthoritative = async () => ({
+      rows: [{ id: 'task-1', estimate: ' ' }],
+      maxCommitSeq: 0,
+    });
+    await expect(client.query(descriptor)).rejects.toMatchObject({
+      code: 'operation.query_failed',
+    });
+    server.storage.db.close();
+  });
+
+  test('returns only columns declared by generated result metadata', async () => {
+    const server = makeServer();
+    const descriptor = {
+      id: 'query/declared-result',
+      hasParams: false,
+      sql: 'SELECT id FROM tasks',
+      tables: ['tasks'],
+      resultColumns: [{ name: 'id', type: 'string', nullable: false }] as const,
+      bind: () => [],
+      dependencies: () => [{ table: 'tasks' }],
+      coverage: () => [],
+      mapRow: (row: Readonly<Record<string, unknown>>) => row,
+    };
+    const registry = new RemoteOperationRegistry([
+      registerRemoteQuery(descriptor, {
+        maxRows: 10,
+        auth: { access: 'privileged', authorize: () => true },
+      }),
+    ]);
+    server.storage.queryAuthoritative = async () => ({
+      rows: [{ id: 'task-1', internal: 'must-not-leak' }],
+      maxCommitSeq: 0,
+    });
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const client = new SyncRemoteClient({
+      clientId: 'query-worker',
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+
+    expect((await client.query(descriptor)).rows).toEqual([{ id: 'task-1' }]);
+    server.storage.db.close();
+  });
+
+  test('sanitizes generated row mapper failures', async () => {
+    const client = new SyncRemoteClient({
+      clientId: 'query-worker',
+      operations: async () =>
+        encodeRemoteOperationResponse({
+          revision: 1,
+          kind: 'query',
+          operationId: 'query/map-failure',
+          rows: [{}],
+          maxCommitSeq: 0,
+        }),
+    });
+
+    await expect(
+      client.query({
+        id: 'query/map-failure',
+        mapRow: () => {
+          throw new Error('raw mapper failure');
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'client.invalid_host_response',
+      message: 'remote query row is malformed',
+    });
+  });
+
+  test('rejects a non-object remote operation response', async () => {
+    const client = new SyncRemoteClient({
+      clientId: 'query-worker',
+      operations: async () => new TextEncoder().encode('{"t":"null"}'),
+    });
+
+    await expect(
+      client.query({ id: 'query/null', mapRow: (row) => row }),
+    ).rejects.toMatchObject({ code: 'client.invalid_host_response' });
+  });
+
+  test('rejects a remote operation clientId bound to another actor', async () => {
+    const server = makeServer();
+    const writer = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'bound-service',
+      transport: (bytes) => handleSyncRequest(bytes, server.ctxFor('worker')),
+    });
+    await writer.commit({
+      requestId: 'bind-client',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Bound',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+    const descriptor = {
+      id: 'sha256:test/boundClientQuery',
+      hasParams: false,
+      sql: 'SELECT id FROM tasks',
+      tables: ['tasks'],
+      resultColumns: [{ name: 'id', type: 'string', nullable: false }] as const,
+      bind: () => [],
+      dependencies: () => [{ table: 'tasks' }],
+      coverage: () => [],
+      mapRow: (row: Readonly<Record<string, unknown>>) => ({
+        id: String(row.id),
+      }),
+    };
+    const registry = new RemoteOperationRegistry([
+      registerRemoteQuery(descriptor, {
+        maxRows: 10,
+        auth: { access: 'privileged', authorize: () => true },
+      }),
+    ]);
+    const context = {
+      ...server.ctxFor('other-actor'),
+      storage: server.storage,
+    };
+    const client = new SyncRemoteClient({
+      clientId: 'bound-service',
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+
+    await expect(client.query(descriptor)).rejects.toMatchObject({
+      code: 'sync.invalid_client_id',
+    });
+    server.storage.db.close();
+  });
+
   test('runs an idempotent authoritative command inside the push transaction', async () => {
     const server = makeServer();
     const descriptor = remoteCommand<{ taskId: string }>(
@@ -304,6 +529,152 @@ describe('SyncRemoteClient', () => {
     server.storage.db.close();
   });
 
+  test('isolates command idempotency when actors reuse a clientId', async () => {
+    const server = makeServer();
+    const descriptor = remoteCommand('commands/actor-isolation');
+    let runs = 0;
+    const registry = new RemoteOperationRegistry([
+      registerRemoteCommand(descriptor, {
+        authorize: () => true,
+        run: ({ actorId }) => {
+          runs += 1;
+          return [
+            {
+              table: 'tasks',
+              op: 'upsert',
+              values: {
+                id: `task-${actorId}`,
+                project_id: 'project-1',
+                title: actorId,
+                done: false,
+                priority: null,
+                meta: null,
+              },
+            },
+          ];
+        },
+      }),
+    ]);
+    const firstContext = {
+      ...server.ctxFor('first-actor'),
+      storage: server.storage,
+    };
+    const secondContext = {
+      ...server.ctxFor('second-actor'),
+      storage: server.storage,
+    };
+    const first = new SyncRemoteClient({
+      clientId: 'shared-worker-id',
+      operations: (bytes) =>
+        handleRemoteOperation(bytes, firstContext, registry),
+    });
+    const second = new SyncRemoteClient({
+      clientId: 'shared-worker-id',
+      operations: (bytes) =>
+        handleRemoteOperation(bytes, secondContext, registry),
+    });
+
+    expect((await first.command(descriptor, 'request-1')).status).toBe(
+      'applied',
+    );
+    expect((await second.command(descriptor, 'request-1')).status).toBe(
+      'applied',
+    );
+    expect(runs).toBe(2);
+    expect(await server.storage.getMaxCommitSeq(PARTITION)).toBe(2);
+    server.storage.db.close();
+  });
+
+  test('keeps command and request id tuples collision-free', async () => {
+    const server = makeServer();
+    const firstDescriptor = remoteCommand<{ taskId: string }>('commands/a:b');
+    const secondDescriptor = remoteCommand<{ taskId: string }>('commands/a');
+    let runs = 0;
+    const register = (descriptor: typeof firstDescriptor, title: string) =>
+      registerRemoteCommand(descriptor, {
+        authorize: () => true,
+        run: async (context, input) => {
+          runs += 1;
+          const task = await context.getRow('tasks', input.taskId);
+          if (task === undefined) throw new Error('task is unavailable');
+          return [
+            {
+              table: 'tasks',
+              op: 'upsert' as const,
+              values: { ...task, title },
+            },
+          ];
+        },
+      });
+    const registry = new RemoteOperationRegistry([
+      register(firstDescriptor, 'First'),
+      register(secondDescriptor, 'Second'),
+    ]);
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const client = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'command-worker',
+      transport: (bytes) => handleSyncRequest(bytes, context),
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+    await client.commit({
+      requestId: 'seed-collision-test',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Original',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+
+    const first = await client.command(firstDescriptor, 'c', {
+      taskId: 'task-1',
+    });
+    const second = await client.command(secondDescriptor, 'b:c', {
+      taskId: 'task-1',
+    });
+
+    expect(first.status).toBe('applied');
+    expect(second.status).toBe('applied');
+    expect(runs).toBe(2);
+    expect(await server.storage.getMaxCommitSeq(PARTITION)).toBe(3);
+    server.storage.db.close();
+  });
+
+  test('reports unexpected command failures as server execution errors', async () => {
+    const server = makeServer();
+    const descriptor = remoteCommand('commands/fails');
+    const registry = new RemoteOperationRegistry([
+      registerRemoteCommand(descriptor, {
+        authorize: () => true,
+        run: () => {
+          throw new Error('private diagnostic');
+        },
+      }),
+    ]);
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const client = new SyncRemoteClient({
+      clientId: 'command-worker',
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+
+    await expect(client.command(descriptor, 'request-1')).rejects.toMatchObject(
+      {
+        code: 'operation.execution_failed',
+        message: 'registered remote operation failed',
+      },
+    );
+    server.storage.db.close();
+  });
+
   test('watches a registered query and receives replacement snapshots', async () => {
     const server = makeServer();
     const descriptor = {
@@ -311,6 +682,10 @@ describe('SyncRemoteClient', () => {
       hasParams: true,
       sql: 'SELECT id, title FROM tasks WHERE project_id = ? ORDER BY id',
       tables: ['tasks'],
+      resultColumns: [
+        { name: 'id', type: 'string', nullable: false },
+        { name: 'title', type: 'string', nullable: false },
+      ] as const,
       bind: (params: { projectId: string }) => [params.projectId],
       dependencies: () => [{ table: 'tasks' }],
       coverage: (params: { projectId: string }) => [
@@ -401,5 +776,171 @@ describe('SyncRemoteClient', () => {
     unwatch();
     client.close();
     server.storage.db.close();
+  });
+
+  test('does not publish a snapshot after its watch is removed', async () => {
+    const server = makeServer();
+    let finish!: (response: RemoteOperationResponse) => void;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const operation = {
+      kind: 'query' as const,
+      id: 'query/deferred',
+      tables: ['tasks'],
+      run: () =>
+        new Promise<RemoteOperationResponse>((resolve) => {
+          markStarted();
+          finish = resolve;
+        }),
+    };
+    const hub = new RemoteOperationWatchHub(
+      new RemoteOperationRegistry([operation]),
+    );
+    const sent: Uint8Array[] = [];
+    const session = hub.connect(server.ctxFor('worker'), (bytes) => {
+      sent.push(bytes);
+    });
+    const pending = session.receive(
+      encodeRemoteOperationRealtimeMessage({
+        revision: 1,
+        kind: 'watch',
+        watchId: 'watch-1',
+        clientId: 'worker-client',
+        operationId: operation.id,
+        params: null,
+      }),
+    );
+    await started;
+    await session.receive(
+      encodeRemoteOperationRealtimeMessage({
+        revision: 1,
+        kind: 'unwatch',
+        watchId: 'watch-1',
+      }),
+    );
+    finish({
+      revision: 1,
+      kind: 'query',
+      operationId: operation.id,
+      rows: [],
+      maxCommitSeq: 0,
+    });
+    await pending;
+
+    expect(sent).toEqual([]);
+    session.close();
+    server.storage.db.close();
+  });
+
+  test('rejects malformed watch messages with a stable operation error', async () => {
+    const server = makeServer();
+    const hub = new RemoteOperationWatchHub(new RemoteOperationRegistry([]));
+    const session = hub.connect(server.ctxFor('worker'), () => undefined);
+
+    await expect(
+      session.receive(new TextEncoder().encode('{')),
+    ).rejects.toMatchObject({ code: 'operation.invalid_request' });
+
+    session.close();
+    server.storage.db.close();
+  });
+
+  test('cancels a realtime connection that opens after close', async () => {
+    let connect!: (socket: {
+      send(bytes: Uint8Array): void;
+      close(): void;
+    }) => void;
+    let closes = 0;
+    const descriptor = {
+      id: 'query/pending-connect',
+      mapRow: (row: Readonly<Record<string, unknown>>) => row,
+    };
+    const client = new SyncRemoteClient({
+      clientId: 'watch-worker',
+      operationRealtime: () =>
+        new Promise((resolve) => {
+          connect = resolve;
+        }),
+    });
+    const pending = client.watch(descriptor, undefined, {
+      onSnapshot: () => undefined,
+    });
+    client.close();
+    connect({
+      send: () => undefined,
+      close: () => {
+        closes += 1;
+      },
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      code: 'client.remote_realtime_cancelled',
+    });
+    expect(closes).toBe(1);
+  });
+
+  test('closes realtime and reports a malformed server message', async () => {
+    let realtimeHandlers!: RemoteOperationRealtimeHandlers;
+    let closes = 0;
+    const errors: string[] = [];
+    const descriptor = {
+      id: 'query/malformed-message',
+      mapRow: (row: Readonly<Record<string, unknown>>) => row,
+    };
+    const client = new SyncRemoteClient({
+      clientId: 'watch-worker',
+      operationRealtime: (handlers) => {
+        realtimeHandlers = handlers;
+        return {
+          send: () => undefined,
+          close: () => {
+            closes += 1;
+          },
+        };
+      },
+    });
+    await client.watch(descriptor, undefined, {
+      onSnapshot: () => undefined,
+      onError: (error) => errors.push(error.code),
+    });
+
+    realtimeHandlers.onMessage(new TextEncoder().encode('{'));
+
+    expect(errors).toEqual(['client.invalid_host_response']);
+    expect(closes).toBe(1);
+  });
+
+  test('closes realtime when watch registration cannot be sent', async () => {
+    let closes = 0;
+    const errors: string[] = [];
+    const client = new SyncRemoteClient({
+      clientId: 'watch-worker',
+      operationRealtime: () => ({
+        send: () => {
+          throw new Error('socket closed');
+        },
+        close: () => {
+          closes += 1;
+        },
+      }),
+    });
+
+    await expect(
+      client.watch(
+        {
+          id: 'query/send-failure',
+          mapRow: (row: Readonly<Record<string, unknown>>) => row,
+        },
+        undefined,
+        {
+          onSnapshot: () => undefined,
+          onError: (error) => errors.push(error.code),
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'client.remote_realtime_closed' });
+    expect(errors).toEqual(['client.remote_realtime_closed']);
+    expect(closes).toBe(1);
   });
 });

--- a/packages/web-client/test/remote.test.ts
+++ b/packages/web-client/test/remote.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, test } from 'bun:test';
+import { decodeRow } from '@syncular/core';
+import {
+  composeRealtimeNotifiers,
+  handleRemoteOperation,
+  handleSyncRequest,
+  registerRemoteCommand,
+  registerRemoteQuery,
+  remoteCommand,
+  RemoteOperationRegistry,
+  RemoteOperationWatchHub,
+} from '@syncular/server';
+import { SyncRemoteClient } from '../src/index';
+import { CLIENT_SCHEMA, makeServer, PARTITION, TASK_COLUMNS } from './helpers';
+
+describe('SyncRemoteClient', () => {
+  test('applies an ordinary push-only commit without a local database', async () => {
+    const server = makeServer();
+    const client = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'appointment-worker',
+      transport: (bytes) => handleSyncRequest(bytes, server.ctxFor('worker')),
+    });
+
+    const outcome = await client.commit({
+      requestId: 'job-1',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            projectId: 'project-1',
+            title: 'Confirm appointment',
+            done: false,
+            priority: 2,
+            meta: '{"source":"worker"}',
+          },
+        },
+      ],
+    });
+
+    expect(outcome.status).toBe('applied');
+    expect(outcome.commitSeq).toBe(1);
+    const stored = await server.storage.getRow(PARTITION, 'tasks', 'task-1');
+    expect(stored).toBeDefined();
+    expect(
+      decodeRow(TASK_COLUMNS, stored?.payload ?? new Uint8Array()),
+    ).toEqual([
+      'task-1',
+      'project-1',
+      'Confirm appointment',
+      false,
+      2,
+      '{"source":"worker"}',
+    ]);
+    server.storage.db.close();
+  });
+
+  test('reuses prepared bytes after response loss and receives cached', async () => {
+    const server = makeServer();
+    const client = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'webhook-worker',
+      transport: (bytes) => handleSyncRequest(bytes, server.ctxFor('worker')),
+    });
+    const prepared = await client.prepareCommit({
+      requestId: 'webhook-7',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-7',
+            project_id: 'project-1',
+            title: 'Imported once',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+
+    await handleSyncRequest(prepared.bytes, server.ctxFor('worker'));
+    const replay = await client.sendCommit(prepared);
+
+    expect(replay.status).toBe('cached');
+    expect(replay.commitSeq).toBe(1);
+    expect(await server.storage.getMaxCommitSeq(PARTITION)).toBe(1);
+    server.storage.db.close();
+  });
+
+  test('surfaces conflicts directly and does not retain an outbox', async () => {
+    const server = makeServer();
+    const client = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'conflict-worker',
+      transport: (bytes) => handleSyncRequest(bytes, server.ctxFor('worker')),
+    });
+    await client.commit({
+      requestId: 'create',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Current',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+
+    const outcome = await client.commit({
+      requestId: 'stale-update',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          baseVersion: 0,
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Stale',
+            done: true,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+
+    expect(outcome.status).toBe('rejected');
+    expect(outcome.results[0]?.status).toBe('conflict');
+    server.storage.db.close();
+  });
+
+  test('runs a registered scoped query without a local database', async () => {
+    const server = makeServer();
+    const descriptor = {
+      id: 'sha256:test/tasksInProject',
+      hasParams: true,
+      sql: 'SELECT id, title, done, NULL AS attachment FROM tasks WHERE project_id = ? ORDER BY id',
+      tables: ['tasks'],
+      resultColumns: [
+        { name: 'id', type: 'string', nullable: false },
+        { name: 'title', type: 'string', nullable: false },
+        { name: 'done', type: 'boolean', nullable: false },
+        { name: 'attachment', type: 'bytes', nullable: true },
+      ] as const,
+      bind: (params: { projectId: string }) => [params.projectId],
+      dependencies: () => [{ table: 'tasks' }],
+      coverage: (params: { projectId: string }) => [
+        {
+          base: { table: 'tasks', variable: 'project_id' },
+          units: [params.projectId],
+        },
+      ],
+      mapRow: (row: Readonly<Record<string, unknown>>) => ({
+        id: String(row.id),
+        title: String(row.title),
+        done: row.done === true || row.done === 1,
+        attachment:
+          row.attachment instanceof Uint8Array
+            ? [...row.attachment]
+            : undefined,
+      }),
+    };
+    const registry = new RemoteOperationRegistry([
+      registerRemoteQuery(descriptor, {
+        maxRows: 100,
+        auth: { access: 'scoped' },
+      }),
+    ]);
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const queryAuthoritative = server.storage.queryAuthoritative.bind(
+      server.storage,
+    );
+    server.storage.queryAuthoritative = async (partition, query) => {
+      const result = await queryAuthoritative(partition, query);
+      return {
+        ...result,
+        rows: result.rows.map((row) => ({
+          ...row,
+          attachment: new Uint8Array([0, 1, 255]).buffer,
+        })),
+      };
+    };
+    const writer = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'query-writer',
+      transport: (bytes) => handleSyncRequest(bytes, context),
+    });
+    const client = new SyncRemoteClient({
+      clientId: 'query-worker',
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+    await writer.commit({
+      requestId: 'query-seed',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Visible',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+
+    const result = await client.query(descriptor, {
+      projectId: 'project-1',
+    });
+
+    expect(result.maxCommitSeq).toBe(1);
+    expect(result.rows).toEqual([
+      {
+        id: 'task-1',
+        title: 'Visible',
+        done: false,
+        attachment: [0, 1, 255],
+      },
+    ]);
+    server.allowed.worker = { project_id: ['project-1'] };
+    await expect(
+      client.query(descriptor, { projectId: 'project-2' }),
+    ).rejects.toMatchObject({ code: 'operation.forbidden' });
+    server.storage.db.close();
+  });
+
+  test('runs an idempotent authoritative command inside the push transaction', async () => {
+    const server = makeServer();
+    const descriptor = remoteCommand<{ taskId: string }>(
+      'commands/complete-task-v1',
+    );
+    let runs = 0;
+    const registry = new RemoteOperationRegistry([
+      registerRemoteCommand(descriptor, {
+        authorize: ({ actorId }) => actorId === 'worker',
+        run: async (context, input) => {
+          runs += 1;
+          const task = await context.getRow('tasks', input.taskId);
+          if (task === undefined) throw new Error('task is unavailable');
+          return [
+            {
+              table: 'tasks',
+              op: 'upsert',
+              values: { ...task, done: true },
+            },
+          ];
+        },
+      }),
+    ]);
+    const context = { ...server.ctxFor('worker'), storage: server.storage };
+    const client = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'command-worker',
+      transport: (bytes) => handleSyncRequest(bytes, context),
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+    });
+    await client.commit({
+      requestId: 'command-seed',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Complete me',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+
+    const first = await client.command(descriptor, 'request-1', {
+      taskId: 'task-1',
+    });
+    const replay = await client.command(descriptor, 'request-1', {
+      taskId: 'task-1',
+    });
+
+    expect(first.status).toBe('applied');
+    expect(first.commitSeq).toBe(2);
+    expect(replay.status).toBe('cached');
+    expect(runs).toBe(1);
+    const stored = await server.storage.getRow(PARTITION, 'tasks', 'task-1');
+    expect(
+      decodeRow(TASK_COLUMNS, stored?.payload ?? new Uint8Array())[3],
+    ).toBe(true);
+    server.storage.db.close();
+  });
+
+  test('watches a registered query and receives replacement snapshots', async () => {
+    const server = makeServer();
+    const descriptor = {
+      id: 'sha256:test/watchTasks',
+      hasParams: true,
+      sql: 'SELECT id, title FROM tasks WHERE project_id = ? ORDER BY id',
+      tables: ['tasks'],
+      bind: (params: { projectId: string }) => [params.projectId],
+      dependencies: () => [{ table: 'tasks' }],
+      coverage: (params: { projectId: string }) => [
+        {
+          base: { table: 'tasks', variable: 'project_id' },
+          units: [params.projectId],
+        },
+      ],
+      mapRow: (row: Readonly<Record<string, unknown>>) => ({
+        id: String(row.id),
+        title: String(row.title),
+      }),
+    };
+    const registry = new RemoteOperationRegistry([
+      registerRemoteQuery(descriptor, {
+        maxRows: 100,
+        auth: { access: 'scoped' },
+      }),
+    ]);
+    const watchHub = new RemoteOperationWatchHub(registry);
+    const baseContext = { ...server.ctxFor('worker'), storage: server.storage };
+    const context = {
+      ...baseContext,
+      realtime: composeRealtimeNotifiers(
+        baseContext.realtime ?? server.hub,
+        watchHub,
+      ),
+    };
+    const client = new SyncRemoteClient({
+      schema: CLIENT_SCHEMA,
+      clientId: 'watch-worker',
+      transport: (bytes) => handleSyncRequest(bytes, context),
+      operations: (bytes) => handleRemoteOperation(bytes, context, registry),
+      operationRealtime: (handlers) => {
+        const session = watchHub.connect(context, handlers.onMessage);
+        return {
+          send: (bytes) => {
+            void session.receive(bytes);
+          },
+          close: () => {
+            session.close();
+            handlers.onClose?.();
+          },
+        };
+      },
+    });
+    const snapshots: Array<readonly { id: string; title: string }[]> = [];
+    let resolveInitial!: () => void;
+    let resolveChanged!: () => void;
+    const initial = new Promise<void>((resolve) => {
+      resolveInitial = resolve;
+    });
+    const changed = new Promise<void>((resolve) => {
+      resolveChanged = resolve;
+    });
+    const unwatch = await client.watch(
+      descriptor,
+      { projectId: 'project-1' },
+      {
+        onSnapshot: (snapshot) => {
+          snapshots.push(snapshot.rows);
+          if (snapshots.length === 1) resolveInitial();
+          if (snapshots.length === 2) resolveChanged();
+        },
+      },
+    );
+    await initial;
+    await client.commit({
+      requestId: 'watch-change',
+      mutations: [
+        {
+          table: 'tasks',
+          op: 'upsert',
+          values: {
+            id: 'task-1',
+            project_id: 'project-1',
+            title: 'Now visible',
+            done: false,
+            priority: null,
+            meta: null,
+          },
+        },
+      ],
+    });
+    await changed;
+
+    expect(snapshots).toEqual([[], [{ id: 'task-1', title: 'Now visible' }]]);
+    unwatch();
+    client.close();
+    server.storage.db.close();
+  });
+});

--- a/rust/crates/client/src/lib.rs
+++ b/rust/crates/client/src/lib.rs
@@ -23,6 +23,7 @@ pub mod crdt;
 pub mod native_transport;
 pub mod query_guard;
 pub mod realtime_round;
+pub mod remote;
 pub mod schema;
 pub mod transport;
 pub mod values;
@@ -49,4 +50,8 @@ pub use transport::{BlobDownload, BlobUploadGrant, SegmentRequest, Transport, Tr
 // native transports (FFI + Tauri plugin) reach it through their existing
 // `syncular-client` dependency, without each adding a direct `ssp2` path dep.
 pub use realtime_round::{RealtimeRound, RoundInbound, REALTIME_TAG_DELTA, REALTIME_TAG_ROUND};
+pub use remote::{
+    PreparedRemoteCommit, RemoteBytes, RemoteClientError, RemoteCommandResult, RemoteCommitInput,
+    RemoteCommitResult, RemoteQueryResult, SyncRemoteClient,
+};
 pub use ssp2::{MessageStreamScanner, ScannedMessage};

--- a/rust/crates/client/src/native_transport.rs
+++ b/rust/crates/client/src/native_transport.rs
@@ -174,6 +174,14 @@ impl Transport for HostTransport {
         }
     }
 
+    fn remote_operation(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
+        match self {
+            HostTransport::Null { .. } => Err(unavailable("remoteOperation")),
+            #[cfg(feature = "native-transport")]
+            HostTransport::Native(t) => t.remote_operation(request),
+        }
+    }
+
     fn realtime_sync(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
         match self {
             HostTransport::Null { .. } => Err(unavailable("realtimeSync")),
@@ -546,6 +554,21 @@ mod native {
             read_body(resp)
         }
 
+        fn post_operation(&self, body: &[u8]) -> Result<Vec<u8>, TransportError> {
+            let url = format!("{}/operations", self.base_url);
+            let mut req = self.agent.post(&url).header(
+                "content-type",
+                "application/vnd.syncular.operations.v1+json",
+            );
+            for (key, value) in &self.headers {
+                req = req.header(key.as_str(), value.as_str());
+            }
+            let response = req
+                .send(body)
+                .map_err(|error| http_err("POST operation", error))?;
+            read_body(response)
+        }
+
         fn get_bytes(&self, url: &str, with_headers: bool) -> Result<Vec<u8>, TransportError> {
             let mut req = self.agent.get(url);
             if with_headers {
@@ -596,6 +619,10 @@ mod native {
     impl Transport for NativeTransport {
         fn sync(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
             self.post_sync("/sync", request)
+        }
+
+        fn remote_operation(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
+            self.post_operation(request)
         }
 
         fn realtime_sync(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {

--- a/rust/crates/client/src/remote.rs
+++ b/rust/crates/client/src/remote.rs
@@ -1,0 +1,828 @@
+//! Database-less SSP2 producer (`SPEC.md` §6.9).
+//!
+//! Prepared request bytes are the retry unit. A caller that needs crash-safe
+//! retry persists them in its own job or request store.
+
+use serde::de::DeserializeOwned;
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+use serde_json::{json, Map, Value};
+use ssp2::model::{Frame, Message, MsgKind, Op, OpResult, Operation, PushResultDetail, PushStatus};
+use ssp2::{decode_message, encode_message};
+
+use crate::api::Mutation;
+use crate::schema::ClientSchema;
+use crate::transport::Transport;
+use crate::values::{
+    encode_row_json, normalize_values_casing, render_row_id_json, EncryptionConfig,
+};
+
+#[derive(Debug, Clone)]
+pub struct RemoteCommitInput {
+    pub request_id: String,
+    pub mutations: Vec<Mutation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedRemoteCommit {
+    pub request_id: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoteCommitResult {
+    pub request_id: String,
+    pub status: PushStatus,
+    pub commit_seq: Option<i64>,
+    pub results: Vec<OpResult>,
+    pub details: Vec<PushResultDetail>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoteQueryResult<Row> {
+    pub rows: Vec<Row>,
+    pub max_commit_seq: i64,
+}
+
+/// Binary value for registered query and command parameters. Plain `Vec<u8>`
+/// serializes as a JSON array, so callers use this wrapper when the remote
+/// operation schema expects the protocol's `bytes` value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteBytes(pub Vec<u8>);
+
+impl Serialize for RemoteBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry("$syncular.bytes", &base64_encode(&self.0))?;
+        map.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoteCommandResult {
+    pub request_id: String,
+    pub status: String,
+    pub commit_seq: Option<i64>,
+    pub results: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteClientError {
+    pub code: String,
+    pub message: String,
+    pub retryable: bool,
+}
+
+impl RemoteClientError {
+    fn new(code: impl Into<String>, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            retryable,
+        }
+    }
+
+    fn invalid(message: impl Into<String>) -> Self {
+        Self::new("sync.invalid_request", message, false)
+    }
+
+    fn invalid_response(message: impl Into<String>) -> Self {
+        Self::new("client.invalid_host_response", message, false)
+    }
+}
+
+impl std::fmt::Display for RemoteClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for RemoteClientError {}
+
+pub struct SyncRemoteClient {
+    schema: Option<ClientSchema>,
+    client_id: String,
+    encryption: EncryptionConfig,
+}
+
+impl SyncRemoteClient {
+    pub fn new(
+        schema: ClientSchema,
+        client_id: impl Into<String>,
+    ) -> Result<Self, RemoteClientError> {
+        let mut client = Self::for_operations(client_id)?;
+        client.schema = Some(schema);
+        Ok(client)
+    }
+
+    pub fn for_operations(client_id: impl Into<String>) -> Result<Self, RemoteClientError> {
+        let client_id = client_id.into();
+        if client_id.is_empty() {
+            return Err(RemoteClientError::invalid(
+                "SyncRemoteClient clientId must be non-empty",
+            ));
+        }
+        Ok(Self {
+            schema: None,
+            client_id,
+            encryption: EncryptionConfig::default(),
+        })
+    }
+
+    pub fn with_encryption(mut self, encryption: EncryptionConfig) -> Self {
+        self.encryption = encryption;
+        self
+    }
+
+    pub fn prepare_commit(
+        &self,
+        input: RemoteCommitInput,
+    ) -> Result<PreparedRemoteCommit, RemoteClientError> {
+        if input.request_id.is_empty() {
+            return Err(RemoteClientError::invalid(
+                "remote commit requestId must be non-empty",
+            ));
+        }
+        if input.mutations.is_empty() {
+            return Err(RemoteClientError::new(
+                "sync.empty_commit",
+                "a remote commit must carry at least one mutation (§6.1)",
+                false,
+            ));
+        }
+        let schema = self.schema.as_ref().ok_or_else(|| {
+            RemoteClientError::new(
+                "client.remote_schema_unconfigured",
+                "SyncRemoteClient needs a schema to prepare ordinary commits",
+                false,
+            )
+        })?;
+        let mut operations = Vec::with_capacity(input.mutations.len());
+        for mutation in input.mutations {
+            match mutation {
+                Mutation::Upsert {
+                    table,
+                    values,
+                    base_version,
+                } => {
+                    let schema_table = schema.table(&table).ok_or_else(|| {
+                        RemoteClientError::invalid("remote commit targets an unknown table")
+                    })?;
+                    let values: Map<String, serde_json::Value> =
+                        normalize_values_casing(schema_table, values)
+                            .map_err(RemoteClientError::invalid)?;
+                    let row_id = render_row_id_json(values.get(&schema_table.primary_key))
+                        .map_err(RemoteClientError::invalid)?;
+                    let payload = encode_row_json(schema_table, &row_id, &values, &self.encryption)
+                        .map_err(RemoteClientError::invalid)?;
+                    operations.push(Operation {
+                        table,
+                        row_id,
+                        op: Op::Upsert,
+                        base_version,
+                        payload: Some(payload),
+                    });
+                }
+                Mutation::Delete {
+                    table,
+                    row_id,
+                    base_version,
+                } => {
+                    if schema.table(&table).is_none() {
+                        return Err(RemoteClientError::invalid(
+                            "remote commit targets an unknown table",
+                        ));
+                    }
+                    if row_id.is_empty() {
+                        return Err(RemoteClientError::invalid(
+                            "remote delete rowId must be non-empty",
+                        ));
+                    }
+                    operations.push(Operation {
+                        table,
+                        row_id,
+                        op: Op::Delete,
+                        base_version,
+                        payload: None,
+                    });
+                }
+            }
+        }
+        let bytes = encode_message(&Message {
+            msg_kind: MsgKind::Request,
+            frames: vec![
+                Frame::ReqHeader {
+                    client_id: self.client_id.clone(),
+                    schema_version: schema.version,
+                },
+                Frame::PushCommit {
+                    client_commit_id: input.request_id.clone(),
+                    operations,
+                },
+            ],
+        });
+        Ok(PreparedRemoteCommit {
+            request_id: input.request_id,
+            bytes,
+        })
+    }
+
+    pub fn send_commit<T: Transport>(
+        &self,
+        transport: &mut T,
+        prepared: &PreparedRemoteCommit,
+    ) -> Result<RemoteCommitResult, RemoteClientError> {
+        let bytes = transport
+            .sync(&prepared.bytes)
+            .map_err(|error| RemoteClientError::new(error.code, error.message, true))?;
+        let response = decode_message(&bytes).map_err(|_| {
+            RemoteClientError::invalid_response("remote commit response is not valid SSP2")
+        })?;
+        if response.msg_kind != MsgKind::Response {
+            return Err(RemoteClientError::invalid_response(
+                "remote commit transport returned a non-response SSP2 message",
+            ));
+        }
+        for frame in &response.frames {
+            if let Frame::Error {
+                code,
+                message,
+                retryable,
+                ..
+            } = frame
+            {
+                return Err(RemoteClientError::new(code, message, *retryable));
+            }
+        }
+        let mut matched = None;
+        let mut details = Vec::new();
+        for frame in response.frames {
+            match frame {
+                Frame::PushResult {
+                    client_commit_id,
+                    status,
+                    commit_seq,
+                    results,
+                } if client_commit_id == prepared.request_id => {
+                    matched = Some((status, commit_seq, results));
+                }
+                Frame::PushResultDetails {
+                    client_commit_id,
+                    entries,
+                } if client_commit_id == prepared.request_id => {
+                    details = entries;
+                }
+                _ => {}
+            }
+        }
+        let Some((status, commit_seq, results)) = matched else {
+            return Err(RemoteClientError::invalid_response(
+                "remote commit response carried no matching PUSH_RESULT",
+            ));
+        };
+        Ok(RemoteCommitResult {
+            request_id: prepared.request_id.clone(),
+            status,
+            commit_seq,
+            results,
+            details,
+        })
+    }
+
+    pub fn commit<T: Transport>(
+        &self,
+        transport: &mut T,
+        input: RemoteCommitInput,
+    ) -> Result<RemoteCommitResult, RemoteClientError> {
+        let prepared = self.prepare_commit(input)?;
+        self.send_commit(transport, &prepared)
+    }
+
+    pub fn query<T, Params, Row>(
+        &self,
+        transport: &mut T,
+        operation_id: &str,
+        params: &Params,
+    ) -> Result<RemoteQueryResult<Row>, RemoteClientError>
+    where
+        T: Transport,
+        Params: Serialize,
+        Row: DeserializeOwned,
+    {
+        if operation_id.is_empty() {
+            return Err(RemoteClientError::invalid(
+                "remote query id must be non-empty",
+            ));
+        }
+        let request = json!({
+            "revision": protocol_revision(),
+            "kind": "query",
+            "clientId": self.client_id,
+            "operationId": operation_id,
+            "params": serde_json::to_value(params)
+                .map_err(|error| RemoteClientError::invalid(error.to_string()))?,
+        });
+        let response = transport
+            .remote_operation(&encode_operation_value(&request)?)
+            .map_err(|error| RemoteClientError::new(error.code, error.message, true))?;
+        let decoded = decode_operation_value(&response)?;
+        if decoded.get("kind").and_then(Value::as_str) == Some("error") {
+            return Err(operation_error(&decoded));
+        }
+        if decoded.get("kind").and_then(Value::as_str) != Some("query")
+            || decoded.get("operationId").and_then(Value::as_str) != Some(operation_id)
+        {
+            return Err(RemoteClientError::invalid_response(
+                "remote query returned a mismatched response",
+            ));
+        }
+        let rows = serde_json::from_value(decoded.get("rows").cloned().unwrap_or(Value::Null))
+            .map_err(|error| RemoteClientError::invalid_response(error.to_string()))?;
+        let max_commit_seq = decoded
+            .get("maxCommitSeq")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| {
+                RemoteClientError::invalid_response("remote query response lacks maxCommitSeq")
+            })?;
+        Ok(RemoteQueryResult {
+            rows,
+            max_commit_seq,
+        })
+    }
+
+    pub fn command<T, Input>(
+        &self,
+        transport: &mut T,
+        operation_id: &str,
+        request_id: &str,
+        input: &Input,
+    ) -> Result<RemoteCommandResult, RemoteClientError>
+    where
+        T: Transport,
+        Input: Serialize,
+    {
+        if operation_id.is_empty() || request_id.is_empty() {
+            return Err(RemoteClientError::invalid(
+                "remote command id and requestId must be non-empty",
+            ));
+        }
+        let request = json!({
+            "revision": protocol_revision(),
+            "kind": "command",
+            "clientId": self.client_id,
+            "operationId": operation_id,
+            "requestId": request_id,
+            "params": serde_json::to_value(input)
+                .map_err(|error| RemoteClientError::invalid(error.to_string()))?,
+        });
+        let response = transport
+            .remote_operation(&encode_operation_value(&request)?)
+            .map_err(|error| RemoteClientError::new(error.code, error.message, true))?;
+        let decoded = decode_operation_value(&response)?;
+        if decoded.get("kind").and_then(Value::as_str) == Some("error") {
+            return Err(operation_error(&decoded));
+        }
+        if decoded.get("kind").and_then(Value::as_str) != Some("command")
+            || decoded.get("operationId").and_then(Value::as_str) != Some(operation_id)
+            || decoded.get("requestId").and_then(Value::as_str) != Some(request_id)
+        {
+            return Err(RemoteClientError::invalid_response(
+                "remote command returned a mismatched response",
+            ));
+        }
+        Ok(RemoteCommandResult {
+            request_id: request_id.to_owned(),
+            status: decoded
+                .get("status")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    RemoteClientError::invalid_response("remote command response lacks status")
+                })?
+                .to_owned(),
+            commit_seq: decoded.get("commitSeq").and_then(Value::as_i64),
+            results: decoded
+                .get("results")
+                .and_then(Value::as_array)
+                .cloned()
+                .ok_or_else(|| {
+                    RemoteClientError::invalid_response("remote command response lacks results")
+                })?,
+        })
+    }
+}
+
+fn protocol_revision() -> Value {
+    Value::Number(serde_json::Number::from_f64(1.0).expect("1.0 is finite"))
+}
+
+fn encode_tagged(value: &Value) -> Result<Value, RemoteClientError> {
+    Ok(match value {
+        Value::Null => json!({ "t": "null" }),
+        Value::Bool(value) => json!({ "t": "boolean", "v": value }),
+        Value::Number(value) if value.is_i64() || value.is_u64() => {
+            json!({ "t": "integer", "v": value.to_string() })
+        }
+        Value::Number(value) => json!({ "t": "number", "v": value }),
+        Value::String(value) => json!({ "t": "string", "v": value }),
+        Value::Array(values) => json!({
+            "t": "array",
+            "v": values.iter().map(encode_tagged).collect::<Result<Vec<_>, _>>()?,
+        }),
+        Value::Object(values)
+            if values.len() == 1
+                && values
+                    .get("$syncular.bytes")
+                    .and_then(Value::as_str)
+                    .is_some() =>
+        {
+            json!({
+                "t": "bytes",
+                "v": values
+                    .get("$syncular.bytes")
+                    .and_then(Value::as_str)
+                    .expect("guarded above"),
+            })
+        }
+        Value::Object(values) => json!({
+            "t": "object",
+            "v": values
+                .iter()
+                .map(|(key, value)| Ok(json!([key, encode_tagged(value)?])))
+                .collect::<Result<Vec<Value>, RemoteClientError>>()?,
+        }),
+    })
+}
+
+fn encode_operation_value(value: &Value) -> Result<Vec<u8>, RemoteClientError> {
+    serde_json::to_vec(&encode_tagged(value)?)
+        .map_err(|error| RemoteClientError::invalid(error.to_string()))
+}
+
+fn decode_tagged(value: &Value) -> Result<Value, RemoteClientError> {
+    let tag = value
+        .get("t")
+        .and_then(Value::as_str)
+        .ok_or_else(|| RemoteClientError::invalid_response("remote operation value lacks a tag"))?;
+    match tag {
+        "null" => Ok(Value::Null),
+        "boolean" | "number" | "string" => value.get("v").cloned().ok_or_else(|| {
+            RemoteClientError::invalid_response("remote operation value lacks data")
+        }),
+        "integer" => {
+            let raw = value.get("v").and_then(Value::as_str).ok_or_else(|| {
+                RemoteClientError::invalid_response("remote integer value is invalid")
+            })?;
+            let number = raw
+                .parse::<i64>()
+                .map_err(|_| RemoteClientError::invalid_response("remote integer exceeds i64"))?;
+            Ok(json!(number))
+        }
+        "bytes" => {
+            let raw = value.get("v").and_then(Value::as_str).ok_or_else(|| {
+                RemoteClientError::invalid_response("remote bytes value is invalid")
+            })?;
+            Ok(Value::Array(
+                base64_decode(raw)?
+                    .into_iter()
+                    .map(|byte| json!(byte))
+                    .collect(),
+            ))
+        }
+        "array" => {
+            let values = value.get("v").and_then(Value::as_array).ok_or_else(|| {
+                RemoteClientError::invalid_response("remote array value is invalid")
+            })?;
+            Ok(Value::Array(
+                values
+                    .iter()
+                    .map(decode_tagged)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        "object" => {
+            let entries = value.get("v").and_then(Value::as_array).ok_or_else(|| {
+                RemoteClientError::invalid_response("remote object value is invalid")
+            })?;
+            let mut object = Map::new();
+            for entry in entries {
+                let pair = entry.as_array().ok_or_else(|| {
+                    RemoteClientError::invalid_response("remote object entry is invalid")
+                })?;
+                let key = pair.first().and_then(Value::as_str).ok_or_else(|| {
+                    RemoteClientError::invalid_response("remote object key is invalid")
+                })?;
+                let encoded = pair.get(1).ok_or_else(|| {
+                    RemoteClientError::invalid_response("remote object entry lacks a value")
+                })?;
+                object.insert(key.to_owned(), decode_tagged(encoded)?);
+            }
+            Ok(Value::Object(object))
+        }
+        _ => Err(RemoteClientError::invalid_response(
+            "remote operation value has an unknown tag",
+        )),
+    }
+}
+
+fn decode_operation_value(bytes: &[u8]) -> Result<Value, RemoteClientError> {
+    let encoded: Value = serde_json::from_slice(bytes)
+        .map_err(|error| RemoteClientError::invalid_response(error.to_string()))?;
+    decode_tagged(&encoded)
+}
+
+fn operation_error(value: &Value) -> RemoteClientError {
+    RemoteClientError::new(
+        value
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("client.invalid_host_response"),
+        value
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("remote operation failed"),
+        value
+            .get("retryable")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    )
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut output = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let first = chunk[0];
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+        output.push(ALPHABET[(first >> 2) as usize] as char);
+        output.push(ALPHABET[(((first & 0x03) << 4) | (second >> 4)) as usize] as char);
+        output.push(if chunk.len() > 1 {
+            ALPHABET[(((second & 0x0f) << 2) | (third >> 6)) as usize] as char
+        } else {
+            '='
+        });
+        output.push(if chunk.len() > 2 {
+            ALPHABET[(third & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    output
+}
+
+fn base64_decode(text: &str) -> Result<Vec<u8>, RemoteClientError> {
+    if !text.len().is_multiple_of(4) {
+        return Err(RemoteClientError::invalid_response(
+            "remote bytes value is invalid base64",
+        ));
+    }
+    let mut output = Vec::with_capacity((text.len() / 4) * 3);
+    for (chunk_index, chunk) in text.as_bytes().chunks(4).enumerate() {
+        let last = chunk_index + 1 == text.len() / 4;
+        let padding = if chunk[2] == b'=' {
+            2
+        } else if chunk[3] == b'=' {
+            1
+        } else {
+            0
+        };
+        if (!last && padding != 0) || (padding == 2 && chunk[3] != b'=') {
+            return Err(RemoteClientError::invalid_response(
+                "remote bytes value is invalid base64",
+            ));
+        }
+        let mut values = [0_u8; 4];
+        for (index, byte) in chunk.iter().copied().enumerate() {
+            values[index] = match byte {
+                b'A'..=b'Z' => byte - b'A',
+                b'a'..=b'z' => byte - b'a' + 26,
+                b'0'..=b'9' => byte - b'0' + 52,
+                b'+' => 62,
+                b'/' => 63,
+                b'=' if index >= 2 => 0,
+                _ => {
+                    return Err(RemoteClientError::invalid_response(
+                        "remote bytes value is invalid base64",
+                    ))
+                }
+            };
+        }
+        output.push((values[0] << 2) | (values[1] >> 4));
+        if padding < 2 {
+            output.push((values[1] << 4) | (values[2] >> 2));
+        }
+        if padding == 0 {
+            output.push((values[2] << 6) | values[3]);
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Map};
+    use ssp2::model::{Frame, Message, MsgKind, Op, OpResult, PushStatus};
+    use ssp2::{decode_message, encode_message};
+
+    use super::{
+        decode_operation_value, encode_operation_value, RemoteBytes, RemoteCommitInput,
+        SyncRemoteClient,
+    };
+    use crate::api::Mutation;
+    use crate::schema::{compile_schema, ColumnIr, SchemaIr, ScopePatternIr, TableIr};
+    use crate::transport::{SegmentRequest, Transport, TransportError};
+
+    struct CachedTransport {
+        requests: Vec<Vec<u8>>,
+        operation_response: Option<Vec<u8>>,
+    }
+
+    impl Transport for CachedTransport {
+        fn sync(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
+            self.requests.push(request.to_vec());
+            Ok(encode_message(&Message {
+                msg_kind: MsgKind::Response,
+                frames: vec![
+                    Frame::RespHeader {
+                        required_schema_version: None,
+                        latest_schema_version: None,
+                    },
+                    Frame::PushResult {
+                        client_commit_id: "job-1".to_owned(),
+                        status: PushStatus::Cached,
+                        commit_seq: Some(7),
+                        results: vec![OpResult::Applied { op_index: 0 }],
+                    },
+                ],
+            }))
+        }
+
+        fn remote_operation(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
+            self.requests.push(request.to_vec());
+            self.operation_response
+                .clone()
+                .ok_or_else(|| TransportError::new("unused", "unused"))
+        }
+
+        fn realtime_sync(&mut self, _request: &[u8]) -> Result<Vec<u8>, TransportError> {
+            Err(TransportError::new("unused", "unused"))
+        }
+
+        fn download_segment(
+            &mut self,
+            _request: &SegmentRequest,
+        ) -> Result<Vec<u8>, TransportError> {
+            Err(TransportError::new("unused", "unused"))
+        }
+
+        fn realtime_connect(&mut self) -> Result<(), TransportError> {
+            Err(TransportError::new("unused", "unused"))
+        }
+
+        fn realtime_send(&mut self, _text: &str) -> Result<(), TransportError> {
+            Err(TransportError::new("unused", "unused"))
+        }
+
+        fn realtime_close(&mut self) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn schema() -> crate::schema::ClientSchema {
+        compile_schema(&SchemaIr {
+            version: 1,
+            tables: vec![TableIr {
+                name: "tasks".to_owned(),
+                columns: vec![
+                    ColumnIr {
+                        name: "id".to_owned(),
+                        column_type: "string".to_owned(),
+                        nullable: false,
+                        encrypted: false,
+                        declared_type: None,
+                    },
+                    ColumnIr {
+                        name: "project_id".to_owned(),
+                        column_type: "string".to_owned(),
+                        nullable: false,
+                        encrypted: false,
+                        declared_type: None,
+                    },
+                ],
+                primary_key: "id".to_owned(),
+                scopes: vec![ScopePatternIr {
+                    pattern: "project:{project_id}".to_owned(),
+                    column: None,
+                }],
+                indexes: Vec::new(),
+                fts_indexes: Vec::new(),
+            }],
+        })
+        .expect("schema compiles")
+    }
+
+    #[test]
+    fn prepares_push_only_bytes_and_reuses_them_for_retry() {
+        let client = SyncRemoteClient::new(schema(), "worker").expect("client");
+        let prepared = client
+            .prepare_commit(RemoteCommitInput {
+                request_id: "job-1".to_owned(),
+                mutations: vec![Mutation::Upsert {
+                    table: "tasks".to_owned(),
+                    values: Map::from_iter([
+                        ("id".to_owned(), json!("task-1")),
+                        ("projectId".to_owned(), json!("project-1")),
+                    ]),
+                    base_version: None,
+                }],
+            })
+            .expect("prepare");
+        let request = decode_message(&prepared.bytes).expect("request decodes");
+        assert!(matches!(
+            request.frames.as_slice(),
+            [
+                Frame::ReqHeader { .. },
+                Frame::PushCommit { operations, .. }
+            ] if operations.len() == 1 && operations[0].op == Op::Upsert
+        ));
+
+        let mut transport = CachedTransport {
+            requests: Vec::new(),
+            operation_response: None,
+        };
+        let first = client
+            .send_commit(&mut transport, &prepared)
+            .expect("first response");
+        let second = client
+            .send_commit(&mut transport, &prepared)
+            .expect("retry response");
+        assert_eq!(first.status, PushStatus::Cached);
+        assert_eq!(second.commit_seq, Some(7));
+        assert_eq!(
+            transport.requests,
+            vec![prepared.bytes.clone(), prepared.bytes]
+        );
+    }
+
+    #[derive(Debug, Serialize)]
+    struct QueryParams {
+        project_id: String,
+        digest: RemoteBytes,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct QueryRow {
+        id: String,
+        digest: Vec<u8>,
+    }
+
+    #[test]
+    fn encodes_query_parameters_and_decodes_binary_rows() {
+        let client = SyncRemoteClient::new(schema(), "worker").expect("client");
+        let response = json!({
+            "revision": super::protocol_revision(),
+            "kind": "query",
+            "operationId": "tasks/by-project",
+            "rows": [{
+                "id": "task-1",
+                "digest": { "$syncular.bytes": "AAEC/w==" },
+            }],
+            "maxCommitSeq": 9,
+        });
+        let mut transport = CachedTransport {
+            requests: Vec::new(),
+            operation_response: Some(encode_operation_value(&response).expect("response")),
+        };
+
+        let result = client
+            .query::<_, _, QueryRow>(
+                &mut transport,
+                "tasks/by-project",
+                &QueryParams {
+                    project_id: "project-1".to_owned(),
+                    digest: RemoteBytes(vec![0, 1, 2, 255]),
+                },
+            )
+            .expect("query");
+
+        assert_eq!(
+            result.rows,
+            vec![QueryRow {
+                id: "task-1".to_owned(),
+                digest: vec![0, 1, 2, 255],
+            }]
+        );
+        assert_eq!(result.max_commit_seq, 9);
+        assert_eq!(
+            decode_operation_value(&transport.requests[0]).expect("request")["params"]["digest"],
+            json!([0, 1, 2, 255])
+        );
+        assert!(String::from_utf8(transport.requests[0].clone())
+            .expect("utf8")
+            .contains("\"t\":\"bytes\""));
+    }
+}

--- a/rust/crates/client/src/remote.rs
+++ b/rust/crates/client/src/remote.rs
@@ -1,4 +1,4 @@
-//! Database-less SSP2 producer (`SPEC.md` §6.9).
+//! Database-less SSP2 producer (`SPEC.md` §6.10).
 //!
 //! Prepared request bytes are the retry unit. A caller that needs crash-safe
 //! retry persists them in its own job or request store.
@@ -329,8 +329,9 @@ impl SyncRemoteClient {
             .remote_operation(&encode_operation_value(&request)?)
             .map_err(|error| RemoteClientError::new(error.code, error.message, true))?;
         let decoded = decode_operation_value(&response)?;
+        validate_operation_revision(&decoded)?;
         if decoded.get("kind").and_then(Value::as_str) == Some("error") {
-            return Err(operation_error(&decoded));
+            return Err(operation_error(&decoded)?);
         }
         if decoded.get("kind").and_then(Value::as_str) != Some("query")
             || decoded.get("operationId").and_then(Value::as_str) != Some(operation_id)
@@ -344,8 +345,11 @@ impl SyncRemoteClient {
         let max_commit_seq = decoded
             .get("maxCommitSeq")
             .and_then(Value::as_i64)
+            .filter(|sequence| (0..=9_007_199_254_740_991).contains(sequence))
             .ok_or_else(|| {
-                RemoteClientError::invalid_response("remote query response lacks maxCommitSeq")
+                RemoteClientError::invalid_response(
+                    "remote query response has invalid maxCommitSeq",
+                )
             })?;
         Ok(RemoteQueryResult {
             rows,
@@ -382,8 +386,9 @@ impl SyncRemoteClient {
             .remote_operation(&encode_operation_value(&request)?)
             .map_err(|error| RemoteClientError::new(error.code, error.message, true))?;
         let decoded = decode_operation_value(&response)?;
+        validate_operation_revision(&decoded)?;
         if decoded.get("kind").and_then(Value::as_str) == Some("error") {
-            return Err(operation_error(&decoded));
+            return Err(operation_error(&decoded)?);
         }
         if decoded.get("kind").and_then(Value::as_str) != Some("command")
             || decoded.get("operationId").and_then(Value::as_str) != Some(operation_id)
@@ -393,16 +398,30 @@ impl SyncRemoteClient {
                 "remote command returned a mismatched response",
             ));
         }
+        let status = decoded
+            .get("status")
+            .and_then(Value::as_str)
+            .filter(|status| matches!(*status, "applied" | "cached" | "rejected"))
+            .ok_or_else(|| {
+                RemoteClientError::invalid_response("remote command response has invalid status")
+            })?;
+        let commit_seq = match decoded.get("commitSeq") {
+            Some(value) => Some(
+                value
+                    .as_i64()
+                    .filter(|sequence| (1..=9_007_199_254_740_991).contains(sequence))
+                    .ok_or_else(|| {
+                        RemoteClientError::invalid_response(
+                            "remote command response has invalid commitSeq",
+                        )
+                    })?,
+            ),
+            None => None,
+        };
         Ok(RemoteCommandResult {
             request_id: request_id.to_owned(),
-            status: decoded
-                .get("status")
-                .and_then(Value::as_str)
-                .ok_or_else(|| {
-                    RemoteClientError::invalid_response("remote command response lacks status")
-                })?
-                .to_owned(),
-            commit_seq: decoded.get("commitSeq").and_then(Value::as_i64),
+            status: status.to_owned(),
+            commit_seq,
             results: decoded
                 .get("results")
                 .and_then(Value::as_array)
@@ -422,7 +441,16 @@ fn encode_tagged(value: &Value) -> Result<Value, RemoteClientError> {
     Ok(match value {
         Value::Null => json!({ "t": "null" }),
         Value::Bool(value) => json!({ "t": "boolean", "v": value }),
-        Value::Number(value) if value.is_i64() || value.is_u64() => {
+        Value::Number(value) if value.is_i64() => {
+            json!({ "t": "integer", "v": value.to_string() })
+        }
+        Value::Number(value) if value.is_u64() => {
+            let integer = value.as_u64().expect("guarded above");
+            if integer > i64::MAX as u64 {
+                return Err(RemoteClientError::invalid(
+                    "remote operation integer exceeds signed 64-bit range",
+                ));
+            }
             json!({ "t": "integer", "v": value.to_string() })
         }
         Value::Number(value) => json!({ "t": "number", "v": value }),
@@ -468,9 +496,21 @@ fn decode_tagged(value: &Value) -> Result<Value, RemoteClientError> {
         .ok_or_else(|| RemoteClientError::invalid_response("remote operation value lacks a tag"))?;
     match tag {
         "null" => Ok(Value::Null),
-        "boolean" | "number" | "string" => value.get("v").cloned().ok_or_else(|| {
-            RemoteClientError::invalid_response("remote operation value lacks data")
-        }),
+        "boolean" => value
+            .get("v")
+            .filter(|value| value.is_boolean())
+            .cloned()
+            .ok_or_else(|| RemoteClientError::invalid_response("remote boolean value is invalid")),
+        "number" => value
+            .get("v")
+            .filter(|value| value.is_number())
+            .cloned()
+            .ok_or_else(|| RemoteClientError::invalid_response("remote number value is invalid")),
+        "string" => value
+            .get("v")
+            .filter(|value| value.is_string())
+            .cloned()
+            .ok_or_else(|| RemoteClientError::invalid_response("remote string value is invalid")),
         "integer" => {
             let raw = value.get("v").and_then(Value::as_str).ok_or_else(|| {
                 RemoteClientError::invalid_response("remote integer value is invalid")
@@ -478,6 +518,11 @@ fn decode_tagged(value: &Value) -> Result<Value, RemoteClientError> {
             let number = raw
                 .parse::<i64>()
                 .map_err(|_| RemoteClientError::invalid_response("remote integer exceeds i64"))?;
+            if number.to_string() != raw {
+                return Err(RemoteClientError::invalid_response(
+                    "remote integer value is not canonical",
+                ));
+            }
             Ok(json!(number))
         }
         "bytes" => {
@@ -511,13 +556,25 @@ fn decode_tagged(value: &Value) -> Result<Value, RemoteClientError> {
                 let pair = entry.as_array().ok_or_else(|| {
                     RemoteClientError::invalid_response("remote object entry is invalid")
                 })?;
+                if pair.len() != 2 {
+                    return Err(RemoteClientError::invalid_response(
+                        "remote object entry is invalid",
+                    ));
+                }
                 let key = pair.first().and_then(Value::as_str).ok_or_else(|| {
                     RemoteClientError::invalid_response("remote object key is invalid")
                 })?;
                 let encoded = pair.get(1).ok_or_else(|| {
                     RemoteClientError::invalid_response("remote object entry lacks a value")
                 })?;
-                object.insert(key.to_owned(), decode_tagged(encoded)?);
+                if object
+                    .insert(key.to_owned(), decode_tagged(encoded)?)
+                    .is_some()
+                {
+                    return Err(RemoteClientError::invalid_response(
+                        "remote object contains a duplicate key",
+                    ));
+                }
             }
             Ok(Value::Object(object))
         }
@@ -533,21 +590,33 @@ fn decode_operation_value(bytes: &[u8]) -> Result<Value, RemoteClientError> {
     decode_tagged(&encoded)
 }
 
-fn operation_error(value: &Value) -> RemoteClientError {
-    RemoteClientError::new(
-        value
-            .get("code")
-            .and_then(Value::as_str)
-            .unwrap_or("client.invalid_host_response"),
-        value
-            .get("message")
-            .and_then(Value::as_str)
-            .unwrap_or("remote operation failed"),
-        value
-            .get("retryable")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
-    )
+fn validate_operation_revision(value: &Value) -> Result<(), RemoteClientError> {
+    if value.get("revision").and_then(Value::as_f64) == Some(1.0) {
+        Ok(())
+    } else {
+        Err(RemoteClientError::invalid_response(
+            "remote operation response has an unsupported revision",
+        ))
+    }
+}
+
+fn operation_error(value: &Value) -> Result<RemoteClientError, RemoteClientError> {
+    let code = value.get("code").and_then(Value::as_str).ok_or_else(|| {
+        RemoteClientError::invalid_response("remote operation error lacks a code")
+    })?;
+    let message = value
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            RemoteClientError::invalid_response("remote operation error lacks a message")
+        })?;
+    let retryable = value
+        .get("retryable")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            RemoteClientError::invalid_response("remote operation error lacks retryable")
+        })?;
+    Ok(RemoteClientError::new(code, message, retryable))
 }
 
 fn base64_encode(bytes: &[u8]) -> String {
@@ -618,13 +687,18 @@ fn base64_decode(text: &str) -> Result<Vec<u8>, RemoteClientError> {
             output.push((values[2] << 6) | values[3]);
         }
     }
+    if base64_encode(&output) != text {
+        return Err(RemoteClientError::invalid_response(
+            "remote bytes value is invalid base64",
+        ));
+    }
     Ok(output)
 }
 
 #[cfg(test)]
 mod tests {
     use serde::{Deserialize, Serialize};
-    use serde_json::{json, Map};
+    use serde_json::{json, Map, Value};
     use ssp2::model::{Frame, Message, MsgKind, Op, OpResult, PushStatus};
     use ssp2::{decode_message, encode_message};
 
@@ -824,5 +898,87 @@ mod tests {
         assert!(String::from_utf8(transport.requests[0].clone())
             .expect("utf8")
             .contains("\"t\":\"bytes\""));
+    }
+
+    #[test]
+    fn rejects_invalid_operation_revision_and_command_status() {
+        let client = SyncRemoteClient::for_operations("worker").expect("client");
+        let mut transport = CachedTransport {
+            requests: Vec::new(),
+            operation_response: Some(
+                encode_operation_value(&json!({
+                    "revision": 2.0,
+                    "kind": "query",
+                    "operationId": "tasks/all",
+                    "rows": [],
+                    "maxCommitSeq": 0,
+                }))
+                .expect("response"),
+            ),
+        };
+
+        let revision = client
+            .query::<_, _, Value>(&mut transport, "tasks/all", &())
+            .expect_err("revision must fail");
+        assert_eq!(revision.code, "client.invalid_host_response");
+
+        transport.operation_response = Some(
+            encode_operation_value(&json!({
+                "revision": super::protocol_revision(),
+                "kind": "query",
+                "operationId": "tasks/all",
+                "rows": [],
+                "maxCommitSeq": 9_007_199_254_740_992i64,
+            }))
+            .expect("response"),
+        );
+        let sequence = client
+            .query::<_, _, Value>(&mut transport, "tasks/all", &())
+            .expect_err("unsafe sequence must fail");
+        assert_eq!(sequence.code, "client.invalid_host_response");
+
+        transport.operation_response = Some(
+            encode_operation_value(&json!({
+                "revision": super::protocol_revision(),
+                "kind": "command",
+                "operationId": "tasks/complete",
+                "requestId": "request-1",
+                "status": "unknown",
+                "results": [],
+            }))
+            .expect("response"),
+        );
+        let status = client
+            .command(&mut transport, "tasks/complete", "request-1", &())
+            .expect_err("status must fail");
+        assert_eq!(status.code, "client.invalid_host_response");
+
+        transport.operation_response = Some(
+            encode_operation_value(&json!({
+                "revision": super::protocol_revision(),
+                "kind": "command",
+                "operationId": "tasks/complete",
+                "requestId": "request-1",
+                "status": "applied",
+                "commitSeq": 0,
+                "results": [],
+            }))
+            .expect("response"),
+        );
+        let sequence = client
+            .command(&mut transport, "tasks/complete", "request-1", &())
+            .expect_err("zero command sequence must fail");
+        assert_eq!(sequence.code, "client.invalid_host_response");
+    }
+
+    #[test]
+    fn rejects_non_portable_integers_and_noncanonical_base64() {
+        let integer = encode_operation_value(&json!(u64::MAX))
+            .expect_err("unsigned values outside i64 must fail");
+        assert_eq!(integer.code, "sync.invalid_request");
+
+        let bytes = decode_operation_value(br#"{"t":"bytes","v":"AB=="}"#)
+            .expect_err("noncanonical base64 must fail");
+        assert_eq!(bytes.code, "client.invalid_host_response");
     }
 }

--- a/rust/crates/client/src/transport.rs
+++ b/rust/crates/client/src/transport.rs
@@ -57,6 +57,15 @@ pub trait Transport {
     /// One combined push+pull round trip (§1.5) over the request/response
     /// binding (`POST /sync`, loopback, …).
     fn sync(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError>;
+    /// One registered authoritative query or command request. Hosts that do
+    /// not expose `<mount>/operations` keep the default fail-loud behavior.
+    fn remote_operation(&mut self, request: &[u8]) -> Result<Vec<u8>, TransportError> {
+        let _ = request;
+        Err(TransportError::new(
+            "client.remote_operations_unconfigured",
+            "this transport has no remote operation endpoint",
+        ))
+    }
     /// One combined push+pull round over the realtime socket (§8.7). The
     /// host owns the WS-binding mechanics — channel tags, chunk assembly
     /// to the response's END — and returns the assembled response bytes.


### PR DESCRIPTION
## Summary

- add transaction-time durable reaction planning after accepted commit validation
- persist reactions atomically with application rows, commit metadata, and push idempotency outcomes
- add leased at-least-once delivery, retries, dead letters, manual retry, stable idempotency keys, and bounded retention
- add a database-less `SyncRemoteClient` for ordinary commits, typed authoritative queries, server commands, and live query watches
- add scoped and privileged authorization for registered queries and commands
- add SQLite, PostgreSQL, and D1 authoritative query support
- add TypeScript and Rust database-less commit clients with conformance coverage
- document domain event rows, server-side sync clients, remote server operations, and durable reactions

## Guarantees

- rejected and conflicted commits enqueue no reactions
- idempotent push replay cannot enqueue a reaction twice
- reaction handlers and external effects execute outside the authoritative push transaction
- database-less ordinary commits use the existing SSP2 commit path and idempotency rules
- server commands execute inside the serialized authoritative transaction
- command idempotency isolates authenticated actors and reserves its internal client namespace
- scoped queries require complete generated scope coverage before executing SQL
- registered queries require generated result metadata and return only declared, type-checked columns
- query watches rerun registered queries after relevant committed changes
- malformed operation values, responses, and realtime messages fail with stable errors
- stable client commit, event, reaction, and consumption identifiers support idempotent retries

## Documentation and discovery

The server navigation now links directly to:

- server-side sync clients
- remote server operations
- domain actions and event rows
- durable reactions
- operations and maintenance

Overview, server setup, reference, platform, root README, and package pages route searches for server client, headless client, background worker, domain action, and domain event to the corresponding guides.

## Validation

- `bun run check`: 1,604 passed, 8 skipped; isolated multi-tab lane 13 passed
- documentation production build: 51 pages
- Rust client tests with `native-transport`: 45 unit and 6 generated-query tests
- Rust formatting and Clippy with warnings denied
- TypeScript and Rust conformance, including the database-less producer and reserved command namespace scenarios
- `git diff --check`

The dependency audit passes with patched overrides for available fixes. Two `image-size` advisories are explicitly ignored because no fixed release exists and the package is present only in React Native Metro development tooling.
