### PR TITLE
fix(demo): enable browser debugging console

### DIFF
--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -39,10 +39,11 @@ persists it to a file.
   offline, edits the row in both panes (pane B's edit wins on the server),
   then asks you to toggle pane A online — the replayed stale-`baseVersion`
   commit surfaces a §6.3 conflict record (never auto-resolved) in pane A.
-- **Server console**: the hosted static demo exposes a read-only `[ console ]`
-  panel backed by `SyncularAdmin` in the embedded server worker. It reports
-  horizon status, metrics, store stats, clients, commit metadata, and the event
-  tail for the in-page `demo` partition. For the Bun development server, run
+- **Debug console**: open browser devtools on the hosted demo and run
+  `await __SYNCULAR__.snapshot()`. The registry contains both live clients;
+  `__SYNCULAR__.clients[0].ref` exposes the first client for queries and sync
+  inspection. Both demo builds explicitly retain this development registry.
+  For the Bun server operator console, run
   `SYNCULAR_DEMO_ADMIN=1 bun run dev` and open `/admin`.
 
 ## Notes

--- a/apps/demo/scripts/build-static.test.ts
+++ b/apps/demo/scripts/build-static.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+test('static bundle retains the Syncular browser debugging registry', async () => {
+  const build = Bun.spawn(
+    [process.execPath, 'run', join(import.meta.dir, 'build-static.ts')],
+    {
+      cwd: join(import.meta.dir, '..'),
+      stdout: 'ignore',
+      stderr: 'pipe',
+    },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    build.exited,
+    new Response(build.stderr).text(),
+  ]);
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: '' });
+
+  const app = await Bun.file(
+    join(import.meta.dir, '..', 'dist', 'app.js'),
+  ).text();
+  expect(app).toContain('__SYNCULAR__');
+  expect(app).toContain('Syncular debug console ready');
+  expect(app).not.toMatch(/NODE_ENV\s*===\s*["']production/);
+});

--- a/apps/demo/scripts/build-static.ts
+++ b/apps/demo/scripts/build-static.ts
@@ -61,7 +61,13 @@ const build = await Bun.build({
   // condition points at compiled dist).
   conditions: ['bun'],
   minify: true,
-  define: { SYNCULAR_DEMO_EMBEDDED: 'true' },
+  // The hosted demo intentionally exposes the documented __SYNCULAR__
+  // browser-console registry. Other production builds keep the registry
+  // gated off through their ordinary production NODE_ENV definition.
+  define: {
+    SYNCULAR_DEMO_EMBEDDED: 'true',
+    SYNCULAR_DEVTOOLS: 'true',
+  },
   external: ['@sqlite.org/sqlite-wasm'],
   plugins: [bunSqliteStub],
 });

--- a/apps/demo/src/frontend/index.html
+++ b/apps/demo/src/frontend/index.html
@@ -129,18 +129,6 @@
     .conflicts .item code { background: var(--panel); border: 1px solid var(--border);
       padding: 0 .3rem; font-size: .72rem; color: #e3d3a2; }
 
-    .server-console { margin: 0 1.25rem 1.25rem; border: 1px solid var(--border);
-      background: var(--panel); }
-    .server-console h2 { display: flex; align-items: center; gap: .8rem; margin: 0;
-      padding: .55rem .9rem; border-bottom: 1px solid var(--border);
-      color: var(--faint); font-size: .72rem; font-weight: 400;
-      letter-spacing: .12em; text-transform: uppercase; }
-    .server-console h2 span { color: var(--dim); letter-spacing: .06em; }
-    .server-console h2 button { margin-left: auto; }
-    .server-console pre { margin: 0; padding: .9rem; max-height: 32rem;
-      overflow: auto; color: var(--ink); font: .72rem/1.55 var(--mono);
-      white-space: pre-wrap; word-break: break-word; }
-
     .rule { color: var(--faint); font-size: .72rem; white-space: nowrap; overflow: hidden;
       user-select: none; padding: 0 1.25rem; }
     footer { display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;
@@ -159,7 +147,6 @@
     <span class="spacer"></span>
     <span id="global-status" class="hint"></span>
     <nav aria-label="Syncular links">
-      <a id="console-link" href="#server-console" hidden>console</a>
       <a href="https://syncular.dev/what-is/">docs</a>
       <a href="https://syncular.dev/demos/">demo guide</a>
       <a href="https://github.com/syncular/syncular">source</a>
@@ -169,14 +156,6 @@
     <section class="pane" id="pane-a"></section>
     <section class="pane" id="pane-b"></section>
   </main>
-  <section class="server-console" id="server-console" hidden>
-    <h2>
-      server console
-      <span>read-only · in-page partition</span>
-      <button id="console-refresh">refresh</button>
-    </h2>
-    <pre id="console-output" aria-live="polite">reading server state…</pre>
-  </section>
   <div class="rule">================================================================================================================================================================</div>
   <footer>
     <span>SYNCULAR v0.0.0 · DEMO · <a href="https://syncular.dev/">SYNCULAR.DEV</a></span>

--- a/apps/demo/src/frontend/main.ts
+++ b/apps/demo/src/frontend/main.ts
@@ -202,7 +202,6 @@ interface EmbeddedServer {
     mediaType?: string,
   ): Promise<void>;
   blobDownload(blobId: string): Promise<Uint8Array>;
-  adminSnapshot(): Promise<Record<string, unknown>>;
   /** A realtime "socket": a numbered channel into the worker's hub (§8.7). */
   rtOpen(clientId: string, handlers: RealtimeHandlers): Promise<RealtimeSocket>;
 }
@@ -218,20 +217,14 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
     const pending = new Map<
       number,
       {
-        resolve: (msg: {
-          bytes?: Uint8Array;
-          snapshot?: Record<string, unknown>;
-        }) => void;
+        resolve: (msg: { bytes?: Uint8Array }) => void;
         reject: (error: Error) => void;
       }
     >();
     const channels = new Map<number, RealtimeHandlers>();
     const call = (
       body: Record<string, unknown>,
-    ): Promise<{
-      bytes?: Uint8Array;
-      snapshot?: Record<string, unknown>;
-    }> =>
+    ): Promise<{ bytes?: Uint8Array }> =>
       new Promise((res, rej) => {
         const id = nextId++;
         pending.set(id, { resolve: res, reject: rej });
@@ -250,13 +243,6 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
         const out = (await call({ kind: 'blob-download', blobId })).bytes;
         if (out === undefined) throw new Error('blob rpc returned no bytes');
         return out;
-      },
-      adminSnapshot: async () => {
-        const snapshot = (await call({ kind: 'admin-snapshot' })).snapshot;
-        if (snapshot === undefined) {
-          throw new Error('admin rpc returned no snapshot');
-        }
-        return snapshot;
       },
       rtOpen: async (clientId, handlers) => {
         const channel = nextChannel++;
@@ -280,7 +266,6 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
         id?: number;
         ok?: boolean;
         bytes?: Uint8Array;
-        snapshot?: Record<string, unknown>;
         text?: string;
         channel?: number;
         error?: { code: string; message: string };
@@ -1022,40 +1007,17 @@ async function main(): Promise<void> {
   const globalStatus = document.getElementById('global-status') as HTMLElement;
 
   await Promise.all([paneA.init(), paneB.init()]);
-
-  const consoleLink = document.getElementById(
-    'console-link',
-  ) as HTMLAnchorElement;
-  const consolePanel = document.getElementById('server-console') as HTMLElement;
-  const consoleOutput = document.getElementById(
-    'console-output',
-  ) as HTMLPreElement;
-  const consoleRefresh = document.getElementById(
-    'console-refresh',
-  ) as HTMLButtonElement;
-  if (EMBEDDED) {
-    consoleLink.hidden = false;
-    const refreshConsole = async () => {
-      consoleRefresh.disabled = true;
-      consoleOutput.textContent = 'reading server state…';
-      try {
-        consoleOutput.textContent = JSON.stringify(
-          await (await getEmbeddedServer()).adminSnapshot(),
-          null,
-          2,
-        );
-      } catch (error) {
-        consoleOutput.textContent =
-          error instanceof Error ? error.message : String(error);
-      } finally {
-        consoleRefresh.disabled = false;
-      }
-    };
-    consoleRefresh.addEventListener('click', () => void refreshConsole());
-    consoleLink.addEventListener('click', () => {
-      consolePanel.hidden = false;
-      void refreshConsole();
-    });
+  const debugRegistry = (
+    window as typeof window & {
+      readonly __SYNCULAR__?: { readonly clients: readonly unknown[] };
+    }
+  ).__SYNCULAR__;
+  if (debugRegistry?.clients.length === 2) {
+    console.info('Syncular debug console ready: await __SYNCULAR__.snapshot()');
+  } else {
+    console.error(
+      'sync.demo_devtools_unavailable: expected two registered clients',
+    );
   }
 
   conflictBtn.disabled = false;

--- a/apps/demo/src/frontend/server-worker.test.ts
+++ b/apps/demo/src/frontend/server-worker.test.ts
@@ -1,46 +1,28 @@
-import { expect, test } from 'bun:test';
+import { test } from 'bun:test';
 
 interface WorkerMessage {
-  readonly id?: number;
   readonly kind: string;
-  readonly ok?: boolean;
   readonly error?: { readonly code: string; readonly message: string };
-  readonly snapshot?: {
-    readonly horizon: { readonly maxCommitSeq: number };
-    readonly commits: readonly { readonly commitSeq: number }[];
-    readonly events: readonly { readonly type: string }[];
-  };
 }
 
-test('embedded server boots, seeds, and exposes its admin snapshot', async () => {
+test('embedded server reaches ready only after its seed applies', async () => {
   const worker = new Worker(new URL('./server-worker.ts', import.meta.url));
   try {
-    const snapshot = await new Promise<WorkerMessage['snapshot']>(
-      (resolve, reject) => {
-        worker.onerror = (event) => reject(event.error);
-        worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
-          const message = event.data;
-          if (message.kind === 'boot-error') {
-            reject(
-              new Error(
-                `${message.error?.code ?? 'sync.internal'}: ${message.error?.message ?? 'embedded server failed to start'}`,
-              ),
-            );
-          } else if (message.kind === 'ready') {
-            worker.postMessage({ kind: 'admin-snapshot', id: 1 });
-          } else if (message.kind === 'result' && message.id === 1) {
-            resolve(message.snapshot);
-          }
-        };
-      },
-    );
-    expect(snapshot?.horizon.maxCommitSeq).toBe(1);
-    expect(snapshot?.commits).toEqual([
-      expect.objectContaining({ commitSeq: 1 }),
-    ]);
-    expect(
-      snapshot?.events.some((event) => event.type === 'push.applied'),
-    ).toBe(true);
+    await new Promise<void>((resolve, reject) => {
+      worker.onerror = (event) => reject(event.error);
+      worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+        const message = event.data;
+        if (message.kind === 'boot-error') {
+          reject(
+            new Error(
+              `${message.error?.code ?? 'sync.internal'}: ${message.error?.message ?? 'embedded server failed to start'}`,
+            ),
+          );
+        } else if (message.kind === 'ready') {
+          resolve();
+        }
+      };
+    });
   } finally {
     worker.terminate();
   }

--- a/apps/demo/src/frontend/server-worker.ts
+++ b/apps/demo/src/frontend/server-worker.ts
@@ -36,7 +36,6 @@ import {
   type SeedMutation,
   seedMutations,
   type SyncServerConfig,
-  SyncularAdmin,
 } from '@syncular/server';
 import { schema } from '../syncular.generated';
 
@@ -101,7 +100,6 @@ const ring = new RingBufferEvents({ capacity: 500 });
 interface EmbeddedServerParts {
   readonly config: SyncServerConfig;
   readonly hub: ReturnType<typeof createRealtimeHub>;
-  readonly admin: SyncularAdmin;
 }
 
 async function bootServer(): Promise<EmbeddedServerParts> {
@@ -134,7 +132,7 @@ async function bootServer(): Promise<EmbeddedServerParts> {
     // Everything inlines: no segment-download path in the embedded demo.
     limits: { inlineSegmentMaxBytes: 64 * 1024 * 1024 },
   };
-  return { config, hub, admin: SyncularAdmin.fromConfig(config, { ring }) };
+  return { config, hub };
 }
 
 /** Seed a few rows through the real push path (same seed as the dev server). */
@@ -210,7 +208,7 @@ const booted = bootServer()
 
 scope.onmessage = (event: MessageEvent) => {
   void (async () => {
-    const { config, hub, admin } = await booted;
+    const { config, hub } = await booted;
     const ctx = { ...config, partition: PARTITION, actorId: ACTOR_ID };
     const msg = event.data as {
       kind: string;
@@ -257,27 +255,6 @@ scope.onmessage = (event: MessageEvent) => {
             throw new Error('memory blob store always serves inline bytes');
           }
           reply({ kind: 'result', ok: true, bytes: result.bytes });
-          break;
-        }
-        case 'admin-snapshot': {
-          const [horizon, clients, commits, stats] = await Promise.all([
-            admin.horizonStatus(PARTITION),
-            admin.listClients(PARTITION),
-            admin.listCommits(PARTITION, { limit: 25 }),
-            admin.stats(PARTITION),
-          ]);
-          reply({
-            kind: 'result',
-            ok: true,
-            snapshot: {
-              horizon,
-              metrics: admin.metrics(PARTITION),
-              stats,
-              clients,
-              commits,
-              events: admin.events({ limit: 50 }),
-            },
-          });
           break;
         }
         case 'rt-open': {

--- a/apps/demo/src/server.ts
+++ b/apps/demo/src/server.ts
@@ -169,6 +169,7 @@ const build = await Bun.build({
   // condition points at compiled dist for external bundlers).
   conditions: ['bun'],
   sourcemap: 'inline',
+  define: { SYNCULAR_DEVTOOLS: 'true' },
   external: ['@sqlite.org/sqlite-wasm'],
 });
 async function bundleText(basename: string): Promise<string> {

--- a/apps/docs/src/changelog.mjs
+++ b/apps/docs/src/changelog.mjs
@@ -16,9 +16,9 @@
 /** @type {readonly ChangelogEntry[]} */
 export const changelog = [
   {
-    date: '2026-08-08',
-    title: 'Embedded demo console',
-    body: 'The hosted two-pane demo seeds through the epoch-aware server helper and exposes its in-page server state through a read-only SyncularAdmin console. The console reports horizon status, metrics, store stats, clients, commit metadata, and the event tail without sending demo data to a remote server.',
+    date: '2026-08-09',
+    title: 'Hosted demo repair and debug console',
+    body: 'The hosted two-pane demo seeds through the epoch-aware server helper and explicitly retains the browser debugging registry. Open browser devtools to inspect both live clients through __SYNCULAR__, including their snapshots and full client handles.',
     links: [{ href: '/demos/', label: 'Live demos' }],
   },
   {

--- a/apps/docs/src/content/demos.md
+++ b/apps/docs/src/content/demos.md
@@ -22,10 +22,11 @@ Bun process. The page drives each core over the `SyncClientHandle` RPC.
 The [hosted version](https://demo.syncular.dev/) replaces the Bun development
 server with the same Syncular server core running over sqlite-wasm in a third
 Web Worker, making the complete demo backend-free and self-contained. Open
-`[ console ]` on the hosted page to read the embedded server's horizon,
-metrics, store stats, clients, commit metadata, and event tail. The console
-reads the in-page `demo` partition through `SyncularAdmin`; it sends no data to
-a remote server.
+browser devtools and run `await __SYNCULAR__.snapshot()` to inspect both live
+clients. `__SYNCULAR__.clients[0].ref` exposes the first client for queries,
+sync rounds, subscriptions, conflicts, and diagnostics. Both demo builds
+explicitly retain this development registry; ordinary production builds gate
+it off.
 
 ```sh
 git clone https://github.com/syncular/syncular

--- a/apps/docs/src/content/troubleshooting.md
+++ b/apps/docs/src/content/troubleshooting.md
@@ -49,6 +49,11 @@ await __SYNCULAR__.clients[0].ref.query('SELECT * FROM todos');
 apply batch, the fastest way to confirm data is arriving and your live
 queries should have re-run.
 
+Production builds omit the registry. A public sandbox with non-sensitive data
+can retain it by defining `SYNCULAR_DEVTOOLS` as `true` in the bundler. The
+registry exposes full client handles, so applications with private data must
+keep the production gate. The two-pane demo enables this flag in both builds.
+
 ## Enter/mutate silently does nothing
 
 Seen in the dev loop: you restart the dev server while a tab stays open,

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -268,6 +268,21 @@ The state is a discriminated union covering startup, migration,
 children; a blocked live query has `phase === 'blocked'`, never an indefinite
 loading state.
 
+## Browser console debugging
+
+Development pages register every live client and page-side worker handle on
+`window.__SYNCULAR__`:
+
+```js
+await __SYNCULAR__.snapshot();
+await __SYNCULAR__.clients[0].ref.query('SELECT * FROM todos');
+```
+
+Production bundles omit this registry. A public sandbox with non-sensitive
+data can retain it by defining `SYNCULAR_DEVTOOLS` as `true` in the bundler.
+The registry exposes full client handles, so applications with private data
+must keep the production gate.
+
 ## Privacy-safe support diagnostics
 
 Every direct and Worker/multi-tab client exposes the same versioned snapshot:

--- a/packages/web-client/src/devtools.ts
+++ b/packages/web-client/src/devtools.ts
@@ -13,11 +13,13 @@
  *
  * Gated to development: the registry installs only where a `window` exists
  * (worker cores register through their page-side handle) and NODE_ENV is
- * anything except `'production'` (bundlers statically replace it, so
- * production builds skip installation; environments without `process` are
- * treated as dev). Cost when gated off: one function call per client.
+ * anything except `'production'`. A browser sandbox can explicitly retain
+ * the registry by defining `SYNCULAR_DEVTOOLS` as `true` in its bundle. Cost
+ * when gated off: one function call per client.
  */
 import type { InvalidationEvent, InvalidationListener } from './invalidation';
+
+declare const SYNCULAR_DEVTOOLS: boolean;
 
 /** What a registrant supplies — plain lambdas over its own surface. */
 export interface DevtoolsRegistration {
@@ -60,7 +62,12 @@ function registryHost(): Record<string, unknown> | undefined {
     process?: { env?: { NODE_ENV?: string } };
   };
   if (g.window === undefined) return undefined;
-  if (g.process?.env?.NODE_ENV === 'production') return undefined;
+  if (
+    g.process?.env?.NODE_ENV === 'production' &&
+    (typeof SYNCULAR_DEVTOOLS === 'undefined' || !SYNCULAR_DEVTOOLS)
+  ) {
+    return undefined;
+  }
   return g;
 }
 


### PR DESCRIPTION
## What changed

- let public browser sandboxes explicitly retain the existing __SYNCULAR__ debugging registry at bundle time
- enable that registry in both two-pane demo builds
- log the exact snapshot command when both demo clients register
- remove the unrelated in-page SyncularAdmin panel from the hosted demo
- add a minified-bundle regression test and document the opt-in safety boundary

## Root cause

The browser debugging registry is gated off when the page environment reports production. The hosted demo did not have an explicit sandbox opt-in. The first repair implemented the server operator console instead of enabling the existing client debugging registry.

## Impact

Opening browser devtools on the demo now exposes both live clients through __SYNCULAR__. Ordinary production applications retain the existing gate because the registry exposes full client handles.

## Validation

- bun run check
- bun run build:sites
- bun run --cwd apps/demo build:static
- local development build: readiness log present, no registry error
- local minified static build: readiness log present, add converges across both panes