### PR TITLE
Fix hosted demo with graphical admin console

### DIFF
--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -39,11 +39,11 @@ persists it to a file.
   offline, edits the row in both panes (pane B's edit wins on the server),
   then asks you to toggle pane A online — the replayed stale-`baseVersion`
   commit surfaces a §6.3 conflict record (never auto-resolved) in pane A.
-- **Debug console**: open browser devtools on the hosted demo and run
-  `await __SYNCULAR__.snapshot()`. The registry contains both live clients;
-  `__SYNCULAR__.clients[0].ref` exposes the first client for queries and sync
-  inspection. Both demo builds explicitly retain this development registry.
-  For the Bun server operator console, run
+- **Server console**: select `[ console ]` in the hosted demo to open the
+  graphical `SyncularAdmin` interface. The interface reads the embedded server
+  worker and displays horizon status, metrics, store stats, clients, commit
+  metadata, row inspection, scope activity, and the event tail for the in-page
+  `demo` partition. For the Bun server operator console, run
   `SYNCULAR_DEMO_ADMIN=1 bun run dev` and open `/admin`.
 
 ## Notes

--- a/apps/demo/scripts/build-static.test.ts
+++ b/apps/demo/scripts/build-static.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { join } from 'node:path';
 
-test('static bundle retains the Syncular browser debugging registry', async () => {
+test('static bundle includes the graphical worker-backed admin console', async () => {
   const build = Bun.spawn(
     [process.execPath, 'run', join(import.meta.dir, 'build-static.ts')],
     {
@@ -16,10 +16,14 @@ test('static bundle retains the Syncular browser debugging registry', async () =
   ]);
   expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: '' });
 
-  const app = await Bun.file(
-    join(import.meta.dir, '..', 'dist', 'app.js'),
-  ).text();
-  expect(app).toContain('__SYNCULAR__');
-  expect(app).toContain('Syncular debug console ready');
-  expect(app).not.toMatch(/NODE_ENV\s*===\s*["']production/);
+  const [app, admin, worker] = await Promise.all([
+    Bun.file(join(import.meta.dir, '..', 'dist', 'app.js')).text(),
+    Bun.file(join(import.meta.dir, '..', 'dist', 'admin.html')).text(),
+    Bun.file(join(import.meta.dir, '..', 'dist', 'server-worker.js')).text(),
+  ]);
+  expect(app).toContain('/admin.html?transport=parent');
+  expect(app).toContain('syncular-admin-request');
+  expect(admin).toContain('<title>Syncular console</title>');
+  expect(admin).toContain('syncular-admin-response');
+  expect(worker).toContain('admin request requires a route path');
 });

--- a/apps/demo/scripts/build-static.ts
+++ b/apps/demo/scripts/build-static.ts
@@ -1,8 +1,8 @@
 /**
  * Static demo build: the backend-free bundle published at demo.syncular.dev.
- * Emits `dist/` — index.html, the shared favicon and social card, app.js
- * (the page, with the embedded flag baked in), server-worker.js (the WHOLE
- * sync server, running in a Web Worker over sqlite-wasm wearing the D1
+ * Emits `dist/`: index.html, admin.html, the shared favicon and social card,
+ * app.js (the page, with the embedded flag baked in), server-worker.js (the
+ * WHOLE sync server, running in a Web Worker over sqlite-wasm wearing the D1
  * shape), and the sqlite-wasm vendor files. Cloudflare serves it as plain
  * static assets; there is no server-side compute anywhere.
  *
@@ -18,6 +18,7 @@
 import { dirname, join } from 'node:path';
 import type { BunPlugin } from 'bun';
 import rootPackage from '../../../package.json';
+import { ADMIN_CONSOLE_HTML } from '../../../packages/server-hono/src/admin-page';
 
 const appDir = join(import.meta.dir, '..');
 const frontendDir = join(appDir, 'src', 'frontend');
@@ -61,13 +62,7 @@ const build = await Bun.build({
   // condition points at compiled dist).
   conditions: ['bun'],
   minify: true,
-  // The hosted demo intentionally exposes the documented __SYNCULAR__
-  // browser-console registry. Other production builds keep the registry
-  // gated off through their ordinary production NODE_ENV definition.
-  define: {
-    SYNCULAR_DEMO_EMBEDDED: 'true',
-    SYNCULAR_DEVTOOLS: 'true',
-  },
+  define: { SYNCULAR_DEMO_EMBEDDED: 'true' },
   external: ['@sqlite.org/sqlite-wasm'],
   plugins: [bunSqliteStub],
 });
@@ -118,6 +113,7 @@ await Bun.write(
   join(outDir, 'index.html'),
   reflectReleaseVersion(await Bun.file(join(frontendDir, 'index.html')).text()),
 );
+await Bun.write(join(outDir, 'admin.html'), ADMIN_CONSOLE_HTML);
 await Bun.write(
   join(outDir, 'version.json'),
   `${JSON.stringify({ version: rootPackage.version }, null, 2)}\n`,

--- a/apps/demo/src/frontend/index.html
+++ b/apps/demo/src/frontend/index.html
@@ -129,6 +129,18 @@
     .conflicts .item code { background: var(--panel); border: 1px solid var(--border);
       padding: 0 .3rem; font-size: .72rem; color: #e3d3a2; }
 
+    dialog { width: calc(100vw - 2rem); height: calc(100vh - 2rem); max-width: none;
+      max-height: none; margin: 1rem; padding: 0; color: var(--ink);
+      background: var(--void); border: 1px solid var(--border-strong); }
+    dialog::backdrop { background: rgba(0,0,0,.86); }
+    .console-head { display: flex; align-items: center; gap: .8rem; padding: .55rem .9rem;
+      border-bottom: 1px solid var(--border); color: var(--faint); font-size: .72rem;
+      letter-spacing: .12em; text-transform: uppercase; }
+    .console-head span { color: var(--dim); letter-spacing: .06em; }
+    .console-head button { margin-left: auto; }
+    #admin-console-frame { display: block; width: 100%; height: calc(100% - 2.9rem);
+      border: 0; background: var(--void); }
+
     .rule { color: var(--faint); font-size: .72rem; white-space: nowrap; overflow: hidden;
       user-select: none; padding: 0 1.25rem; }
     footer { display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;
@@ -147,6 +159,7 @@
     <span class="spacer"></span>
     <span id="global-status" class="hint"></span>
     <nav aria-label="Syncular links">
+      <a id="console-link" href="/admin" hidden>console</a>
       <a href="https://syncular.dev/what-is/">docs</a>
       <a href="https://syncular.dev/demos/">demo guide</a>
       <a href="https://github.com/syncular/syncular">source</a>
@@ -156,6 +169,14 @@
     <section class="pane" id="pane-a"></section>
     <section class="pane" id="pane-b"></section>
   </main>
+  <dialog id="admin-console-dialog" aria-label="Syncular server console">
+    <div class="console-head">
+      server console
+      <span>read-only · in-page partition</span>
+      <button id="console-close" type="button">close</button>
+    </div>
+    <iframe id="admin-console-frame" title="Syncular server console"></iframe>
+  </dialog>
   <div class="rule">================================================================================================================================================================</div>
   <footer>
     <span>SYNCULAR v0.0.0 · DEMO · <a href="https://syncular.dev/">SYNCULAR.DEV</a></span>

--- a/apps/demo/src/frontend/main.ts
+++ b/apps/demo/src/frontend/main.ts
@@ -202,6 +202,9 @@ interface EmbeddedServer {
     mediaType?: string,
   ): Promise<void>;
   blobDownload(blobId: string): Promise<Uint8Array>;
+  admin(
+    path: string,
+  ): Promise<{ readonly status: number; readonly body: unknown }>;
   /** A realtime "socket": a numbered channel into the worker's hub (§8.7). */
   rtOpen(clientId: string, handlers: RealtimeHandlers): Promise<RealtimeSocket>;
 }
@@ -217,14 +220,18 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
     const pending = new Map<
       number,
       {
-        resolve: (msg: { bytes?: Uint8Array }) => void;
+        resolve: (msg: {
+          bytes?: Uint8Array;
+          status?: number;
+          body?: unknown;
+        }) => void;
         reject: (error: Error) => void;
       }
     >();
     const channels = new Map<number, RealtimeHandlers>();
     const call = (
       body: Record<string, unknown>,
-    ): Promise<{ bytes?: Uint8Array }> =>
+    ): Promise<{ bytes?: Uint8Array; status?: number; body?: unknown }> =>
       new Promise((res, rej) => {
         const id = nextId++;
         pending.set(id, { resolve: res, reject: rej });
@@ -243,6 +250,13 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
         const out = (await call({ kind: 'blob-download', blobId })).bytes;
         if (out === undefined) throw new Error('blob rpc returned no bytes');
         return out;
+      },
+      admin: async (path) => {
+        const result = await call({ kind: 'admin', path });
+        if (result.status === undefined || result.body === undefined) {
+          throw new Error('admin rpc returned no response');
+        }
+        return { status: result.status, body: result.body };
       },
       rtOpen: async (clientId, handlers) => {
         const channel = nextChannel++;
@@ -266,6 +280,8 @@ function getEmbeddedServer(): Promise<EmbeddedServer> {
         id?: number;
         ok?: boolean;
         bytes?: Uint8Array;
+        status?: number;
+        body?: unknown;
         text?: string;
         channel?: number;
         error?: { code: string; message: string };
@@ -1007,17 +1023,80 @@ async function main(): Promise<void> {
   const globalStatus = document.getElementById('global-status') as HTMLElement;
 
   await Promise.all([paneA.init(), paneB.init()]);
-  const debugRegistry = (
-    window as typeof window & {
-      readonly __SYNCULAR__?: { readonly clients: readonly unknown[] };
-    }
-  ).__SYNCULAR__;
-  if (debugRegistry?.clients.length === 2) {
-    console.info('Syncular debug console ready: await __SYNCULAR__.snapshot()');
-  } else {
-    console.error(
-      'sync.demo_devtools_unavailable: expected two registered clients',
-    );
+  const consoleLink = document.getElementById(
+    'console-link',
+  ) as HTMLAnchorElement;
+  if (EMBEDDED) {
+    consoleLink.hidden = false;
+    const dialog = document.getElementById(
+      'admin-console-dialog',
+    ) as HTMLDialogElement;
+    const frame = document.getElementById(
+      'admin-console-frame',
+    ) as HTMLIFrameElement;
+    window.addEventListener('message', (event) => {
+      if (
+        event.origin !== location.origin ||
+        event.source !== frame.contentWindow
+      ) {
+        return;
+      }
+      const message = event.data as {
+        readonly kind?: unknown;
+        readonly id?: unknown;
+        readonly path?: unknown;
+      };
+      if (
+        message.kind !== 'syncular-admin-request' ||
+        typeof message.id !== 'number' ||
+        typeof message.path !== 'string'
+      ) {
+        return;
+      }
+      const requestId = message.id;
+      const path = message.path;
+      void (async () => {
+        try {
+          const response = await (await getEmbeddedServer()).admin(path);
+          frame.contentWindow?.postMessage(
+            {
+              kind: 'syncular-admin-response',
+              id: requestId,
+              ok: response.status >= 200 && response.status < 300,
+              status: response.status,
+              body: response.body,
+            },
+            location.origin,
+          );
+        } catch (error) {
+          frame.contentWindow?.postMessage(
+            {
+              kind: 'syncular-admin-response',
+              id: requestId,
+              ok: false,
+              status: 500,
+              body: {
+                code:
+                  error instanceof ClientSyncError
+                    ? error.code
+                    : 'sync.internal',
+              },
+            },
+            location.origin,
+          );
+        }
+      })();
+    });
+    consoleLink.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (frame.getAttribute('src') === null) {
+        frame.src = '/admin.html?transport=parent';
+      }
+      dialog.showModal();
+    });
+    document.getElementById('console-close')?.addEventListener('click', () => {
+      dialog.close();
+    });
   }
 
   conflictBtn.disabled = false;

--- a/apps/demo/src/frontend/server-worker.test.ts
+++ b/apps/demo/src/frontend/server-worker.test.ts
@@ -1,14 +1,20 @@
-import { test } from 'bun:test';
+import { expect, test } from 'bun:test';
 
 interface WorkerMessage {
+  readonly id?: number;
   readonly kind: string;
+  readonly ok?: boolean;
+  readonly status?: number;
+  readonly body?: {
+    readonly horizon?: { readonly maxCommitSeq: number };
+  };
   readonly error?: { readonly code: string; readonly message: string };
 }
 
-test('embedded server reaches ready only after its seed applies', async () => {
+test('embedded server seeds before serving its admin routes', async () => {
   const worker = new Worker(new URL('./server-worker.ts', import.meta.url));
   try {
-    await new Promise<void>((resolve, reject) => {
+    const response = await new Promise<WorkerMessage>((resolve, reject) => {
       worker.onerror = (event) => reject(event.error);
       worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
         const message = event.data;
@@ -19,10 +25,15 @@ test('embedded server reaches ready only after its seed applies', async () => {
             ),
           );
         } else if (message.kind === 'ready') {
-          resolve();
+          worker.postMessage({ kind: 'admin', id: 1, path: '/horizon' });
+        } else if (message.kind === 'result' && message.id === 1) {
+          resolve(message);
         }
       };
     });
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+    expect(response.body?.horizon?.maxCommitSeq).toBe(1);
   } finally {
     worker.terminate();
   }

--- a/apps/demo/src/frontend/server-worker.ts
+++ b/apps/demo/src/frontend/server-worker.ts
@@ -8,7 +8,7 @@
  * SQLite instead of bun:sqlite).
  *
  * The page talks to this worker over a small RPC:
- *   page → worker: {kind:'sync'|'blob-upload'|'blob-download', id, …}
+ *   page → worker: {kind:'sync'|'blob-upload'|'blob-download'|'admin', id, …}
  *                  {kind:'rt-open'|'rt-text'|'rt-bytes'|'rt-close', channel, …}
  *   worker → page: {kind:'result', id, ok, …} · {kind:'rt-…', channel, …}
  *                  {kind:'ready'} once seeded.
@@ -36,7 +36,9 @@ import {
   type SeedMutation,
   seedMutations,
   type SyncServerConfig,
+  SyncularAdmin,
 } from '@syncular/server';
+import { createSyncularAdminRoutes } from '@syncular/server-hono';
 import { schema } from '../syncular.generated';
 
 const PARTITION = 'demo';
@@ -100,6 +102,7 @@ const ring = new RingBufferEvents({ capacity: 500 });
 interface EmbeddedServerParts {
   readonly config: SyncServerConfig;
   readonly hub: ReturnType<typeof createRealtimeHub>;
+  readonly adminRequest: (path: string) => Promise<Response>;
 }
 
 async function bootServer(): Promise<EmbeddedServerParts> {
@@ -132,7 +135,20 @@ async function bootServer(): Promise<EmbeddedServerParts> {
     // Everything inlines: no segment-download path in the embedded demo.
     limits: { inlineSegmentMaxBytes: 64 * 1024 * 1024 },
   };
-  return { config, hub };
+  const adminRoutes = createSyncularAdminRoutes(
+    SyncularAdmin.fromConfig(config, { ring }),
+    {
+      defaultPartition: PARTITION,
+      // This route surface is reachable only through the worker RPC. The page
+      // verifies the same-origin console frame before forwarding a request.
+      authorize: () => true,
+    },
+  );
+  return {
+    config,
+    hub,
+    adminRequest: async (path) => adminRoutes.request(path),
+  };
 }
 
 /** Seed a few rows through the real push path (same seed as the dev server). */
@@ -208,7 +224,7 @@ const booted = bootServer()
 
 scope.onmessage = (event: MessageEvent) => {
   void (async () => {
-    const { config, hub } = await booted;
+    const { config, hub, adminRequest } = await booted;
     const ctx = { ...config, partition: PARTITION, actorId: ACTOR_ID };
     const msg = event.data as {
       kind: string;
@@ -219,6 +235,7 @@ scope.onmessage = (event: MessageEvent) => {
       channel?: number;
       clientId?: string;
       text?: string;
+      path?: string;
     };
     const reply = (body: Record<string, unknown>, transfer?: Transferable[]) =>
       scope.postMessage({ id: msg.id, ...body }, transfer);
@@ -255,6 +272,19 @@ scope.onmessage = (event: MessageEvent) => {
             throw new Error('memory blob store always serves inline bytes');
           }
           reply({ kind: 'result', ok: true, bytes: result.bytes });
+          break;
+        }
+        case 'admin': {
+          if (msg.path === undefined || !msg.path.startsWith('/')) {
+            throw new Error('admin request requires a route path');
+          }
+          const response = await adminRequest(msg.path);
+          reply({
+            kind: 'result',
+            ok: true,
+            status: response.status,
+            body: await response.json(),
+          });
           break;
         }
         case 'rt-open': {

--- a/apps/demo/src/server.ts
+++ b/apps/demo/src/server.ts
@@ -169,7 +169,6 @@ const build = await Bun.build({
   // condition points at compiled dist for external bundlers).
   conditions: ['bun'],
   sourcemap: 'inline',
-  define: { SYNCULAR_DEVTOOLS: 'true' },
   external: ['@sqlite.org/sqlite-wasm'],
 });
 async function bundleText(basename: string): Promise<string> {

--- a/apps/docs/src/changelog.mjs
+++ b/apps/docs/src/changelog.mjs
@@ -17,8 +17,8 @@
 export const changelog = [
   {
     date: '2026-08-09',
-    title: 'Hosted demo repair and debug console',
-    body: 'The hosted two-pane demo seeds through the epoch-aware server helper and explicitly retains the browser debugging registry. Open browser devtools to inspect both live clients through __SYNCULAR__, including their snapshots and full client handles.',
+    title: 'Hosted demo repair and graphical console',
+    body: 'The hosted two-pane demo seeds through the epoch-aware server helper and opens the existing graphical SyncularAdmin console against its embedded server worker. The console reads horizon status, metrics, store stats, clients, commits, rows, scope activity, and events without sending demo data to a remote server.',
     links: [{ href: '/demos/', label: 'Live demos' }],
   },
   {

--- a/apps/docs/src/content/demos.md
+++ b/apps/docs/src/content/demos.md
@@ -21,12 +21,11 @@ Bun process. The page drives each core over the `SyncClientHandle` RPC.
 
 The [hosted version](https://demo.syncular.dev/) replaces the Bun development
 server with the same Syncular server core running over sqlite-wasm in a third
-Web Worker, making the complete demo backend-free and self-contained. Open
-browser devtools and run `await __SYNCULAR__.snapshot()` to inspect both live
-clients. `__SYNCULAR__.clients[0].ref` exposes the first client for queries,
-sync rounds, subscriptions, conflicts, and diagnostics. Both demo builds
-explicitly retain this development registry; ordinary production builds gate
-it off.
+Web Worker, making the complete demo backend-free and self-contained. Select
+`[ console ]` to open the graphical `SyncularAdmin` interface for that worker.
+The interface displays horizon status, metrics, store stats, clients, commit
+metadata, row inspection, scope activity, and the event tail. Demo data stays
+inside the page.
 
 ```sh
 git clone https://github.com/syncular/syncular
@@ -40,7 +39,7 @@ One process serves everything on one port: `POST /sync` and
 bundles. Server storage is in-memory by default;
 `SYNCULAR_DEMO_DB=path bun run --cwd apps/demo dev` persists it to a file.
 Run `SYNCULAR_DEMO_ADMIN=1 bun run --cwd apps/demo dev` to mount the complete
-operator console at `/admin`.
+graphical operator console at `/admin`.
 
 What to try:
 

--- a/apps/docs/src/content/troubleshooting.md
+++ b/apps/docs/src/content/troubleshooting.md
@@ -49,11 +49,6 @@ await __SYNCULAR__.clients[0].ref.query('SELECT * FROM todos');
 apply batch, the fastest way to confirm data is arriving and your live
 queries should have re-run.
 
-Production builds omit the registry. A public sandbox with non-sensitive data
-can retain it by defining `SYNCULAR_DEVTOOLS` as `true` in the bundler. The
-registry exposes full client handles, so applications with private data must
-keep the production gate. The two-pane demo enables this flag in both builds.
-
 ## Enter/mutate silently does nothing
 
 Seen in the dev loop: you restart the dev server while a tab stays open,

--- a/packages/server-hono/src/admin-page.ts
+++ b/packages/server-hono/src/admin-page.ts
@@ -14,6 +14,9 @@
  * All fetches are same-origin and relative ('./clients', …), so the page
  * works under whatever prefix the host mounts the routes at, and the host's
  * `authorize` guard applies to the page's own XHRs (same cookies/headers).
+ * `?transport=parent` sends the same route paths to a same-origin parent
+ * frame. Static demos can reuse this page while their admin routes run in a
+ * Web Worker.
  *
  * Panels cover the whole read surface: a metrics statusbar (ring-derived
  * rates + sparkline), the fleet view (`/partitions`, doubling as the
@@ -217,6 +220,21 @@ export const ADMIN_CONSOLE_HTML = `<!doctype html>
   // trailing slash so 'base + /clients' hits '…/admin/clients' regardless of
   // whether the URL had the trailing slash.
   var base = location.pathname.replace(/\\/+$/, '');
+  var parentTransport = new URLSearchParams(location.search).get('transport') === 'parent';
+  var nextRequestId = 1;
+  var parentRequests = {};
+  if (parentTransport) {
+    window.addEventListener('message', function (event) {
+      if (event.source !== window.parent || event.origin !== location.origin) return;
+      var message = event.data;
+      if (!message || message.kind !== 'syncular-admin-response' || typeof message.id !== 'number') return;
+      var request = parentRequests[message.id];
+      if (!request) return;
+      delete parentRequests[message.id];
+      if (message.ok) request.resolve(message.body);
+      else request.reject(new Error((message.body && message.body.code) || ('HTTP ' + message.status)));
+    });
+  }
   function qs(params) {
     var parts = [];
     var p = el('partition').value.trim();
@@ -230,7 +248,17 @@ export const ADMIN_CONSOLE_HTML = `<!doctype html>
     return parts.length ? '?' + parts.join('&') : '';
   }
   function get(path, params) {
-    return fetch(base + path + qs(params), { headers: { accept: 'application/json' } })
+    var query = qs(params);
+    if (parentTransport) {
+      return new Promise(function (resolve, reject) {
+        var id = nextRequestId++;
+        parentRequests[id] = { resolve: resolve, reject: reject };
+        window.parent.postMessage({
+          kind: 'syncular-admin-request', id: id, path: path + query
+        }, location.origin);
+      });
+    }
+    return fetch(base + path + query, { headers: { accept: 'application/json' } })
       .then(function (r) {
         if (!r.ok) return r.json().then(function (b) { throw new Error(b.code || ('HTTP ' + r.status)); });
         return r.json();
@@ -445,7 +473,7 @@ export const ADMIN_CONSOLE_HTML = `<!doctype html>
         el('events').innerHTML = empty('no RingBufferEvents wired on this admin');
         return;
       }
-      if (typeof EventSource === 'function') { connectStream(); return; }
+      if (!parentTransport && typeof EventSource === 'function') { connectStream(); return; }
       renderEventList(res.events);
     });
   }

--- a/packages/server-hono/src/admin.test.ts
+++ b/packages/server-hono/src/admin.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@syncular/server';
 import { Hono } from 'hono';
 import { createSyncularAdminRoutes } from './admin';
+import { ADMIN_CONSOLE_HTML } from './admin-page';
 import { createSyncularHono } from './index';
 
 const COLUMNS: readonly RowColumn[] = [
@@ -388,5 +389,11 @@ describe('static console page', () => {
     const html = await res.text();
     expect(html).toContain('Syncular console');
     expect(html).toContain('<!doctype html>');
+  });
+
+  test('supports the same-origin parent transport used by static hosts', () => {
+    expect(ADMIN_CONSOLE_HTML).toContain("get('transport') === 'parent'");
+    expect(ADMIN_CONSOLE_HTML).toContain('syncular-admin-request');
+    expect(ADMIN_CONSOLE_HTML).toContain('syncular-admin-response');
   });
 });

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -268,21 +268,6 @@ The state is a discriminated union covering startup, migration,
 children; a blocked live query has `phase === 'blocked'`, never an indefinite
 loading state.
 
-## Browser console debugging
-
-Development pages register every live client and page-side worker handle on
-`window.__SYNCULAR__`:
-
-```js
-await __SYNCULAR__.snapshot();
-await __SYNCULAR__.clients[0].ref.query('SELECT * FROM todos');
-```
-
-Production bundles omit this registry. A public sandbox with non-sensitive
-data can retain it by defining `SYNCULAR_DEVTOOLS` as `true` in the bundler.
-The registry exposes full client handles, so applications with private data
-must keep the production gate.
-
 ## Privacy-safe support diagnostics
 
 Every direct and Worker/multi-tab client exposes the same versioned snapshot:

--- a/packages/web-client/src/devtools.ts
+++ b/packages/web-client/src/devtools.ts
@@ -13,13 +13,11 @@
  *
  * Gated to development: the registry installs only where a `window` exists
  * (worker cores register through their page-side handle) and NODE_ENV is
- * anything except `'production'`. A browser sandbox can explicitly retain
- * the registry by defining `SYNCULAR_DEVTOOLS` as `true` in its bundle. Cost
- * when gated off: one function call per client.
+ * anything except `'production'` (bundlers statically replace it, so
+ * production builds skip installation; environments without `process` are
+ * treated as dev). Cost when gated off: one function call per client.
  */
 import type { InvalidationEvent, InvalidationListener } from './invalidation';
-
-declare const SYNCULAR_DEVTOOLS: boolean;
 
 /** What a registrant supplies — plain lambdas over its own surface. */
 export interface DevtoolsRegistration {
@@ -62,12 +60,7 @@ function registryHost(): Record<string, unknown> | undefined {
     process?: { env?: { NODE_ENV?: string } };
   };
   if (g.window === undefined) return undefined;
-  if (
-    g.process?.env?.NODE_ENV === 'production' &&
-    (typeof SYNCULAR_DEVTOOLS === 'undefined' || !SYNCULAR_DEVTOOLS)
-  ) {
-    return undefined;
-  }
+  if (g.process?.env?.NODE_ENV === 'production') return undefined;
   return g;
 }
 


### PR DESCRIPTION
## What changed

- opens the existing graphical Syncular admin console from the hosted demo
- forwards the console's route requests to `createSyncularAdminRoutes` inside the embedded server worker
- keeps the HTTP `/admin` console unchanged for the Bun demo server
- removes the production browser-registry override that addressed the wrong console
- updates the demo tests, documentation, and changelog

## Root cause

The hosted demo runs its server in a Web Worker and publishes static assets, so it had no HTTP `/admin` route for the existing console page. The first correction exposed raw state and the second exposed the browser debugging registry. Neither connected the graphical admin interface to the worker-backed server.

## Verification

- `bun run check`
- static bundle and embedded admin-route tests
- local browser test: added a todo, confirmed two-pane convergence, opened `[ console ]`, and confirmed the console showed commit sequence 2, three clients, metrics, and the event tail
