### PR TITLE
fix(demo): restore embedded sync and expose console

### DIFF
--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -39,6 +39,11 @@ persists it to a file.
   offline, edits the row in both panes (pane B's edit wins on the server),
   then asks you to toggle pane A online — the replayed stale-`baseVersion`
   commit surfaces a §6.3 conflict record (never auto-resolved) in pane A.
+- **Server console**: the hosted static demo exposes a read-only `[ console ]`
+  panel backed by `SyncularAdmin` in the embedded server worker. It reports
+  horizon status, metrics, store stats, clients, commit metadata, and the event
+  tail for the in-page `demo` partition. For the Bun development server, run
+  `SYNCULAR_DEMO_ADMIN=1 bun run dev` and open `/admin`.
 
 ## Notes
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
-    "@syncular/core": "workspace:*",
     "@syncular/server": "workspace:*",
     "@syncular/server-hono": "workspace:*",
     "@syncular/client": "workspace:*",

--- a/apps/demo/src/frontend/index.html
+++ b/apps/demo/src/frontend/index.html
@@ -129,6 +129,18 @@
     .conflicts .item code { background: var(--panel); border: 1px solid var(--border);
       padding: 0 .3rem; font-size: .72rem; color: #e3d3a2; }
 
+    .server-console { margin: 0 1.25rem 1.25rem; border: 1px solid var(--border);
+      background: var(--panel); }
+    .server-console h2 { display: flex; align-items: center; gap: .8rem; margin: 0;
+      padding: .55rem .9rem; border-bottom: 1px solid var(--border);
+      color: var(--faint); font-size: .72rem; font-weight: 400;
+      letter-spacing: .12em; text-transform: uppercase; }
+    .server-console h2 span { color: var(--dim); letter-spacing: .06em; }
+    .server-console h2 button { margin-left: auto; }
+    .server-console pre { margin: 0; padding: .9rem; max-height: 32rem;
+      overflow: auto; color: var(--ink); font: .72rem/1.55 var(--mono);
+      white-space: pre-wrap; word-break: break-word; }
+
     .rule { color: var(--faint); font-size: .72rem; white-space: nowrap; overflow: hidden;
       user-select: none; padding: 0 1.25rem; }
     footer { display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;
@@ -147,6 +159,7 @@
     <span class="spacer"></span>
     <span id="global-status" class="hint"></span>
     <nav aria-label="Syncular links">
+      <a id="console-link" href="#server-console" hidden>console</a>
       <a href="https://syncular.dev/what-is/">docs</a>
       <a href="https://syncular.dev/demos/">demo guide</a>
       <a href="https://github.com/syncular/syncular">source</a>
@@ -156,6 +169,14 @@
     <section class="pane" id="pane-a"></section>
     <section class="pane" id="pane-b"></section>
   </main>
+  <section class="server-console" id="server-console" hidden>
+    <h2>
+      server console
+      <span>read-only · in-page partition</span>
+      <button id="console-refresh">refresh</button>
+    </h2>
+    <pre id="console-output" aria-live="polite">reading server state…</pre>
+  </section>
   <div class="rule">================================================================================================================================================================</div>
   <footer>
     <span>SYNCULAR v0.0.0 · DEMO · <a href="https://syncular.dev/">SYNCULAR.DEV</a></span>

--- a/apps/demo/src/frontend/main.ts
+++ b/apps/demo/src/frontend/main.ts
@@ -78,7 +78,7 @@ function mutableConnectivitySignal() {
   };
 }
 
-type LocalTodo = TodosRow & { _sync_version: number };
+type LocalTodo = TodosRow & { syncVersion: number };
 
 /**
  * The pane's view of a client core: the handle's async surface. The
@@ -202,6 +202,7 @@ interface EmbeddedServer {
     mediaType?: string,
   ): Promise<void>;
   blobDownload(blobId: string): Promise<Uint8Array>;
+  adminSnapshot(): Promise<Record<string, unknown>>;
   /** A realtime "socket": a numbered channel into the worker's hub (§8.7). */
   rtOpen(clientId: string, handlers: RealtimeHandlers): Promise<RealtimeSocket>;
 }
@@ -217,14 +218,20 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
     const pending = new Map<
       number,
       {
-        resolve: (msg: { bytes?: Uint8Array }) => void;
+        resolve: (msg: {
+          bytes?: Uint8Array;
+          snapshot?: Record<string, unknown>;
+        }) => void;
         reject: (error: Error) => void;
       }
     >();
     const channels = new Map<number, RealtimeHandlers>();
     const call = (
       body: Record<string, unknown>,
-    ): Promise<{ bytes?: Uint8Array }> =>
+    ): Promise<{
+      bytes?: Uint8Array;
+      snapshot?: Record<string, unknown>;
+    }> =>
       new Promise((res, rej) => {
         const id = nextId++;
         pending.set(id, { resolve: res, reject: rej });
@@ -243,6 +250,13 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
         const out = (await call({ kind: 'blob-download', blobId })).bytes;
         if (out === undefined) throw new Error('blob rpc returned no bytes');
         return out;
+      },
+      adminSnapshot: async () => {
+        const snapshot = (await call({ kind: 'admin-snapshot' })).snapshot;
+        if (snapshot === undefined) {
+          throw new Error('admin rpc returned no snapshot');
+        }
+        return snapshot;
       },
       rtOpen: async (clientId, handlers) => {
         const channel = nextChannel++;
@@ -266,6 +280,7 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
         id?: number;
         ok?: boolean;
         bytes?: Uint8Array;
+        snapshot?: Record<string, unknown>;
         text?: string;
         channel?: number;
         error?: { code: string; message: string };
@@ -273,6 +288,15 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
       switch (msg.kind) {
         case 'ready':
           resolve(api);
+          break;
+        case 'boot-error':
+          reject(
+            new ClientSyncError(
+              msg.error?.code ?? 'sync.internal',
+              msg.error?.message ?? 'embedded server failed to start',
+              false,
+            ),
+          );
           break;
         case 'result': {
           if (msg.id === undefined) break;
@@ -570,6 +594,12 @@ class Pane {
       scopes: todoListSubscription.scopes({ listId: LIST_ID }),
     });
     this.#ready = true;
+    this.#offlineBtn.disabled = false;
+    for (const control of this.root.querySelectorAll<
+      HTMLInputElement | HTMLButtonElement
+    >('form.add input, form.add button')) {
+      control.disabled = false;
+    }
     // Connect-then-sync (§8.7 reference boot order): the first sync
     // round rides the socket and registers this connection's
     // subscriptions at round end — no reconnect, no silent-no-fanout
@@ -667,7 +697,7 @@ class Pane {
         table: 'todos',
         op: 'upsert',
         values: { ...values },
-        ...(row._sync_version >= 1 ? { baseVersion: row._sync_version } : {}),
+        ...(row.syncVersion >= 1 ? { baseVersion: row.syncVersion } : {}),
       },
     ]);
     await this.afterMutation();
@@ -739,7 +769,7 @@ class Pane {
       this.core.query(
         `SELECT id, list_id AS listId, title, done, position,
                 updated_at_ms AS updatedAtMs, attachment,
-                "${SYNC_VERSION_COLUMN}" AS _sync_version
+                "${SYNC_VERSION_COLUMN}" AS syncVersion
          FROM todos ORDER BY position ASC, id ASC`,
       ),
       this.core.pendingCount(),
@@ -765,6 +795,7 @@ class Pane {
       title.append(this.#roleBadge);
     }
     this.#offlineBtn = el('button', undefined, 'Go offline');
+    this.#offlineBtn.disabled = true;
     this.#offlineBtn.addEventListener('click', () => {
       void this.setOffline(!this.offline);
     });
@@ -776,11 +807,14 @@ class Pane {
 
     const form = el('form', 'add');
     const input = el('input');
+    input.disabled = true;
     input.placeholder = `Add a todo in pane ${this.name}…`;
     const submit = el('button', undefined, 'Add');
+    submit.disabled = true;
     form.append(input, submit);
     form.addEventListener('submit', (event) => {
       event.preventDefault();
+      if (!this.#ready) return;
       const value = input.value.trim();
       if (value.length === 0) return;
       input.value = '';
@@ -836,7 +870,7 @@ class Pane {
     const version = el(
       'span',
       'ver',
-      row._sync_version === -1 ? 'local' : `v${row._sync_version}`,
+      row.syncVersion === -1 ? 'local' : `v${row.syncVersion}`,
     );
     titleCell.append(version);
 
@@ -954,7 +988,7 @@ async function simulateConflict(
   await b.syncNow();
   const inA = a.todo(id);
   const inB = b.todo(id);
-  if (inA === undefined || inB === undefined || inA._sync_version < 1) {
+  if (inA === undefined || inB === undefined || inA.syncVersion < 1) {
     status.textContent = 'conflict setup failed — panes did not converge';
     return;
   }
@@ -989,6 +1023,41 @@ async function main(): Promise<void> {
 
   await Promise.all([paneA.init(), paneB.init()]);
 
+  const consoleLink = document.getElementById(
+    'console-link',
+  ) as HTMLAnchorElement;
+  const consolePanel = document.getElementById('server-console') as HTMLElement;
+  const consoleOutput = document.getElementById(
+    'console-output',
+  ) as HTMLPreElement;
+  const consoleRefresh = document.getElementById(
+    'console-refresh',
+  ) as HTMLButtonElement;
+  if (EMBEDDED) {
+    consoleLink.hidden = false;
+    const refreshConsole = async () => {
+      consoleRefresh.disabled = true;
+      consoleOutput.textContent = 'reading server state…';
+      try {
+        consoleOutput.textContent = JSON.stringify(
+          await (await getEmbeddedServer()).adminSnapshot(),
+          null,
+          2,
+        );
+      } catch (error) {
+        consoleOutput.textContent =
+          error instanceof Error ? error.message : String(error);
+      } finally {
+        consoleRefresh.disabled = false;
+      }
+    };
+    consoleRefresh.addEventListener('click', () => void refreshConsole());
+    consoleLink.addEventListener('click', () => {
+      consolePanel.hidden = false;
+      void refreshConsole();
+    });
+  }
+
   conflictBtn.disabled = false;
   conflictBtn.addEventListener('click', () => {
     conflictBtn.disabled = true;
@@ -998,4 +1067,4 @@ async function main(): Promise<void> {
   });
 }
 
-void main();
+void main().catch((error: unknown) => console.error(error));

--- a/apps/demo/src/frontend/server-worker.test.ts
+++ b/apps/demo/src/frontend/server-worker.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'bun:test';
+
+interface WorkerMessage {
+  readonly id?: number;
+  readonly kind: string;
+  readonly ok?: boolean;
+  readonly error?: { readonly code: string; readonly message: string };
+  readonly snapshot?: {
+    readonly horizon: { readonly maxCommitSeq: number };
+    readonly commits: readonly { readonly commitSeq: number }[];
+    readonly events: readonly { readonly type: string }[];
+  };
+}
+
+test('embedded server boots, seeds, and exposes its admin snapshot', async () => {
+  const worker = new Worker(new URL('./server-worker.ts', import.meta.url));
+  try {
+    const snapshot = await new Promise<WorkerMessage['snapshot']>(
+      (resolve, reject) => {
+        worker.onerror = (event) => reject(event.error);
+        worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+          const message = event.data;
+          if (message.kind === 'boot-error') {
+            reject(
+              new Error(
+                `${message.error?.code ?? 'sync.internal'}: ${message.error?.message ?? 'embedded server failed to start'}`,
+              ),
+            );
+          } else if (message.kind === 'ready') {
+            worker.postMessage({ kind: 'admin-snapshot', id: 1 });
+          } else if (message.kind === 'result' && message.id === 1) {
+            resolve(message.snapshot);
+          }
+        };
+      },
+    );
+    expect(snapshot?.horizon.maxCommitSeq).toBe(1);
+    expect(snapshot?.commits).toEqual([
+      expect.objectContaining({ commitSeq: 1 }),
+    ]);
+    expect(
+      snapshot?.events.some((event) => event.type === 'push.applied'),
+    ).toBe(true);
+  } finally {
+    worker.terminate();
+  }
+});

--- a/apps/demo/src/frontend/server-worker.ts
+++ b/apps/demo/src/frontend/server-worker.ts
@@ -22,12 +22,6 @@
  */
 import sqlite3InitModule from '@sqlite.org/sqlite-wasm';
 import {
-  encodeMessage,
-  encodeRow,
-  PROTOCOL_WIRE_VERSION,
-  type RequestFrame,
-} from '@syncular/core';
-import {
   createRealtimeHub,
   type D1Database,
   type D1PreparedStatement,
@@ -39,9 +33,12 @@ import {
   MemorySegmentStore,
   type RealtimeSession,
   RingBufferEvents,
+  type SeedMutation,
+  seedMutations,
   type SyncServerConfig,
+  SyncularAdmin,
 } from '@syncular/server';
-import { schema, type TodosRow } from '../syncular.generated';
+import { schema } from '../syncular.generated';
 
 const PARTITION = 'demo';
 const ACTOR_ID = 'demo-user';
@@ -104,6 +101,7 @@ const ring = new RingBufferEvents({ capacity: 500 });
 interface EmbeddedServerParts {
   readonly config: SyncServerConfig;
   readonly hub: ReturnType<typeof createRealtimeHub>;
+  readonly admin: SyncularAdmin;
 }
 
 async function bootServer(): Promise<EmbeddedServerParts> {
@@ -136,62 +134,33 @@ async function bootServer(): Promise<EmbeddedServerParts> {
     // Everything inlines: no segment-download path in the embedded demo.
     limits: { inlineSegmentMaxBytes: 64 * 1024 * 1024 },
   };
-  return { config, hub };
+  return { config, hub, admin: SyncularAdmin.fromConfig(config, { ring }) };
 }
 
 /** Seed a few rows through the real push path (same seed as the dev server). */
 async function seed(config: SyncServerConfig): Promise<void> {
-  const table = schema.tables[0];
-  if (table === undefined) throw new Error('schema has no tables');
   const now = Date.now();
-  const rows: TodosRow[] = [
+  const mutations: SeedMutation[] = [
     'Open this page in two panes',
     'Toggle a pane offline and keep editing',
     'Attach a file to a todo — it uploads then syncs',
   ].map((title, index) => ({
-    id: `seed-${index + 1}`,
-    listId: 'demo',
-    title,
-    done: false,
-    position: index + 1,
-    updatedAtMs: now,
-    attachment: null,
+    table: 'todos',
+    op: 'upsert',
+    values: {
+      id: `seed-${index + 1}`,
+      listId: 'demo',
+      title,
+      done: false,
+      position: index + 1,
+      updatedAtMs: now,
+      attachment: null,
+    },
   }));
-  const frames: RequestFrame[] = [
-    { type: 'REQ_HEADER', clientId: 'seed', schemaVersion: schema.version },
-    {
-      type: 'PUSH_COMMIT',
-      clientCommitId: 'seed-commit-1',
-      operations: rows.map((row) => ({
-        table: 'todos',
-        rowId: row.id,
-        op: 'upsert' as const,
-        payload: encodeRow(table.columns, [
-          row.id,
-          row.listId,
-          row.title,
-          row.done,
-          row.position,
-          row.updatedAtMs,
-          row.attachment,
-        ]),
-      })),
-    },
-    {
-      type: 'PULL_HEADER',
-      limitCommits: 0,
-      limitSnapshotRows: 0,
-      maxSnapshotPages: 0,
-      accept: 0b0011,
-    },
-  ];
-  await handleSyncRequest(
-    encodeMessage({
-      wireVersion: PROTOCOL_WIRE_VERSION,
-      msgKind: 'request',
-      frames,
-    }),
-    { ...config, partition: PARTITION, actorId: ACTOR_ID },
+  await seedMutations(
+    config,
+    { partition: PARTITION, actorId: ACTOR_ID },
+    mutations,
   );
 }
 
@@ -228,15 +197,20 @@ function serializeSyncRound<T>(operation: () => Promise<T>): Promise<T> {
   return result;
 }
 
-const booted = bootServer().then(async (parts) => {
-  await seed(parts.config);
-  scope.postMessage({ kind: 'ready' });
-  return parts;
-});
+const booted = bootServer()
+  .then(async (parts) => {
+    await seed(parts.config);
+    scope.postMessage({ kind: 'ready' });
+    return parts;
+  })
+  .catch((error: unknown) => {
+    scope.postMessage({ kind: 'boot-error', error: toRpcError(error) });
+    throw error;
+  });
 
 scope.onmessage = (event: MessageEvent) => {
   void (async () => {
-    const { config, hub } = await booted;
+    const { config, hub, admin } = await booted;
     const ctx = { ...config, partition: PARTITION, actorId: ACTOR_ID };
     const msg = event.data as {
       kind: string;
@@ -283,6 +257,27 @@ scope.onmessage = (event: MessageEvent) => {
             throw new Error('memory blob store always serves inline bytes');
           }
           reply({ kind: 'result', ok: true, bytes: result.bytes });
+          break;
+        }
+        case 'admin-snapshot': {
+          const [horizon, clients, commits, stats] = await Promise.all([
+            admin.horizonStatus(PARTITION),
+            admin.listClients(PARTITION),
+            admin.listCommits(PARTITION, { limit: 25 }),
+            admin.stats(PARTITION),
+          ]);
+          reply({
+            kind: 'result',
+            ok: true,
+            snapshot: {
+              horizon,
+              metrics: admin.metrics(PARTITION),
+              stats,
+              clients,
+              commits,
+              events: admin.events({ limit: 50 }),
+            },
+          });
           break;
         }
         case 'rt-open': {

--- a/apps/docs/src/changelog.mjs
+++ b/apps/docs/src/changelog.mjs
@@ -17,6 +17,12 @@
 export const changelog = [
   {
     date: '2026-08-08',
+    title: 'Embedded demo console',
+    body: 'The hosted two-pane demo seeds through the epoch-aware server helper and exposes its in-page server state through a read-only SyncularAdmin console. The console reports horizon status, metrics, store stats, clients, commit metadata, and the event tail without sending demo data to a remote server.',
+    links: [{ href: '/demos/', label: 'Live demos' }],
+  },
+  {
+    date: '2026-08-08',
     title: 'Restore fencing and host lifecycle controls',
     body: 'Wire version 2 fences restored partition timelines with log epochs while preserving each client outbox. The client package adds a shared sync scheduler and UTC month-window helpers. Native bindings add runtime header rotation and connectivity adapters. The server adds an authenticated partition registry, and typegen publishes a diagnostic remedy catalog.',
     links: [

--- a/apps/docs/src/content/demos.md
+++ b/apps/docs/src/content/demos.md
@@ -21,7 +21,11 @@ Bun process. The page drives each core over the `SyncClientHandle` RPC.
 
 The [hosted version](https://demo.syncular.dev/) replaces the Bun development
 server with the same Syncular server core running over sqlite-wasm in a third
-Web Worker, making the complete demo backend-free and self-contained.
+Web Worker, making the complete demo backend-free and self-contained. Open
+`[ console ]` on the hosted page to read the embedded server's horizon,
+metrics, store stats, clients, commit metadata, and event tail. The console
+reads the in-page `demo` partition through `SyncularAdmin`; it sends no data to
+a remote server.
 
 ```sh
 git clone https://github.com/syncular/syncular
@@ -34,6 +38,8 @@ One process serves everything on one port: `POST /sync` and
 `GET /segments/:id`, the `/realtime` WebSocket, and the frontend + worker
 bundles. Server storage is in-memory by default;
 `SYNCULAR_DEMO_DB=path bun run --cwd apps/demo dev` persists it to a file.
+Run `SYNCULAR_DEMO_ADMIN=1 bun run --cwd apps/demo dev` to mount the complete
+operator console at `/admin`.
 
 What to try:
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
       "dependencies": {
         "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
         "@syncular/client": "workspace:*",
-        "@syncular/core": "workspace:*",
         "@syncular/server": "workspace:*",
         "@syncular/server-hono": "workspace:*",
         "hono": "^4.12.34",


### PR DESCRIPTION
## What changed

- seed the embedded server through the epoch-aware seed path
- surface worker boot errors and keep controls disabled until both clients are ready
- expose a read-only in-page server console backed by SyncularAdmin
- preserve the public sync version alias used by conflict simulation
- cover worker boot, seed data, and the admin snapshot with a regression test
- document the console and add the changelog entry

## Root cause

Wire v2 requires a client to acquire the partition log epoch before pushing. The embedded demo still sent a hand-built seed request containing push commits without an epoch, so the worker rejected the request before it could signal readiness. The page left write controls enabled and did not show the boot failure.

## Validation

- bun run check
- bun run build:sites
- bun run --cwd apps/demo build:static
- local Cloudflare static runtime: add convergence, version labels, conflict simulation, and console snapshot