### PR TITLE
Harden TypeScript sync concurrency and migrations

### DIFF
--- a/apps/demo/src/frontend/server-worker.ts
+++ b/apps/demo/src/frontend/server-worker.ts
@@ -56,25 +56,33 @@ interface WasmDb {
 }
 
 function d1OverWasm(db: WasmDb): D1Database {
+  const prepared = new WeakMap<
+    D1PreparedStatement,
+    { readonly sql: string; readonly params: readonly unknown[] }
+  >();
   const statement = (
     sql: string,
     params: readonly unknown[],
-  ): D1PreparedStatement => ({
-    bind: (...values: unknown[]) => statement(sql, values),
-    first: async <T>() =>
-      (db.selectObjects(sql, params.length > 0 ? params : undefined)[0] ??
-        null) as T | null,
-    all: async <T>() => ({
-      results: db.selectObjects(
-        sql,
-        params.length > 0 ? params : undefined,
-      ) as T[],
-    }),
-    run: async () => {
-      db.exec({ sql, ...(params.length > 0 ? { bind: params } : {}) });
-      return {};
-    },
-  });
+  ): D1PreparedStatement => {
+    const result: D1PreparedStatement = {
+      bind: (...values: unknown[]) => statement(sql, values),
+      first: async <T>() =>
+        (db.selectObjects(sql, params.length > 0 ? params : undefined)[0] ??
+          null) as T | null,
+      all: async <T>() => ({
+        results: db.selectObjects(
+          sql,
+          params.length > 0 ? params : undefined,
+        ) as T[],
+      }),
+      run: async () => {
+        db.exec({ sql, ...(params.length > 0 ? { bind: params } : {}) });
+        return {};
+      },
+    };
+    prepared.set(result, { sql, params });
+    return result;
+  };
   return {
     prepare: (sql) => statement(sql, []),
     // Real D1 wraps a batch in one implicit transaction (all-or-nothing);
@@ -83,7 +91,22 @@ function d1OverWasm(db: WasmDb): D1Database {
       db.exec({ sql: 'BEGIN' });
       try {
         const results: unknown[] = [];
-        for (const stmt of statements) results.push(await stmt.run());
+        for (const stmt of statements) {
+          const source = prepared.get(stmt);
+          if (source === undefined) {
+            throw new Error('batch received a statement from another adapter');
+          }
+          if (/^\s*(?:SELECT|WITH)\b/i.test(source.sql)) {
+            results.push({
+              results: db.selectObjects(
+                source.sql,
+                source.params.length > 0 ? source.params : undefined,
+              ),
+            });
+          } else {
+            results.push(await stmt.run());
+          }
+        }
         db.exec({ sql: 'COMMIT' });
         return results;
       } catch (error) {

--- a/packages/conformance/src/catalog/ws-rounds.ts
+++ b/packages/conformance/src/catalog/ws-rounds.ts
@@ -7,6 +7,17 @@
  * Readiness doctrine: every wait is an explicit completion promise at
  * the transport seam (rounds completed, deltas, acks, server close).
  * Zero sleeps, zero polls.
+ *
+ * There is deliberately no stalled-transport scenario here. §8.7 makes
+ * backpressure mechanics ("drain events, thresholds, chunk sizes") host
+ * concerns, so the only wire-observable requirement under a socket that
+ * cannot drain is the one every scenario below already asserts: the
+ * response stream arrives complete and in order, never truncated,
+ * reordered, or interleaved. The rate it arrives at is not observable.
+ * `RealtimeSink` matches that: `onText`/`onBinary` return void, so a
+ * harness sink has no way to decline a frame, defer one, or report a
+ * buffer depth, and giving it one would change a contract both server
+ * drivers implement.
  */
 import { REALTIME_TAG_ROUND } from '@syncular/core';
 import { check, checkEqual } from '../checks';

--- a/packages/conformance/src/drivers/ts-server.ts
+++ b/packages/conformance/src/drivers/ts-server.ts
@@ -374,6 +374,8 @@ class TsServerInstance implements ServerInstance {
       scanRows: (p, q) => this.#storage.scanRows(p, q),
       getClientRecord: (p, c) => this.#storage.getClientRecord(p, c),
       putClientRecord: (p, r) => this.#storage.putClientRecord(p, r),
+      updateClientCursor: (p, c, cursor, updatedAtMs) =>
+        this.#storage.updateClientCursor(p, c, cursor, updatedAtMs),
       listClientCursors: (p) => this.#storage.listClientCursors(p),
       // §5.9.4 blob reference index reads.
       listRowsReferencingBlob: (p, b) =>

--- a/packages/server/src/d1-storage.ts
+++ b/packages/server/src/d1-storage.ts
@@ -49,7 +49,10 @@ import {
   commitWindowPageSql,
   deleteRowSql,
   dropTableDdl,
+  expectedIndexShapes,
   indexRowPageStatement,
+  indexReconciliationDdl,
+  indexesNeedReconciliation,
   layoutsOf,
   migratePayload,
   parseLayouts,
@@ -61,7 +64,7 @@ import {
   SCHEMA_META_DDL_SQLITE,
   type StoredColumnLayout,
   scanRowPageSql,
-  schemaDdl,
+  schemaProjectionDdl,
   selectRowScopesSql,
   selectRowSql,
   selectRowsForRewriteSql,
@@ -206,6 +209,7 @@ class D1Transaction implements StorageTransaction {
   readonly #partition: string;
   readonly #resolveTable: (name: string) => CompiledTable;
   readonly #pushApplySerialized: boolean;
+  readonly #schemaVersion: number | undefined;
   readonly #buffer: BufferedStatement[] = [];
   #open = true;
   /** Live snapshot of `max_commit_seq`, advanced within this transaction. */
@@ -234,11 +238,13 @@ class D1Transaction implements StorageTransaction {
     partition: string,
     resolveTable: (name: string) => CompiledTable,
     pushApplySerialized: boolean,
+    schemaVersion: number | undefined,
   ) {
     this.#db = db;
     this.#partition = partition;
     this.#resolveTable = resolveTable;
     this.#pushApplySerialized = pushApplySerialized;
+    this.#schemaVersion = schemaVersion;
   }
 
   #assertOpen(): void {
@@ -249,6 +255,21 @@ class D1Transaction implements StorageTransaction {
     this.#buffer.push({ sql, params });
   }
 
+  async #guardedBatch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+    const schemaVersion = this.#schemaVersion;
+    if (schemaVersion === undefined) {
+      throw new Error('ensureSchema(schema) must run before relational access');
+    }
+    try {
+      return await this.#db.batch([
+        d1SchemaFenceStatement(this.#db, schemaVersion),
+        ...statements,
+      ]);
+    } catch (error) {
+      return throwD1SchemaFenceFailure(this.#db, schemaVersion, error);
+    }
+  }
+
   static #key(table: string, rowId: string): string {
     return `${table}\u0000${rowId}`;
   }
@@ -257,12 +278,15 @@ class D1Transaction implements StorageTransaction {
     this.#assertOpen();
     const pending = this.#pending.get(D1Transaction.#key(table, rowId));
     if (pending !== undefined) {
+      await this.#guardedBatch([]);
       return pending.kind === 'row' ? pending.row : undefined;
     }
-    const record = await this.#db
-      .prepare(selectRowSql(this.#resolveTable(table), 'sqlite'))
-      .bind(this.#partition, rowId)
-      .first<SqliteRowRecord>();
+    const results = await this.#guardedBatch([
+      this.#db
+        .prepare(selectRowSql(this.#resolveTable(table), 'sqlite'))
+        .bind(this.#partition, rowId),
+    ]);
+    const record = d1BatchRows<SqliteRowRecord>(results[1])[0] ?? null;
     return record === null ? undefined : toStoredRow(record);
   }
 
@@ -309,18 +333,22 @@ class D1Transaction implements StorageTransaction {
     let afterRowId = query.afterRowId ?? '';
     const batchSize = Math.max(64, persistedLimit);
     while (persisted.length < persistedLimit) {
-      const { results: records } = await this.#db
-        .prepare(sql)
-        .bind(
-          this.#partition,
-          query.table,
-          firstVariable,
-          ...firstValues,
-          afterRowId,
-          batchSize,
-          this.#partition,
-        )
-        .all<SqliteRowRecord & { payload: Uint8Array | null }>();
+      const results = await this.#guardedBatch([
+        this.#db
+          .prepare(sql)
+          .bind(
+            this.#partition,
+            query.table,
+            firstVariable,
+            ...firstValues,
+            afterRowId,
+            batchSize,
+            this.#partition,
+          ),
+      ]);
+      const records = d1BatchRows<
+        SqliteRowRecord & { payload: Uint8Array | null }
+      >(results[1]);
       if (records.length === 0) break;
       for (const record of records) {
         afterRowId = record.row_id;
@@ -368,10 +396,10 @@ class D1Transaction implements StorageTransaction {
       persistedLimit,
       'sqlite',
     );
-    const { results: records } = await this.#db
-      .prepare(statement.sql)
-      .bind(...statement.params)
-      .all<SqliteRowRecord>();
+    const results = await this.#guardedBatch([
+      this.#db.prepare(statement.sql).bind(...statement.params),
+    ]);
+    const records = d1BatchRows<SqliteRowRecord>(results[1]);
 
     const rows = new Map(
       records.map((record) => {
@@ -489,10 +517,10 @@ class D1Transaction implements StorageTransaction {
         }
         return toSqlValue(schemaColumn, values[valueIndex] ?? null, 'sqlite');
       });
-      const persisted = await this.#db
-        .prepare(sql)
-        .bind(this.#partition, ...bind, row.rowId)
-        .first<{ row_id: string }>();
+      const results = await this.#guardedBatch([
+        this.#db.prepare(sql).bind(this.#partition, ...bind, row.rowId),
+      ]);
+      const persisted = d1BatchRows<{ row_id: string }>(results[1])[0] ?? null;
       if (persisted === null) continue;
 
       const pending = this.#pending.get(
@@ -687,7 +715,7 @@ class D1Transaction implements StorageTransaction {
     );
     // One atomic D1 batch — the §6.4 all-or-nothing commit.
     try {
-      await this.#db.batch(statements);
+      await this.#guardedBatch(statements);
       this.#open = false;
     } catch (error) {
       if (isD1ConstraintError(error)) {
@@ -717,6 +745,124 @@ class D1Transaction implements StorageTransaction {
  * binds one per app column plus the five `_sync_*` meta columns.
  */
 const D1_MAX_BIND_PARAMS = 100;
+
+const D1_SCHEMA_MIGRATION_DDL = `CREATE TABLE IF NOT EXISTS sync_schema_migration(
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  from_version INTEGER,
+  target_version INTEGER NOT NULL,
+  target_identity TEXT NOT NULL,
+  plans TEXT NOT NULL,
+  progress TEXT NOT NULL
+)`;
+
+interface D1SchemaMigrationPlan {
+  readonly table: string;
+  readonly migrate: boolean;
+  readonly backfill: boolean;
+  readonly oldLayout?: readonly StoredColumnLayout[];
+}
+
+interface D1SchemaMigrationProgress {
+  readonly tableIndex: number;
+  readonly afterPartition: string;
+  readonly afterRowId: string;
+}
+
+interface D1SchemaMigrationRecord {
+  readonly from_version: number | null;
+  readonly target_version: number;
+  readonly target_identity: string;
+  readonly plans: string;
+  readonly progress: string;
+}
+
+function d1SchemaMigrationIdentity(schema: CompiledSchema): string {
+  return JSON.stringify({
+    version: schema.version,
+    tables: [...schema.tables.values()]
+      .sort((left, right) =>
+        left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+      )
+      .map((table) => ({
+        name: table.name,
+        materialize: table.materialize,
+        columns: table.columns.map((column) => ({
+          name: column.name,
+          type: column.type,
+          nullable: column.nullable,
+          ...(column.crdtType !== undefined
+            ? { crdtType: column.crdtType }
+            : {}),
+          ...(column.encrypted !== undefined
+            ? { encrypted: column.encrypted }
+            : {}),
+          ...(column.declaredType !== undefined
+            ? { declaredType: column.declaredType }
+            : {}),
+        })),
+        primaryKeyIndex: table.primaryKeyIndex,
+        indexes: [...expectedIndexShapes(table)].sort((left, right) =>
+          left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+        ),
+      })),
+  });
+}
+
+function d1SchemaMigrationInProgress(): Error {
+  return new Error('schema migration is already in progress');
+}
+
+function d1SchemaFenceStatement(
+  db: D1Database,
+  schemaVersion: number,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO sync_schema_migration(
+         id, from_version, target_version, target_identity, plans, progress
+       )
+       SELECT 2, NULL, 0, '', '', '{}'
+        WHERE EXISTS (
+          SELECT 1 FROM sync_schema_migration WHERE id=1
+        ) OR NOT EXISTS (
+          SELECT 1 FROM sync_schema_meta
+           WHERE id=1 AND schema_version=?
+        )`,
+    )
+    .bind(schemaVersion);
+}
+
+async function throwD1SchemaFenceFailure(
+  db: D1Database,
+  schemaVersion: number,
+  cause: unknown,
+): Promise<never> {
+  const migration = await db
+    .prepare('SELECT target_version FROM sync_schema_migration WHERE id=1')
+    .first<{ target_version: number }>();
+  if (migration !== null) throw d1SchemaMigrationInProgress();
+  const marker = await db
+    .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+    .first<{ schema_version: number }>();
+  if (marker !== null && marker.schema_version !== schemaVersion) {
+    throw new Error(
+      `stored schema version ${marker.schema_version} differs from the active storage schema (${schemaVersion})`,
+    );
+  }
+  throw cause;
+}
+
+function d1BatchRows<T>(result: unknown): T[] {
+  if (
+    typeof result !== 'object' ||
+    result === null ||
+    !('results' in result) ||
+    !Array.isArray(result.results)
+  ) {
+    throw new Error('D1 guarded read returned an invalid batch result');
+  }
+  return result.results as T[];
+}
 
 export interface D1ServerStorageOptions {
   /**
@@ -774,11 +920,45 @@ export class D1ServerStorage implements ServerStorage {
     return table;
   }
 
+  async #projectionColumns(
+    schema: CompiledSchema,
+  ): Promise<ReadonlyMap<string, ReadonlySet<string>>> {
+    const columns = new Map<string, ReadonlySet<string>>();
+    for (const table of schema.tables.values()) {
+      const escapedTableName = table.name.replaceAll('"', '""');
+      const { results } = await this.#db
+        .prepare(`PRAGMA table_info("${escapedTableName}")`)
+        .all<{ name: string }>();
+      if (results.length > 0) {
+        columns.set(table.name, new Set(results.map((column) => column.name)));
+      }
+    }
+    return columns;
+  }
+
+  async #guardedBatch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+    const schemaVersion = this.#schemaVersion;
+    if (schemaVersion === undefined) {
+      throw new Error('ensureSchema(schema) must run before relational reads');
+    }
+    try {
+      return await this.#db.batch([
+        d1SchemaFenceStatement(this.#db, schemaVersion),
+        ...statements,
+      ]);
+    } catch (error) {
+      return throwD1SchemaFenceFailure(this.#db, schemaVersion, error);
+    }
+  }
+
   async ensureSchema(schema: CompiledSchema): Promise<void> {
-    // Memoized fast path: same instance, same schema version. D1 storages
-    // are typically constructed per request — a fresh instance pays exactly
-    // one marker read below when the version already matches.
-    if (this.#schemaVersion === schema.version) return;
+    // A persistent Durable Object reuses one storage instance while schema
+    // migration claims are database-global. Even the memoized path must
+    // validate the marker and active claim on every round.
+    if (this.#schemaVersion === schema.version) {
+      await this.#guardedBatch([]);
+      return;
+    }
     for (const table of schema.tables.values()) {
       const bindCount = tableColumnNames(table).length;
       if (bindCount > D1_MAX_BIND_PARAMS) {
@@ -788,6 +968,7 @@ export class D1ServerStorage implements ServerStorage {
       }
     }
     await this.#db.exec(`${SCHEMA_META_DDL_SQLITE.replace(/\s+/g, ' ')};`);
+    await this.#db.exec(`${D1_SCHEMA_MIGRATION_DDL.replace(/\s+/g, ' ')};`);
     const marker = await this.#db
       .prepare(
         'SELECT schema_version, layouts FROM sync_schema_meta WHERE id=1',
@@ -798,8 +979,89 @@ export class D1ServerStorage implements ServerStorage {
         `stored schema version ${marker.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
       );
     }
+    if (marker?.schema_version === schema.version) {
+      const activeMigration = await this.#db
+        .prepare('SELECT target_version FROM sync_schema_migration WHERE id=1')
+        .first<{ target_version: number }>();
+      if (activeMigration !== null) throw d1SchemaMigrationInProgress();
+      const existingIndexes = new Map<string, ReadonlySet<string>>();
+      let reconciliationNeeded = false;
+      for (const table of schema.tables.values()) {
+        const expected = expectedIndexShapes(table);
+        if (expected.length === 0) continue;
+        const escapedTableName = table.name.replaceAll('"', '""');
+        const indexes = await this.#db
+          .prepare(`PRAGMA index_list("${escapedTableName}")`)
+          .all<{ name: string; unique: number; origin: string }>();
+        const freeStanding = indexes.results.filter(
+          (index) => index.origin === 'c',
+        );
+        existingIndexes.set(
+          table.name,
+          new Set(freeStanding.map((index) => index.name)),
+        );
+        const expectedNames = new Set(expected.map((index) => index.name));
+        const shapes = new Map<
+          string,
+          { readonly unique: boolean; readonly columns: readonly string[] }
+        >();
+        for (const index of freeStanding) {
+          if (!expectedNames.has(index.name)) continue;
+          const escapedIndexName = index.name.replaceAll('"', '""');
+          const columns = await this.#db
+            .prepare(`PRAGMA index_info("${escapedIndexName}")`)
+            .all<{ name: string }>();
+          shapes.set(index.name, {
+            unique: index.unique === 1,
+            columns: columns.results.map((column) => column.name),
+          });
+        }
+        reconciliationNeeded ||= indexesNeedReconciliation(table, shapes);
+      }
+      if (reconciliationNeeded) {
+        // The first statement fails the atomic batch unless the marker still
+        // names the version whose index shapes were inspected above.
+        try {
+          await this.#db.batch([
+            this.#db
+              .prepare(
+                `INSERT INTO sync_schema_migration(
+                   id, from_version, target_version,
+                   target_identity, plans, progress
+                 )
+                 SELECT 2, NULL, 0, '', '', '{}'
+                  WHERE NOT EXISTS (
+                    SELECT 1 FROM sync_schema_meta
+                     WHERE id=1 AND schema_version=?
+                  ) OR EXISTS (
+                    SELECT 1 FROM sync_schema_migration WHERE id=1
+                  )`,
+              )
+              .bind(schema.version),
+            ...indexReconciliationDdl(schema, existingIndexes).map(
+              (statement) => this.#db.prepare(statement),
+            ),
+          ]);
+        } catch (error) {
+          const current = await this.#db
+            .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+            .first<{ schema_version: number }>();
+          const migration = await this.#db
+            .prepare(
+              'SELECT target_version FROM sync_schema_migration WHERE id=1',
+            )
+            .first<{ target_version: number }>();
+          if (migration !== null) throw d1SchemaMigrationInProgress();
+          if (current !== null && current.schema_version > schema.version) {
+            throw new Error(
+              `stored schema version ${current.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+            );
+          }
+          throw error;
+        }
+      }
+    }
     if (marker === null || marker.schema_version < schema.version) {
-      await this.migrate();
       const layouts = parseLayouts(marker?.layouts);
       const retiredTables = retiredTableNames(schema, layouts);
       const existing = new Map<string, ReadonlySet<string>>();
@@ -824,45 +1086,217 @@ export class D1ServerStorage implements ServerStorage {
           );
         }
       }
-      for (const statement of schemaDdl(
-        schema,
-        existing,
-        'sqlite',
-        existingIndexes,
-      )) {
-        await this.#db.exec(`${statement.replace(/\s+/g, ' ')};`);
-      }
-      // Migration rewrite: payload re-encode on layout change and/or
-      // projection backfill on flipped-on materialization. D1 has no
-      // interactive transaction — the rewrite runs statement-at-a-time,
-      // which is safe (each rewrite is idempotent and the marker only
-      // advances after all rewrites land; a mid-run crash re-runs them).
+      const plans: D1SchemaMigrationPlan[] = [];
       for (const table of schema.tables.values()) {
         const oldLayout = layouts[table.name];
         const plan = rewritePlan(table, oldLayout, existing.get(table.name));
         if (!plan.migrate && !plan.backfill) continue;
-        await this.#rewriteRows(table, plan.migrate ? oldLayout : undefined);
+        plans.push({
+          table: table.name,
+          migrate: plan.migrate,
+          backfill: plan.backfill,
+          ...(plan.migrate ? { oldLayout } : {}),
+        });
       }
-      // Retire tables only after the additive DDL and rewrites succeed. D1
-      // cannot wrap the whole bump in an interactive transaction, but this
-      // ordering avoids destructive work before every fallible preparatory
-      // step and the batch keeps table + live-scope cleanup atomic.
-      if (retiredTables.length > 0) {
-        await this.#db.batch(
-          retiredTables.flatMap((tableName) => [
+      const targetIdentity = d1SchemaMigrationIdentity(schema);
+      const encodedPlans = JSON.stringify(plans);
+      const initialProgress = JSON.stringify({
+        tableIndex: 0,
+        afterPartition: '',
+        afterRowId: '',
+      } satisfies D1SchemaMigrationProgress);
+      try {
+        await this.#db.batch([
+          marker === null
+            ? this.#db.prepare(
+                `INSERT INTO sync_schema_migration(
+                   id, from_version, target_version,
+                   target_identity, plans, progress
+                 )
+                 SELECT 2, NULL, 0, '', '', '{}'
+                  WHERE EXISTS (
+                    SELECT 1 FROM sync_schema_meta WHERE id=1
+                  )`,
+              )
+            : this.#db
+                .prepare(
+                  `INSERT INTO sync_schema_migration(
+                     id, from_version, target_version,
+                     target_identity, plans, progress
+                   )
+                   SELECT 2, NULL, 0, '', '', '{}'
+                    WHERE NOT EXISTS (
+                      SELECT 1 FROM sync_schema_meta
+                       WHERE id=1 AND schema_version=?
+                    )`,
+                )
+                .bind(marker.schema_version),
+          this.#db
+            .prepare(
+              `INSERT OR IGNORE INTO sync_schema_migration(
+                 id, from_version, target_version,
+                 target_identity, plans, progress
+               ) VALUES (1, ?, ?, ?, ?, ?)`,
+            )
+            .bind(
+              marker?.schema_version ?? null,
+              schema.version,
+              targetIdentity,
+              encodedPlans,
+              initialProgress,
+            ),
+        ]);
+      } catch (error) {
+        const active = await this.#db
+          .prepare(
+            'SELECT target_version FROM sync_schema_migration WHERE id=1',
+          )
+          .first<{ target_version: number }>();
+        if (active !== null) throw d1SchemaMigrationInProgress();
+        const current = await this.#db
+          .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+          .first<{ schema_version: number }>();
+        if (current?.schema_version === schema.version) {
+          await this.ensureSchema(schema);
+          return;
+        }
+        if (current !== null && current.schema_version > schema.version) {
+          throw new Error(
+            `stored schema version ${current.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+          );
+        }
+        throw error;
+      }
+      const migration = await this.#db
+        .prepare(
+          `SELECT from_version, target_version, target_identity, plans, progress
+             FROM sync_schema_migration WHERE id=1`,
+        )
+        .first<D1SchemaMigrationRecord>();
+      if (
+        migration === null ||
+        migration.target_version !== schema.version ||
+        migration.target_identity !== targetIdentity
+      ) {
+        throw d1SchemaMigrationInProgress();
+      }
+
+      // D1 has no interactive transactions. The durable claim above is the
+      // serialization boundary: additive DDL is idempotent, and each bounded
+      // rewrite page below advances its keyset checkpoint in the same atomic
+      // batch as that page's row updates. A crash can therefore resume without
+      // decoding a payload that was already rewritten under the target layout.
+      await this.migrate();
+      for (;;) {
+        const currentColumns = await this.#projectionColumns(schema);
+        const statement = schemaProjectionDdl(
+          schema,
+          currentColumns,
+          'sqlite',
+        )[0];
+        if (statement === undefined) break;
+        try {
+          await this.#db.exec(`${statement.replace(/\s+/g, ' ')};`);
+        } catch (error) {
+          const refreshedColumns = await this.#projectionColumns(schema);
+          if (
+            schemaProjectionDdl(schema, refreshedColumns, 'sqlite')[0] ===
+            statement
+          ) {
+            throw error;
+          }
+        }
+      }
+      await this.#rewriteRows(schema, targetIdentity);
+
+      const completedMigration = await this.#db
+        .prepare(
+          `SELECT from_version, target_version, target_identity, plans, progress
+             FROM sync_schema_migration WHERE id=1`,
+        )
+        .first<D1SchemaMigrationRecord>();
+      if (completedMigration === null) {
+        const current = await this.#db
+          .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+          .first<{ schema_version: number }>();
+        if (current?.schema_version === schema.version) {
+          this.#tables = schema.tables;
+          this.#schemaVersion = schema.version;
+          return;
+        }
+        throw d1SchemaMigrationInProgress();
+      }
+      if (completedMigration.target_identity !== targetIdentity) {
+        throw d1SchemaMigrationInProgress();
+      }
+      const completedProgress = JSON.parse(
+        completedMigration.progress,
+      ) as D1SchemaMigrationProgress;
+      const storedPlans = JSON.parse(
+        completedMigration.plans,
+      ) as D1SchemaMigrationPlan[];
+      if (completedProgress.tableIndex < storedPlans.length) {
+        throw new Error('schema migration rewrite did not complete');
+      }
+
+      // Publication is the only destructive phase. The exact durable claim,
+      // completed progress, index rebuild, table retirement, marker advance,
+      // and claim deletion share one D1 transaction.
+      try {
+        await this.#db.batch([
+          this.#db
+            .prepare(
+              `INSERT INTO sync_schema_migration(
+                 id, from_version, target_version,
+                 target_identity, plans, progress
+               )
+               SELECT 2, NULL, 0, '', '', '{}'
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM sync_schema_migration
+                   WHERE id=1 AND target_identity=? AND progress=?
+                )`,
+            )
+            .bind(targetIdentity, completedMigration.progress),
+          ...indexReconciliationDdl(schema, existingIndexes).map((statement) =>
+            this.#db.prepare(statement),
+          ),
+          ...retiredTables.flatMap((tableName) => [
             this.#db
               .prepare('DELETE FROM sync_row_scopes WHERE tbl=?')
               .bind(tableName),
+            this.#db
+              .prepare('DELETE FROM sync_blob_refs WHERE tbl=?')
+              .bind(tableName),
             this.#db.prepare(dropTableDdl(tableName)),
           ]),
-        );
+          this.#db
+            .prepare(
+              'INSERT INTO sync_schema_meta(id, schema_version, layouts) VALUES (1, ?, ?) ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, layouts=excluded.layouts',
+            )
+            .bind(schema.version, layoutsOf(schema)),
+          this.#db
+            .prepare(
+              'DELETE FROM sync_schema_migration WHERE id=1 AND target_identity=?',
+            )
+            .bind(targetIdentity),
+        ]);
+      } catch (error) {
+        const current = await this.#db
+          .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+          .first<{ schema_version: number }>();
+        if (current?.schema_version === schema.version) {
+          // An equal concurrent bump published the same projection.
+        } else if (
+          current !== null &&
+          current.schema_version > schema.version
+        ) {
+          throw new Error(
+            `stored schema version ${current.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+          );
+        } else {
+          throw error;
+        }
       }
-      await this.#db
-        .prepare(
-          'INSERT INTO sync_schema_meta(id, schema_version, layouts) VALUES (1, ?, ?) ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, layouts=excluded.layouts',
-        )
-        .bind(schema.version, layoutsOf(schema))
-        .run();
     }
     this.#tables = schema.tables;
     this.#schemaVersion = schema.version;
@@ -959,25 +1393,52 @@ export class D1ServerStorage implements ServerStorage {
 
   /** Keyset-paged migration rewrite (see the sqlite storage's counterpart). */
   async #rewriteRows(
-    table: CompiledTable,
-    oldLayout: readonly StoredColumnLayout[] | undefined,
+    schema: CompiledSchema,
+    targetIdentity: string,
   ): Promise<void> {
-    const select = selectRowsForRewriteSql(table, 'sqlite');
-    const update = rewriteRowSql(table, 'sqlite');
+    // D1 does not document a batch statement-count limit. Keep the existing
+    // fixed page bound so memory and transaction duration never scale with
+    // the database; the platform still applies its per-statement and 30-second
+    // query limits to each atomic batch.
     const BATCH = 500;
-    let afterPartition = '';
-    let afterRowId = '';
     for (;;) {
+      const migration = await this.#db
+        .prepare(
+          `SELECT from_version, target_version, target_identity, plans, progress
+             FROM sync_schema_migration WHERE id=1`,
+        )
+        .first<D1SchemaMigrationRecord>();
+      if (migration === null) {
+        const marker = await this.#db
+          .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+          .first<{ schema_version: number }>();
+        if (marker?.schema_version === schema.version) return;
+        throw d1SchemaMigrationInProgress();
+      }
+      if (migration.target_identity !== targetIdentity) {
+        throw d1SchemaMigrationInProgress();
+      }
+      const plans = JSON.parse(migration.plans) as D1SchemaMigrationPlan[];
+      const progress = JSON.parse(
+        migration.progress,
+      ) as D1SchemaMigrationProgress;
+      const plan = plans[progress.tableIndex];
+      if (plan === undefined) return;
+      const table = schema.tables.get(plan.table);
+      if (table === undefined) {
+        throw new Error('schema migration plan names an unknown table');
+      }
+      const select = selectRowsForRewriteSql(table, 'sqlite');
+      const update = rewriteRowSql(table, 'sqlite');
       const { results } = await this.#db
         .prepare(select)
-        .bind(afterPartition, afterRowId, BATCH)
+        .bind(progress.afterPartition, progress.afterRowId, BATCH)
         .all<{ partition: string; row_id: string; payload: unknown }>();
-      if (results.length === 0) break;
       const statements = results.map((row) => {
         const bytes = asUint8Array(row.payload);
         const payload =
-          oldLayout !== undefined
-            ? migratePayload(oldLayout, table, bytes)
+          plan.migrate && plan.oldLayout !== undefined
+            ? migratePayload(plan.oldLayout, table, bytes)
             : bytes;
         return this.#db
           .prepare(update)
@@ -991,11 +1452,67 @@ export class D1ServerStorage implements ServerStorage {
             ),
           );
       });
-      await this.#db.batch(statements);
       const last = results[results.length - 1];
-      if (last === undefined || results.length < BATCH) break;
-      afterPartition = last.partition;
-      afterRowId = last.row_id;
+      const nextProgress: D1SchemaMigrationProgress =
+        results.length < BATCH
+          ? {
+              tableIndex: progress.tableIndex + 1,
+              afterPartition: '',
+              afterRowId: '',
+            }
+          : {
+              tableIndex: progress.tableIndex,
+              afterPartition: last?.partition ?? progress.afterPartition,
+              afterRowId: last?.row_id ?? progress.afterRowId,
+            };
+      const encodedProgress = JSON.stringify(nextProgress);
+      try {
+        await this.#db.batch([
+          this.#db
+            .prepare(
+              `INSERT INTO sync_schema_migration(
+                 id, from_version, target_version,
+                 target_identity, plans, progress
+               )
+               SELECT 2, NULL, 0, '', '', '{}'
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM sync_schema_migration
+                   WHERE id=1 AND target_identity=? AND progress=?
+                )`,
+            )
+            .bind(targetIdentity, migration.progress),
+          ...statements,
+          this.#db
+            .prepare(
+              `UPDATE sync_schema_migration SET progress=?
+                WHERE id=1 AND target_identity=? AND progress=?`,
+            )
+            .bind(encodedProgress, targetIdentity, migration.progress),
+        ]);
+      } catch (error) {
+        const current = await this.#db
+          .prepare(
+            'SELECT target_identity, progress FROM sync_schema_migration WHERE id=1',
+          )
+          .first<{ target_identity: string; progress: string }>();
+        if (
+          current !== null &&
+          current.target_identity === targetIdentity &&
+          current.progress !== migration.progress
+        ) {
+          continue;
+        }
+        if (current === null) {
+          const marker = await this.#db
+            .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+            .first<{ schema_version: number }>();
+          if (marker?.schema_version === schema.version) return;
+        }
+        if (current?.target_identity !== targetIdentity) {
+          throw d1SchemaMigrationInProgress();
+        }
+        throw error;
+      }
     }
   }
 
@@ -1005,6 +1522,7 @@ export class D1ServerStorage implements ServerStorage {
       partition,
       (name) => this.table(name),
       this.#pushApplySerialized,
+      this.#schemaVersion,
     );
   }
 
@@ -1034,14 +1552,14 @@ export class D1ServerStorage implements ServerStorage {
       ),
       partition,
     );
-    const results = await this.#db.batch([
+    const results = await this.#guardedBatch([
       this.#db.prepare(prepared.sql).bind(...prepared.params),
       this.#db
         .prepare('SELECT max_commit_seq FROM sync_partitions WHERE partition=?')
         .bind(partition),
     ]);
-    const rowsResult = results[0];
-    const cursorResult = results[1];
+    const rowsResult = results[1];
+    const cursorResult = results[2];
     if (
       typeof rowsResult !== 'object' ||
       rowsResult === null ||
@@ -1082,7 +1600,7 @@ export class D1ServerStorage implements ServerStorage {
   async setHorizonSeq(partition: string, seq: number): Promise<void> {
     await this.#db
       .prepare(
-        'INSERT INTO sync_partitions(partition, horizon_seq) VALUES (?,?) ON CONFLICT(partition) DO UPDATE SET horizon_seq=excluded.horizon_seq',
+        'INSERT INTO sync_partitions(partition, horizon_seq) VALUES (?,?) ON CONFLICT(partition) DO UPDATE SET horizon_seq=MAX(sync_partitions.horizon_seq, excluded.horizon_seq)',
       )
       .bind(partition, seq)
       .run();
@@ -1129,10 +1647,12 @@ export class D1ServerStorage implements ServerStorage {
     table: string,
     rowId: string,
   ): Promise<StoredRow | undefined> {
-    const record = await this.#db
-      .prepare(selectRowSql(this.table(table), 'sqlite'))
-      .bind(partition, rowId)
-      .first<SqliteRowRecord>();
+    const results = await this.#guardedBatch([
+      this.#db
+        .prepare(selectRowSql(this.table(table), 'sqlite'))
+        .bind(partition, rowId),
+    ]);
+    const record = d1BatchRows<SqliteRowRecord>(results[1])[0] ?? null;
     return record === null ? undefined : toStoredRow(record);
   }
 
@@ -1432,18 +1952,22 @@ export class D1ServerStorage implements ServerStorage {
     let afterRowId = query.afterRowId ?? '';
     const batchSize = Math.max(64, query.limit);
     while (rows.length < query.limit) {
-      const { results: records } = await this.#db
-        .prepare(sql)
-        .bind(
-          partition,
-          query.table,
-          firstVariable,
-          ...firstValues,
-          afterRowId,
-          batchSize,
-          partition,
-        )
-        .all<SqliteRowRecord & { payload: Uint8Array | null }>();
+      const results = await this.#guardedBatch([
+        this.#db
+          .prepare(sql)
+          .bind(
+            partition,
+            query.table,
+            firstVariable,
+            ...firstValues,
+            afterRowId,
+            batchSize,
+            partition,
+          ),
+      ]);
+      const records = d1BatchRows<
+        SqliteRowRecord & { payload: Uint8Array | null }
+      >(results[1]);
       if (records.length === 0) break;
       for (const record of records) {
         afterRowId = record.row_id;
@@ -1475,11 +1999,10 @@ export class D1ServerStorage implements ServerStorage {
       query.limit,
       'sqlite',
     );
-    const { results } = await this.#db
-      .prepare(statement.sql)
-      .bind(...statement.params)
-      .all<SqliteRowRecord>();
-    return results.map(toStoredRow);
+    const results = await this.#guardedBatch([
+      this.#db.prepare(statement.sql).bind(...statement.params),
+    ]);
+    return d1BatchRows<SqliteRowRecord>(results[1]).map(toStoredRow);
   }
 
   async getClientRecord(
@@ -1516,7 +2039,14 @@ export class D1ServerStorage implements ServerStorage {
   ): Promise<void> {
     await this.#db
       .prepare(
-        'INSERT OR REPLACE INTO sync_clients(partition, client_id, actor_id, wire_version, cursor, subscriptions, updated_at_ms) VALUES (?,?,?,?,?,?,?)',
+        `INSERT INTO sync_clients(partition, client_id, actor_id, wire_version, cursor, subscriptions, updated_at_ms)
+         VALUES (?,?,?,?,?,?,?)
+         ON CONFLICT(partition, client_id) DO UPDATE SET
+           actor_id=excluded.actor_id,
+           wire_version=excluded.wire_version,
+           cursor=MAX(sync_clients.cursor, excluded.cursor),
+           subscriptions=excluded.subscriptions,
+           updated_at_ms=MAX(sync_clients.updated_at_ms, excluded.updated_at_ms)`,
       )
       .bind(
         partition,
@@ -1527,6 +2057,22 @@ export class D1ServerStorage implements ServerStorage {
         JSON.stringify(record.subscriptions),
         record.updatedAtMs,
       )
+      .run();
+  }
+
+  async updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void> {
+    await this.#db
+      .prepare(
+        `UPDATE sync_clients
+         SET cursor=MAX(cursor, ?), updated_at_ms=MAX(updated_at_ms, ?)
+         WHERE partition=? AND client_id=?`,
+      )
+      .bind(cursor, updatedAtMs, partition, clientId)
       .run();
   }
 
@@ -1568,10 +2114,12 @@ export class D1ServerStorage implements ServerStorage {
     for (const ref of refs) {
       const compiled = this.#tables?.get(ref.tbl);
       if (compiled === undefined) continue; // table no longer in the schema
-      const row = await this.#db
-        .prepare(selectRowScopesSql(compiled, 'sqlite'))
-        .bind(partition, ref.row_id)
-        .first<{ scopes: string }>();
+      const results = await this.#guardedBatch([
+        this.#db
+          .prepare(selectRowScopesSql(compiled, 'sqlite'))
+          .bind(partition, ref.row_id),
+      ]);
+      const row = d1BatchRows<{ scopes: string }>(results[1])[0] ?? null;
       if (row === null) continue;
       out.push({
         table: ref.tbl,
@@ -1719,10 +2267,14 @@ export class D1ServerStorage implements ServerStorage {
   ): Promise<
     { serverVersion: number; scopes: Record<string, string> } | undefined
   > {
-    const record = await this.#db
-      .prepare(selectRowScopesSql(this.table(table), 'sqlite'))
-      .bind(partition, rowId)
-      .first<{ server_version: number; scopes: string }>();
+    const results = await this.#guardedBatch([
+      this.#db
+        .prepare(selectRowScopesSql(this.table(table), 'sqlite'))
+        .bind(partition, rowId),
+    ]);
+    const record =
+      d1BatchRows<{ server_version: number; scopes: string }>(results[1])[0] ??
+      null;
     if (record === null) return undefined;
     return {
       serverVersion: record.server_version,

--- a/packages/server/src/postgres-storage.ts
+++ b/packages/server/src/postgres-storage.ts
@@ -52,10 +52,14 @@ import {
   commitWindowPageSql,
   deleteRowSql,
   dropTableDdl,
+  expectedIndexShapes,
   indexRowPageStatement,
+  indexReconciliationDdl,
+  indexesNeedReconciliation,
   layoutsOf,
   migratePayload,
   parseLayouts,
+  postgresScopeValueParam,
   retiredTableNames,
   rewritePlan,
   rewriteRowSql,
@@ -619,7 +623,7 @@ class PostgresTransaction implements StorageTransaction {
         this.#partition,
         query.table,
         firstVariable,
-        ...firstValues,
+        ...postgresScopeValueParam(firstValues),
         afterRowId,
         batchSize,
       ]);
@@ -867,6 +871,70 @@ class RollbackSignal extends Error {
   }
 }
 
+async function postgresDeclaredIndexState(
+  queryable: PgQueryable,
+  schema: CompiledSchema,
+): Promise<{
+  existingIndexes: ReadonlyMap<string, ReadonlySet<string>>;
+  reconciliationNeeded: boolean;
+}> {
+  const existingIndexes = new Map<string, ReadonlySet<string>>();
+  let reconciliationNeeded = false;
+  for (const table of schema.tables.values()) {
+    const expected = expectedIndexShapes(table);
+    if (expected.length === 0) continue;
+    const indexes = await queryable.query<{
+      index_name: string;
+      is_unique: boolean;
+      columns: string[];
+    }>(
+      `SELECT index_class.relname AS index_name,
+              index_meta.indisunique AS is_unique,
+              array_agg(attribute.attname ORDER BY key.ordinality) AS columns
+         FROM pg_catalog.pg_class AS table_class
+         JOIN pg_catalog.pg_namespace AS namespace
+           ON namespace.oid = table_class.relnamespace
+         JOIN pg_catalog.pg_index AS index_meta
+           ON index_meta.indrelid = table_class.oid
+         JOIN pg_catalog.pg_class AS index_class
+           ON index_class.oid = index_meta.indexrelid
+         CROSS JOIN LATERAL unnest(index_meta.indkey)
+           WITH ORDINALITY AS key(attnum, ordinality)
+         JOIN pg_catalog.pg_attribute AS attribute
+           ON attribute.attrelid = table_class.oid
+          AND attribute.attnum = key.attnum
+        WHERE namespace.nspname = current_schema()
+          AND table_class.relname = $1
+          AND NOT index_meta.indisprimary
+          AND NOT EXISTS (
+            SELECT 1
+              FROM pg_catalog.pg_constraint AS owning_constraint
+             WHERE owning_constraint.conindid = index_meta.indexrelid
+          )
+        GROUP BY index_class.relname, index_meta.indisunique`,
+      [table.name],
+    );
+    existingIndexes.set(
+      table.name,
+      new Set(indexes.rows.map((index) => index.index_name)),
+    );
+    const expectedNames = new Set(expected.map((index) => index.name));
+    const shapes = new Map<
+      string,
+      { readonly unique: boolean; readonly columns: readonly string[] }
+    >();
+    for (const index of indexes.rows) {
+      if (!expectedNames.has(index.index_name)) continue;
+      shapes.set(index.index_name, {
+        unique: index.is_unique,
+        columns: index.columns,
+      });
+    }
+    reconciliationNeeded ||= indexesNeedReconciliation(table, shapes);
+  }
+  return { existingIndexes, reconciliationNeeded };
+}
+
 export class PostgresServerStorage implements ServerStorage {
   readonly #exec: PgExecutor;
   /** Set by `ensureSchema`: app-table lookup for the relational row store. */
@@ -918,20 +986,68 @@ export class PostgresServerStorage implements ServerStorage {
         `stored schema version ${stored} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
       );
     }
-    if (stored === undefined || stored < schema.version) {
-      // Introspect existing app tables, apply the migration subset
-      // (CREATE TABLE / ADD COLUMN / rebuild indexes), then rewrite stored
-      // rows (payload re-encode for layout changes and/or projection
-      // backfill for flipped-on materialization) — all inside one
-      // transaction (Postgres DDL is transactional — a failed bump leaves
-      // no half-state).
-      const layouts = parseLayouts(
-        typeof marker.rows[0]?.layouts === 'string'
-          ? marker.rows[0].layouts
-          : undefined,
-      );
-      const retiredTables = retiredTableNames(schema, layouts);
+    if (
+      stored === schema.version &&
+      (await postgresDeclaredIndexState(this.#exec, schema))
+        .reconciliationNeeded
+    ) {
       await this.#exec.transaction(async (client) => {
+        await client.query(
+          'LOCK TABLE sync_schema_meta IN ACCESS EXCLUSIVE MODE',
+        );
+        const authoritative = await client.query<{ schema_version: unknown }>(
+          'SELECT schema_version FROM sync_schema_meta WHERE id=1',
+        );
+        const currentVersion =
+          authoritative.rows[0] === undefined
+            ? undefined
+            : asNumber(authoritative.rows[0].schema_version);
+        if (currentVersion !== undefined && currentVersion > schema.version) {
+          throw new Error(
+            `stored schema version ${currentVersion} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+          );
+        }
+        if (currentVersion !== schema.version) {
+          throw new Error(
+            'stored schema version changed during index reconciliation',
+          );
+        }
+        const current = await postgresDeclaredIndexState(client, schema);
+        if (current.reconciliationNeeded) {
+          for (const statement of indexReconciliationDdl(
+            schema,
+            current.existingIndexes,
+          )) {
+            await client.query(statement);
+          }
+        }
+      });
+    }
+    if (stored === undefined || stored < schema.version) {
+      await this.#exec.transaction(async (client) => {
+        await client.query(
+          'LOCK TABLE sync_schema_meta IN ACCESS EXCLUSIVE MODE',
+        );
+        const authoritative = await client.query<{
+          schema_version: unknown;
+          layouts: unknown;
+        }>('SELECT schema_version, layouts FROM sync_schema_meta WHERE id=1');
+        const currentVersion =
+          authoritative.rows[0] === undefined
+            ? undefined
+            : asNumber(authoritative.rows[0].schema_version);
+        if (currentVersion !== undefined && currentVersion > schema.version) {
+          throw new Error(
+            `stored schema version ${currentVersion} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+          );
+        }
+        if (currentVersion === schema.version) return;
+        const layouts = parseLayouts(
+          typeof authoritative.rows[0]?.layouts === 'string'
+            ? authoritative.rows[0].layouts
+            : undefined,
+        );
+        const retiredTables = retiredTableNames(schema, layouts);
         const existing = new Map<string, ReadonlySet<string>>();
         const existingIndexes = new Map<string, ReadonlySet<string>>();
         for (const table of schema.tables.values()) {
@@ -974,6 +1090,14 @@ export class PostgresServerStorage implements ServerStorage {
         }
         for (const tableName of retiredTables) {
           await client.query('DELETE FROM sync_row_scopes WHERE tbl=$1', [
+            tableName,
+          ]);
+          // Blob references go with the scope index. One left behind still
+          // answers the reference lookup the §5.9.2 sweep consults, so the
+          // bytes are never reclaimed, and it is skipped by the row lookup
+          // §5.9.5 authorizes downloads against, so every download is denied:
+          // the blob becomes undeletable and unreachable in the same move.
+          await client.query('DELETE FROM sync_blob_refs WHERE tbl=$1', [
             tableName,
           ]);
           await client.query(dropTableDdl(tableName));
@@ -1188,7 +1312,8 @@ export class PostgresServerStorage implements ServerStorage {
   async setHorizonSeq(partition: string, seq: number): Promise<void> {
     await this.#exec.query(
       `INSERT INTO sync_partitions(partition, horizon_seq) VALUES ($1,$2)
-       ON CONFLICT (partition) DO UPDATE SET horizon_seq=EXCLUDED.horizon_seq`,
+       ON CONFLICT (partition) DO UPDATE SET
+         horizon_seq=GREATEST(sync_partitions.horizon_seq, EXCLUDED.horizon_seq)`,
       [partition, seq],
     );
   }
@@ -1469,7 +1594,7 @@ export class PostgresServerStorage implements ServerStorage {
           partition,
           query.table,
           firstVariable,
-          ...firstValues,
+          ...postgresScopeValueParam(firstValues),
           afterSeq,
           query.throughSeq,
           batchSize,
@@ -1547,7 +1672,7 @@ export class PostgresServerStorage implements ServerStorage {
         partition,
         query.table,
         firstVariable,
-        ...firstValues,
+        ...postgresScopeValueParam(firstValues),
         afterRowId,
         batchSize,
       ]);
@@ -1615,9 +1740,9 @@ export class PostgresServerStorage implements ServerStorage {
        VALUES ($1,$2,$3,$4,$5,$6,$7)
        ON CONFLICT (partition, client_id) DO UPDATE
          SET actor_id=EXCLUDED.actor_id, wire_version=EXCLUDED.wire_version,
-             cursor=EXCLUDED.cursor,
+             cursor=GREATEST(sync_clients.cursor, EXCLUDED.cursor),
              subscriptions=EXCLUDED.subscriptions,
-             updated_at_ms=EXCLUDED.updated_at_ms`,
+             updated_at_ms=GREATEST(sync_clients.updated_at_ms, EXCLUDED.updated_at_ms)`,
       [
         partition,
         record.clientId,
@@ -1627,6 +1752,20 @@ export class PostgresServerStorage implements ServerStorage {
         JSON.stringify(record.subscriptions),
         record.updatedAtMs,
       ],
+    );
+  }
+
+  async updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void> {
+    await this.#exec.query(
+      `UPDATE sync_clients
+       SET cursor=GREATEST(cursor, $3), updated_at_ms=GREATEST(updated_at_ms, $4)
+       WHERE partition=$1 AND client_id=$2`,
+      [partition, clientId, cursor, updatedAtMs],
     );
   }
 

--- a/packages/server/src/prune.ts
+++ b/packages/server/src/prune.ts
@@ -53,12 +53,20 @@ export async function pruneCommitLog(options: PruneOptions): Promise<number> {
   const retainFloor = maxSeq - policy.minRetainedCommits;
   const target = Math.min(Math.max(cursorFloor, forcedSeq), retainFloor);
   const current = await storage.getHorizonSeq(partition);
-  const horizon = Math.max(current, Math.max(0, target));
-  let removedCommits = 0;
-  if (horizon > current) {
-    await storage.setHorizonSeq(partition, horizon);
-    removedCommits = await storage.pruneCommitsThrough(partition, horizon);
+  const proposedHorizon = Math.max(current, Math.max(0, target));
+  if (proposedHorizon > current) {
+    // This order is load-bearing for concurrent pulls. The storage update is
+    // monotonic, so concurrent prune passes cannot restore an older horizon.
+    // A reader may observe the new horizon before deletion, which safely
+    // overstates what is gone; it must never observe the old horizon after
+    // the log has been pruned.
+    await storage.setHorizonSeq(partition, proposedHorizon);
   }
+  // Re-read after the monotonic write so a concurrent higher winner governs
+  // this pass too. Deletion is idempotent and runs even when the horizon did
+  // not move, repairing a crash between an earlier horizon write and delete.
+  const horizon = await storage.getHorizonSeq(partition);
+  const removedCommits = await storage.pruneCommitsThrough(partition, horizon);
   const events = options.events;
   if (events !== undefined) {
     emitEvent(events, {

--- a/packages/server/src/pull.ts
+++ b/packages/server/src/pull.ts
@@ -14,6 +14,7 @@ import {
 } from '@syncular/core';
 import type { SyncRequestContext } from './context';
 import { clockOf, limitsOf } from './context';
+import { syncError } from './errors';
 import type { PullSegmentSummary } from './events';
 import type { CompiledSchema, CompiledTable } from './schema';
 import { scopeDigest } from './scopes';
@@ -543,6 +544,15 @@ export async function* subscriptionSection(
     throughSeq: maxSeq,
     limitChanges: limits.limitCommits + 1,
   });
+  // Pruning advances the horizon before deleting commits. Re-reading after
+  // the window query therefore detects any deletion that could have made the
+  // incremental result incomplete, before SUB_END lets the client persist it.
+  if (sub.cursor < (await ctx.storage.getHorizonSeq(ctx.partition))) {
+    throw syncError(
+      'sync.cursor_expired',
+      'the retention horizon advanced during the incremental pull (§4.6)',
+    );
+  }
   let delivered = 0;
   let deliveredCommits = 0;
   let lastDeliveredSeq = sub.cursor;

--- a/packages/server/src/realtime.ts
+++ b/packages/server/src/realtime.ts
@@ -307,6 +307,10 @@ export class RealtimeSession {
     const cursor = (parsed as { cursor?: unknown }).cursor;
     if (typeof cursor !== 'number' || !Number.isSafeInteger(cursor)) return;
     this.cursor = Math.max(this.cursor, cursor);
+    // The client may have caught up through another binding (§8.4). Its ack
+    // proves those commits no longer need socket notifications, so the next
+    // notification must be adjacent to the acknowledged cursor.
+    this.lastKnownSeq = Math.max(this.lastKnownSeq, this.cursor);
     if (this.cursor >= this.lastKnownSeq) this.wakePending = false;
     // §8.2: acks update the client cursor record without an HTTP pull.
     void this.#persistCursor();
@@ -626,16 +630,12 @@ export class RealtimeSession {
 
   async #persistCursor(): Promise<void> {
     try {
-      const record = await this.#storage.getClientRecord(
+      await this.#storage.updateClientCursor(
         this.partition,
         this.clientId,
+        this.cursor,
+        this.#clock(),
       );
-      if (record === undefined) return;
-      await this.#storage.putClientRecord(this.partition, {
-        ...record,
-        cursor: Math.max(record.cursor, this.cursor),
-        updatedAtMs: this.#clock(),
-      });
     } catch {
       // Cursor persistence is best-effort; the next pull repairs it.
     }
@@ -688,8 +688,9 @@ export class RealtimeSession {
     }
   }
 
-  /** Called by the hub for every applied commit, in commitSeq order. */
+  /** Called by the hub for every applied commit notification. */
   deliverCommit(commit: StoredCommit): void {
+    const contiguous = commit.commitSeq === this.lastKnownSeq + 1;
     this.lastKnownSeq = Math.max(this.lastKnownSeq, commit.commitSeq);
     const sections: Array<{
       registration: Registration;
@@ -715,6 +716,14 @@ export class RealtimeSession {
           }),
         );
       if (changes.length > 0) sections.push({ registration, changes });
+    }
+    if (!contiguous) {
+      // Pushes allocate commitSeq under the partition lock but notify after
+      // commit, so racing notifications may arrive out of order. A gap,
+      // duplicate, or regression cannot be a delta: the client would apply
+      // and acknowledge a cursor that does not prove the intervening log.
+      this.sendWake('catchup-required');
+      return;
     }
     if (sections.length === 0) return;
     if (this.#activeRound !== undefined) {
@@ -771,7 +780,7 @@ export class RealtimeSession {
     tagged[0] = REALTIME_TAG_DELTA;
     tagged.set(bytes, 1);
     this.#sendSafe(tagged);
-    this.cursor = commit.commitSeq;
+    this.cursor = Math.max(this.cursor, commit.commitSeq);
     const events = this.#events;
     if (events !== undefined) {
       emitEvent(events, {

--- a/packages/server/src/relational-rows.ts
+++ b/packages/server/src/relational-rows.ts
@@ -209,17 +209,74 @@ export function physicalIndexName(declaredName: string): string {
  * index-name uniqueness is the user's schema concern, as it is client-side.
  * Server-side the physical name carries the {@link SYNC_INDEX_PREFIX}
  * ownership marker.
+ *
+ * Every index leads with {@link SYNC_PARTITION_COLUMN}. One physical table
+ * holds every partition, so a declared `UNIQUE` over the app columns alone
+ * would reserve a value across every partition on the server, and a trusted
+ * index lookup would find its partition predicate outside the index. The
+ * declared name and the declared column order the client materializes are
+ * unchanged; the partition column is server-side only.
  */
 export function createIndexDdl(table: CompiledTable): string[] {
-  // User indexes name app columns — nothing to index without the projection.
-  if (!table.materialize) return [];
-  return table.indexes.map((index) => {
+  return expectedIndexShapes(table).map((index) => {
     const unique = index.unique ? 'UNIQUE ' : '';
     const columns = index.columns
       .map((column) => quoteIdent(column))
       .join(', ');
-    return `CREATE ${unique}INDEX IF NOT EXISTS ${quoteIdent(physicalIndexName(index.name))} ON ${quoteIdent(table.name)} (${columns})`;
+    return `CREATE ${unique}INDEX IF NOT EXISTS ${quoteIdent(index.name)} ON ${quoteIdent(table.name)} (${columns})`;
   });
+}
+
+/** The physical definition every declared server index must have. */
+export function expectedIndexShapes(table: CompiledTable): readonly {
+  readonly name: string;
+  readonly unique: boolean;
+  readonly columns: readonly string[];
+}[] {
+  if (!table.materialize) return [];
+  return table.indexes.map((index) => ({
+    name: physicalIndexName(index.name),
+    unique: index.unique === true,
+    columns: [SYNC_PARTITION_COLUMN, ...index.columns],
+  }));
+}
+
+/** True when a declared physical index is absent or has an obsolete shape. */
+export function indexesNeedReconciliation(
+  table: CompiledTable,
+  existing: ReadonlyMap<
+    string,
+    { readonly unique: boolean; readonly columns: readonly string[] }
+  >,
+): boolean {
+  return expectedIndexShapes(table).some((expected) => {
+    const actual = existing.get(expected.name);
+    return (
+      actual === undefined ||
+      actual.unique !== expected.unique ||
+      actual.columns.length !== expected.columns.length ||
+      actual.columns.some((column, index) => column !== expected.columns[index])
+    );
+  });
+}
+
+/** Rebuild only Syncular-owned declared indexes against an equal-version schema. */
+export function indexReconciliationDdl(
+  schema: CompiledSchema,
+  existingIndexesByTable: ReadonlyMap<string, ReadonlySet<string>>,
+): string[] {
+  const drops: string[] = [];
+  const creates: string[] = [];
+  for (const table of schema.tables.values()) {
+    const declared = new Set(table.indexes.map((index) => index.name));
+    for (const indexName of existingIndexesByTable.get(table.name) ?? []) {
+      if (indexName.startsWith(SYNC_INDEX_PREFIX) || declared.has(indexName)) {
+        drops.push(dropIndexDdl(indexName));
+      }
+    }
+    creates.push(...createIndexDdl(table));
+  }
+  return [...drops, ...creates];
 }
 
 /** Idempotent removal of one Syncular-owned relational projection index. */
@@ -366,6 +423,55 @@ export function indexRowPageStatement(
 }
 
 /**
+ * The `value` predicate of both candidate subqueries, the placeholder number
+ * the predicate stops at, and whether the predicate has to be driven from a
+ * `LATERAL` scan per value.
+ *
+ * On sqlite (and D1 through it) every value is its own placeholder, which is
+ * the shape those drivers accept.
+ *
+ * On postgres one value binds as a scalar, so the planner sees an equality on
+ * `value` and walks the covering index in candidate order. More than one
+ * cannot become an array qual on `value`: that column precedes the ordering
+ * column in both scope-index primary keys, so the planner aggregates and
+ * sorts the whole matched candidate set before the `LIMIT` applies, and by
+ * eight values it drops the index for a parallel sequential scan. Measured on
+ * 200k index rows over eight values: 28.955 ms and 1714 buffers for the array
+ * qual against 0.548 ms and 89 buffers for the lateral form.
+ *
+ * So the array is unnested and each value gets its own index range, bounded
+ * by the page `LIMIT`. That keeps the whole list in ONE bind, which is what
+ * removes the 65,535 bind-parameter ceiling.
+ */
+function scopeValuePredicate(
+  valueCount: number,
+  dialect: RelationalDialect,
+): { predicate: string; next: number; lateral: boolean } {
+  if (dialect === 'sqlite') {
+    const values: string[] = [];
+    for (let i = 0; i < valueCount; i++) values.push('?');
+    return {
+      predicate: `value IN (${values.join(',')})`,
+      next: 4 + valueCount,
+      lateral: false,
+    };
+  }
+  if (valueCount === 1)
+    return { predicate: 'value=$4', next: 5, lateral: false };
+  return { predicate: 'value=v.value', next: 5, lateral: true };
+}
+
+/**
+ * The `$4` bind of the postgres form: the value itself when there is one, and
+ * the whole list as one `text[]` when there is more than one. Returned as an
+ * array so a call site spreads it into its parameter list exactly where it
+ * spread the values before.
+ */
+export function postgresScopeValueParam(values: readonly string[]): unknown[] {
+  return values.length === 1 ? [values[0]] : [values];
+}
+
+/**
  * One-round-trip page scan for `scanRows`: candidates from the inverted
  * scope index (ordered + LIMITed at the covering `sync_row_scopes` PK —
  * exactly the old candidate query, so the index-first posture is unchanged)
@@ -380,10 +486,11 @@ export function indexRowPageStatement(
  * disappearing from the page.
  *
  * Bind order:
- *   - postgres: [partition, tbl, var, ...values, afterRowId, limit]
- *     (the join reuses `$1` for the partition);
+ *   - postgres: [partition, tbl, var, values, afterRowId, limit] (the join
+ *     reuses `$1` for the partition; `values` is one bind carrying the
+ *     single value or the whole list, see {@link postgresScopeValueParam});
  *   - sqlite:   [partition, tbl, var, ...values, afterRowId, limit,
- *     partition] (positional `?` — the partition binds again for the join).
+ *     partition] (positional `?`: the partition binds again for the join).
  */
 export function scanRowPageSql(
   table: CompiledTable,
@@ -391,16 +498,24 @@ export function scanRowPageSql(
   dialect: RelationalDialect,
 ): string {
   const p = (n: number) => (dialect === 'sqlite' ? '?' : `$${n}`);
-  const values: string[] = [];
-  for (let i = 0; i < valueCount; i++) values.push(p(4 + i));
-  const after = p(4 + valueCount);
-  const limit = p(5 + valueCount);
+  const { predicate, next, lateral } = scopeValuePredicate(valueCount, dialect);
+  const after = p(next);
+  const limit = p(next + 1);
   const joinPartition = dialect === 'sqlite' ? '?' : '$1';
+  const where = `WHERE partition=${p(1)} AND tbl=${p(2)} AND var=${p(3)} AND ${predicate}
+           AND row_id>${after}
+         ORDER BY row_id LIMIT ${limit}`;
+  const candidates = lateral
+    ? `SELECT DISTINCT row_id FROM (
+       SELECT s.row_id FROM unnest($4::text[]) AS v(value)
+         CROSS JOIN LATERAL (
+           SELECT row_id FROM sync_row_scopes
+         ${where}) s) u
+     ORDER BY row_id LIMIT ${limit}`
+    : `SELECT DISTINCT row_id FROM sync_row_scopes
+       ${where}`;
   return `SELECT c.row_id AS row_id, r.${quoteIdent(SYNC_VERSION_COLUMN)} AS server_version, r.${quoteIdent(SYNC_SCOPES_COLUMN)} AS scopes, r.${quoteIdent(SYNC_PAYLOAD_COLUMN)} AS payload
-     FROM (SELECT DISTINCT row_id FROM sync_row_scopes
-       WHERE partition=${p(1)} AND tbl=${p(2)} AND var=${p(3)} AND value IN (${values.join(',')})
-         AND row_id>${after}
-       ORDER BY row_id LIMIT ${limit}) c
+     FROM (${candidates}) c
      LEFT JOIN ${quoteIdent(table.name)} r
        ON r.${quoteIdent(SYNC_PARTITION_COLUMN)}=${joinPartition} AND r.${quoteIdent(SYNC_ROW_ID_COLUMN)}=c.row_id
      ORDER BY c.row_id`;
@@ -428,10 +543,11 @@ export function scanRowPageSql(
  * rows and verifies the full multi-variable scope match in JS.
  *
  * Bind order:
- *   - postgres: [partition, tbl, var, ...values, afterSeq, throughSeq,
- *     limit] (the joins reuse `$1`/`$2`);
+ *   - postgres: [partition, tbl, var, values, afterSeq, throughSeq, limit]
+ *     (the joins reuse `$1`/`$2`; `values` is one bind carrying the single
+ *     value or the whole list, see {@link postgresScopeValueParam});
  *   - sqlite:   [partition, tbl, var, ...values, afterSeq, throughSeq,
- *     limit, partition, partition, tbl] (positional `?` — partition/tbl bind
+ *     limit, partition, partition, tbl] (positional `?`: partition/tbl bind
  *     again for the joins).
  */
 export function commitWindowPageSql(
@@ -439,19 +555,27 @@ export function commitWindowPageSql(
   dialect: RelationalDialect,
 ): string {
   const p = (n: number) => (dialect === 'sqlite' ? '?' : `$${n}`);
-  const values: string[] = [];
-  for (let i = 0; i < valueCount; i++) values.push(p(4 + i));
-  const after = p(4 + valueCount);
-  const through = p(5 + valueCount);
-  const limit = p(6 + valueCount);
+  const { predicate, next, lateral } = scopeValuePredicate(valueCount, dialect);
+  const after = p(next);
+  const through = p(next + 1);
+  const limit = p(next + 2);
   const joinPartition = dialect === 'sqlite' ? '?' : '$1';
   const joinTbl = dialect === 'sqlite' ? '?' : '$2';
+  const where = `WHERE partition=${p(1)} AND tbl=${p(2)} AND var=${p(3)} AND ${predicate}
+         AND commit_seq>${after} AND commit_seq<=${through}
+       ORDER BY commit_seq LIMIT ${limit}`;
+  const candidates = lateral
+    ? `SELECT DISTINCT commit_seq FROM (
+       SELECT s.commit_seq FROM unnest($4::text[]) AS v(value)
+         CROSS JOIN LATERAL (
+           SELECT commit_seq FROM sync_change_scopes
+       ${where}) s) u
+     ORDER BY commit_seq LIMIT ${limit}`
+    : `SELECT DISTINCT commit_seq FROM sync_change_scopes
+       ${where}`;
   return `SELECT c.commit_seq AS commit_seq, m.actor_id AS actor_id, m.created_at_ms AS created_at_ms,
        ch.tbl AS tbl, ch.row_id AS row_id, ch.op AS op, ch.row_version AS row_version, ch.scopes AS scopes, ch.payload AS payload
-     FROM (SELECT DISTINCT commit_seq FROM sync_change_scopes
-       WHERE partition=${p(1)} AND tbl=${p(2)} AND var=${p(3)} AND value IN (${values.join(',')})
-         AND commit_seq>${after} AND commit_seq<=${through}
-       ORDER BY commit_seq LIMIT ${limit}) c
+     FROM (${candidates}) c
      LEFT JOIN sync_commits m
        ON m.partition=${joinPartition} AND m.commit_seq=c.commit_seq
      LEFT JOIN sync_changes ch
@@ -478,10 +602,10 @@ export function deleteRowSql(
 }
 
 /**
- * The schema-version marker table gates DDL work. `ensureSchema` compares the
- * stored version and skips
- * all introspection/DDL when it matches — one cheap read per storage
- * instance (relevant for D1's per-request instantiation).
+ * The schema-version marker gates app-table migration and payload rewrites.
+ * An equal version skips that work, but `ensureSchema` still verifies tables
+ * with declared physical indexes because the marker does not record their
+ * server-only partition column. A current index shape issues no DDL.
  *
  * `layouts` persists each table's column layout (name/type/nullable, the
  * exact inputs the row codec's byte layout depends on) as of the LAST
@@ -726,12 +850,10 @@ export function schemaDdl(
   existingIndexesByTable: ReadonlyMap<string, ReadonlySet<string>> = new Map(),
 ): string[] {
   const drops: string[] = [];
-  const creates: string[] = [];
+  const indexes: string[] = [];
   for (const table of schema.tables.values()) {
     const existing = existingColumnsByTable.get(table.name);
-    if (existing === undefined) {
-      creates.push(createTableDdl(table, dialect));
-    } else {
+    if (existing !== undefined) {
       const declared = new Set(table.indexes.map((index) => index.name));
       for (const indexName of existingIndexesByTable.get(table.name) ?? []) {
         if (
@@ -741,12 +863,33 @@ export function schemaDdl(
           drops.push(dropIndexDdl(indexName));
         }
       }
-      creates.push(...addColumnDdl(table, existing, dialect));
     }
-    creates.push(...createIndexDdl(table));
+    indexes.push(...createIndexDdl(table));
   }
   // Every drop precedes every create: an index name moving between tables in
   // one bump must release the global (SQLite) index namespace before the
   // receiving table re-creates it.
-  return [...drops, ...creates];
+  return [
+    ...drops,
+    ...schemaProjectionDdl(schema, existingColumnsByTable, dialect),
+    ...indexes,
+  ];
+}
+
+/** CREATE TABLE and ADD COLUMN statements without secondary-index changes. */
+export function schemaProjectionDdl(
+  schema: CompiledSchema,
+  existingColumnsByTable: ReadonlyMap<string, ReadonlySet<string>>,
+  dialect: RelationalDialect,
+): string[] {
+  const statements: string[] = [];
+  for (const table of schema.tables.values()) {
+    const existing = existingColumnsByTable.get(table.name);
+    if (existing === undefined) {
+      statements.push(createTableDdl(table, dialect));
+    } else {
+      statements.push(...addColumnDdl(table, existing, dialect));
+    }
+  }
+  return statements;
 }

--- a/packages/server/src/sqlite-storage.ts
+++ b/packages/server/src/sqlite-storage.ts
@@ -15,7 +15,10 @@ import {
   commitWindowPageSql,
   deleteRowSql,
   dropTableDdl,
+  expectedIndexShapes,
   indexRowPageStatement,
+  indexReconciliationDdl,
+  indexesNeedReconciliation,
   layoutsOf,
   migratePayload,
   parseLayouts,
@@ -382,6 +385,48 @@ class SqliteTransaction implements StorageTransaction {
   }
 }
 
+function sqliteDeclaredIndexState(
+  db: SqliteDatabase,
+  schema: CompiledSchema,
+): {
+  existingIndexes: ReadonlyMap<string, ReadonlySet<string>>;
+  reconciliationNeeded: boolean;
+} {
+  const existingIndexes = new Map<string, ReadonlySet<string>>();
+  let reconciliationNeeded = false;
+  for (const table of schema.tables.values()) {
+    const expected = expectedIndexShapes(table);
+    if (expected.length === 0) continue;
+    const escapedTableName = table.name.replaceAll('"', '""');
+    const indexes = db
+      .query<{ name: string; unique: number; origin: string }, []>(
+        `PRAGMA index_list("${escapedTableName}")`,
+      )
+      .all()
+      .filter((index) => index.origin === 'c');
+    existingIndexes.set(
+      table.name,
+      new Set(indexes.map((index) => index.name)),
+    );
+    const expectedNames = new Set(expected.map((index) => index.name));
+    const shapes = new Map<
+      string,
+      { readonly unique: boolean; readonly columns: readonly string[] }
+    >();
+    for (const index of indexes) {
+      if (!expectedNames.has(index.name)) continue;
+      const escapedIndexName = index.name.replaceAll('"', '""');
+      const columns = db
+        .query<{ name: string }, []>(`PRAGMA index_info("${escapedIndexName}")`)
+        .all()
+        .map((column) => column.name);
+      shapes.set(index.name, { unique: index.unique === 1, columns });
+    }
+    reconciliationNeeded ||= indexesNeedReconciliation(table, shapes);
+  }
+  return { existingIndexes, reconciliationNeeded };
+}
+
 export class SqliteServerStorage implements ServerStorage {
   readonly db: SqliteDatabase;
   /** One SQLite connection can own only one transaction at a time. */
@@ -445,64 +490,123 @@ export class SqliteServerStorage implements ServerStorage {
         `stored schema version ${marker.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
       );
     }
-    if (marker === null || marker.schema_version < schema.version) {
-      // Introspect existing app tables, then apply the migration subset
-      // (CREATE TABLE / ADD COLUMN / rebuild indexes) to reach `schema`, then
-      // rewrite stored rows (payload re-encode for layout changes, and/or
-      // projection backfill for flipped-on materialization). One
-      // transaction: a failed bump leaves no half-state.
-      const layouts = parseLayouts(marker?.layouts);
-      const retiredTables = retiredTableNames(schema, layouts);
-      const existing = new Map<string, ReadonlySet<string>>();
-      const existingIndexes = new Map<string, ReadonlySet<string>>();
-      for (const table of schema.tables.values()) {
-        const escapedTableName = table.name.replaceAll('"', '""');
-        const columns = this.db
-          .query<{ name: string }, []>(
-            `PRAGMA table_info("${escapedTableName}")`,
-          )
-          .all();
-        if (columns.length > 0) {
-          existing.set(table.name, new Set(columns.map((c) => c.name)));
-          const indexes = this.db
-            .query<{ name: string; origin: string }, []>(
-              `PRAGMA index_list("${escapedTableName}")`,
-            )
-            .all()
-            .filter((index) => index.origin === 'c');
-          existingIndexes.set(
-            table.name,
-            new Set(indexes.map((index) => index.name)),
-          );
-        }
-      }
+    if (
+      marker?.schema_version === schema.version &&
+      sqliteDeclaredIndexState(this.db, schema).reconciliationNeeded
+    ) {
       this.db.exec('BEGIN IMMEDIATE');
       try {
-        for (const tableName of retiredTables) {
-          this.db
-            .query('DELETE FROM sync_row_scopes WHERE tbl=?')
-            .run(tableName);
-          this.db.exec(dropTableDdl(tableName));
-        }
-        for (const statement of schemaDdl(
-          schema,
-          existing,
-          'sqlite',
-          existingIndexes,
-        )) {
-          this.db.exec(statement);
-        }
-        for (const table of schema.tables.values()) {
-          const oldLayout = layouts[table.name];
-          const plan = rewritePlan(table, oldLayout, existing.get(table.name));
-          if (!plan.migrate && !plan.backfill) continue;
-          this.#rewriteRows(table, plan.migrate ? oldLayout : undefined);
-        }
-        this.db
-          .query(
-            'INSERT INTO sync_schema_meta(id, schema_version, layouts) VALUES (1, ?, ?) ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, layouts=excluded.layouts',
+        const authoritative = this.db
+          .query<{ schema_version: number }, []>(
+            'SELECT schema_version FROM sync_schema_meta WHERE id=1',
           )
-          .run(schema.version, layoutsOf(schema));
+          .get();
+        if (
+          authoritative !== null &&
+          authoritative.schema_version > schema.version
+        ) {
+          throw new Error(
+            `stored schema version ${authoritative.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+          );
+        }
+        if (authoritative?.schema_version !== schema.version) {
+          throw new Error(
+            'stored schema version changed during index reconciliation',
+          );
+        }
+        const current = sqliteDeclaredIndexState(this.db, schema);
+        if (current.reconciliationNeeded) {
+          for (const statement of indexReconciliationDdl(
+            schema,
+            current.existingIndexes,
+          )) {
+            this.db.exec(statement);
+          }
+        }
+        this.db.exec('COMMIT');
+      } catch (error) {
+        this.db.exec('ROLLBACK');
+        throw error;
+      }
+    }
+    if (marker === null || marker.schema_version < schema.version) {
+      this.db.exec('BEGIN IMMEDIATE');
+      try {
+        const authoritative = this.db
+          .query<{ schema_version: number; layouts: string }, []>(
+            'SELECT schema_version, layouts FROM sync_schema_meta WHERE id=1',
+          )
+          .get();
+        if (
+          authoritative !== null &&
+          authoritative.schema_version > schema.version
+        ) {
+          throw new Error(
+            `stored schema version ${authoritative.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
+          );
+        }
+        if (authoritative?.schema_version !== schema.version) {
+          const layouts = parseLayouts(authoritative?.layouts);
+          const retiredTables = retiredTableNames(schema, layouts);
+          const existing = new Map<string, ReadonlySet<string>>();
+          const existingIndexes = new Map<string, ReadonlySet<string>>();
+          for (const table of schema.tables.values()) {
+            const escapedTableName = table.name.replaceAll('"', '""');
+            const columns = this.db
+              .query<{ name: string }, []>(
+                `PRAGMA table_info("${escapedTableName}")`,
+              )
+              .all();
+            if (columns.length > 0) {
+              existing.set(table.name, new Set(columns.map((c) => c.name)));
+              const indexes = this.db
+                .query<{ name: string; origin: string }, []>(
+                  `PRAGMA index_list("${escapedTableName}")`,
+                )
+                .all()
+                .filter((index) => index.origin === 'c');
+              existingIndexes.set(
+                table.name,
+                new Set(indexes.map((index) => index.name)),
+              );
+            }
+          }
+          for (const tableName of retiredTables) {
+            this.db
+              .query('DELETE FROM sync_row_scopes WHERE tbl=?')
+              .run(tableName);
+            // With the scope index: a blob reference that outlives its table is
+            // both unreclaimable by the §5.9.2 sweep and undownloadable through
+            // the §5.9.5 row lookup.
+            this.db
+              .query('DELETE FROM sync_blob_refs WHERE tbl=?')
+              .run(tableName);
+            this.db.exec(dropTableDdl(tableName));
+          }
+          for (const statement of schemaDdl(
+            schema,
+            existing,
+            'sqlite',
+            existingIndexes,
+          )) {
+            this.db.exec(statement);
+          }
+          for (const table of schema.tables.values()) {
+            const oldLayout = layouts[table.name];
+            const plan = rewritePlan(
+              table,
+              oldLayout,
+              existing.get(table.name),
+            );
+            if (!plan.migrate && !plan.backfill) continue;
+            this.#rewriteRows(table, plan.migrate ? oldLayout : undefined);
+          }
+          this.db
+            .query(
+              'INSERT INTO sync_schema_meta(id, schema_version, layouts) VALUES (1, ?, ?) ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, layouts=excluded.layouts',
+            )
+            .run(schema.version, layoutsOf(schema));
+        }
         this.db.exec('COMMIT');
       } catch (error) {
         this.db.exec('ROLLBACK');
@@ -777,7 +881,9 @@ export class SqliteServerStorage implements ServerStorage {
       .query('INSERT OR IGNORE INTO sync_partitions(partition) VALUES (?)')
       .run(partition);
     this.db
-      .query('UPDATE sync_partitions SET horizon_seq=? WHERE partition=?')
+      .query(
+        'UPDATE sync_partitions SET horizon_seq=MAX(horizon_seq, ?) WHERE partition=?',
+      )
       .run(seq, partition);
   }
 
@@ -1213,7 +1319,14 @@ export class SqliteServerStorage implements ServerStorage {
   ): Promise<void> {
     this.db
       .query(
-        'INSERT OR REPLACE INTO sync_clients(partition, client_id, actor_id, wire_version, cursor, subscriptions, updated_at_ms) VALUES (?,?,?,?,?,?,?)',
+        `INSERT INTO sync_clients(partition, client_id, actor_id, wire_version, cursor, subscriptions, updated_at_ms)
+         VALUES (?,?,?,?,?,?,?)
+         ON CONFLICT(partition, client_id) DO UPDATE SET
+           actor_id=excluded.actor_id,
+           wire_version=excluded.wire_version,
+           cursor=MAX(sync_clients.cursor, excluded.cursor),
+           subscriptions=excluded.subscriptions,
+           updated_at_ms=MAX(sync_clients.updated_at_ms, excluded.updated_at_ms)`,
       )
       .run(
         partition,
@@ -1224,6 +1337,21 @@ export class SqliteServerStorage implements ServerStorage {
         JSON.stringify(record.subscriptions),
         record.updatedAtMs,
       );
+  }
+
+  async updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void> {
+    this.db
+      .query(
+        `UPDATE sync_clients
+         SET cursor=MAX(cursor, ?), updated_at_ms=MAX(updated_at_ms, ?)
+         WHERE partition=? AND client_id=?`,
+      )
+      .run(cursor, updatedAtMs, partition, clientId);
   }
 
   async listClientCursors(partition: string): Promise<ClientCursorInfo[]> {

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -426,6 +426,7 @@ export interface ServerStorage {
 
   getMaxCommitSeq(partition: string): Promise<number>;
   getHorizonSeq(partition: string): Promise<number>;
+  /** Advances the retention horizon monotonically; lower values are ignored. */
   setHorizonSeq(partition: string, seq: number): Promise<void>;
   /**
    * Deletes commits with `commitSeq <= seq` (log, changes, scope index).
@@ -541,6 +542,13 @@ export interface ServerStorage {
     clientId: string,
   ): Promise<ClientRecord | undefined>;
   putClientRecord(partition: string, record: ClientRecord): Promise<void>;
+  /** Atomically advances an existing client's cursor and update timestamp. */
+  updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void>;
   /** Cursor records feeding the §4.6 retention watermark. */
   listClientCursors(partition: string): Promise<ClientCursorInfo[]>;
 

--- a/packages/server/test/events.test.ts
+++ b/packages/server/test/events.test.ts
@@ -402,6 +402,8 @@ function wrapStorage(
     scanRows: (p, q) => storage.scanRows(p, q),
     getClientRecord: (p, c) => storage.getClientRecord(p, c),
     putClientRecord: (p, r) => storage.putClientRecord(p, r),
+    updateClientCursor: (p, c, cursor, updatedAtMs) =>
+      storage.updateClientCursor(p, c, cursor, updatedAtMs),
     listClientCursors: (p) => storage.listClientCursors(p),
   };
 }

--- a/packages/server/test/horizon.test.ts
+++ b/packages/server/test/horizon.test.ts
@@ -3,10 +3,16 @@
  * (SPEC.md §4.6).
  */
 import { describe, expect, test } from 'bun:test';
-import { pruneCommitLog } from '@syncular/server';
+import { decodeMessage } from '@syncular/core';
+import {
+  createSyncResponseStream,
+  pruneCommitLog,
+  type PruneCompletedEvent,
+} from '@syncular/server';
 import {
   makeContext,
   pullHeader,
+  requestBytes,
   section,
   seedTask,
   subFrame,
@@ -58,6 +64,98 @@ describe('cursor behind the horizon (§4.6)', () => {
     expect(s.start.bootstrap).toBe(true);
     expect(s.end.nextCursor).toBe(3);
   });
+
+  test('a prune that lands during an incremental section expires it before SUB_END', async () => {
+    const t = makeContext();
+    for (let i = 1; i <= 4; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
+
+    const readCommitWindow = t.storage.readCommitWindow.bind(t.storage);
+    Object.assign(t.storage, {
+      readCommitWindow: async (
+        ...args: Parameters<typeof readCommitWindow>
+      ) => {
+        // This hook runs after any check before the storage call and before
+        // the real query. A post-read check is the only placement that sees
+        // the truncated result and the advanced horizon together.
+        expect(
+          await pruneCommitLog({
+            storage: t.storage,
+            partition: 'part-1',
+            nowMs: t.now.ms + 1,
+            retention: { activeWindowMs: 0, minRetainedCommits: 1 },
+          }),
+        ).toBe(3);
+        return readCommitWindow(...args);
+      },
+    });
+
+    const stream = await createSyncResponseStream(
+      requestBytes([
+        pullHeader(),
+        subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+      ]),
+      t.ctx,
+    );
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+      total += chunk.length;
+    }
+    const responseBytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      responseBytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const response = decodeMessage(responseBytes);
+
+    expect(response.frames.map((frame) => frame.type)).toEqual([
+      'RESP_HEADER',
+      'SUB_START',
+      'ERROR',
+    ]);
+    expect(response.frames.find((frame) => frame.type === 'ERROR')?.code).toBe(
+      'sync.cursor_expired',
+    );
+    expect(response.frames.some((frame) => frame.type === 'SUB_END')).toBe(
+      false,
+    );
+    expect(
+      (await t.storage.getClientRecord('part-1', 'client-1'))?.cursor,
+    ).toBe(-1);
+  });
+
+  test('a horizon that advances exactly to the incremental cursor remains serviceable', async () => {
+    const t = makeContext();
+    for (let i = 1; i <= 4; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
+
+    const readCommitWindow = t.storage.readCommitWindow.bind(t.storage);
+    Object.assign(t.storage, {
+      readCommitWindow: async (
+        ...args: Parameters<typeof readCommitWindow>
+      ) => {
+        expect(
+          await pruneCommitLog({
+            storage: t.storage,
+            partition: 'part-1',
+            nowMs: t.now.ms + 1,
+            retention: { activeWindowMs: 0, minRetainedCommits: 1 },
+          }),
+        ).toBe(3);
+        return readCommitWindow(...args);
+      },
+    });
+
+    const message = await sync(t, [
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 3),
+    ]);
+    const s = section(message, 's1');
+    expect(s.start.status).toBe('active');
+    expect(s.body.filter((frame) => frame.type === 'COMMIT')).toHaveLength(1);
+    expect(s.end.nextCursor).toBe(4);
+  });
 });
 
 describe('pruneCommitLog retention floors (§4.6)', () => {
@@ -101,6 +199,132 @@ describe('pruneCommitLog retention floors (§4.6)', () => {
     expect(horizon).toBe(2); // 5 - 3
   });
 
+  test('advances the horizon before deleting retained history', async () => {
+    const t = makeContext();
+    for (let i = 1; i <= 4; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
+    const record = await t.storage.getClientRecord('part-1', 'client-1');
+    if (record === undefined) throw new Error('expected client record');
+    await t.storage.putClientRecord('part-1', {
+      ...record,
+      cursor: 4,
+      updatedAtMs: t.now.ms,
+    });
+
+    let deleteObserved = false;
+    const pruneCommitsThrough = t.storage.pruneCommitsThrough.bind(t.storage);
+    Object.assign(t.storage, {
+      pruneCommitsThrough: async (
+        ...args: Parameters<typeof pruneCommitsThrough>
+      ) => {
+        expect(await t.storage.getHorizonSeq(args[0])).toBe(args[1]);
+        deleteObserved = true;
+        return pruneCommitsThrough(...args);
+      },
+    });
+
+    expect(
+      await pruneCommitLog({
+        storage: t.storage,
+        partition: 'part-1',
+        nowMs: t.now.ms,
+        retention: { minRetainedCommits: 1 },
+      }),
+    ).toBe(3);
+    expect(deleteObserved).toBe(true);
+  });
+
+  test('repairs deletion after a crash left the horizon pre-advanced', async () => {
+    const t = makeContext();
+    for (let i = 1; i <= 5; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
+
+    // This is the durable state left by a crash between the required
+    // horizon-first write and the idempotent commit deletion.
+    await t.storage.setHorizonSeq('part-1', 3);
+    expect(
+      await t.storage.readCommitWindow('part-1', {
+        table: 'tasks',
+        scopeFilter: { project_id: ['p1'] },
+        afterSeq: 0,
+        throughSeq: 5,
+        limitChanges: 10,
+      }),
+    ).toHaveLength(5);
+
+    expect(
+      await pruneCommitLog({
+        storage: t.storage,
+        partition: 'part-1',
+        nowMs: t.now.ms,
+        retention: { minRetainedCommits: 2 },
+      }),
+    ).toBe(3);
+    expect(
+      (
+        await t.storage.readCommitWindow('part-1', {
+          table: 'tasks',
+          scopeFilter: { project_id: ['p1'] },
+          afterSeq: 0,
+          throughSeq: 5,
+          limitChanges: 10,
+        })
+      ).map((commit) => commit.commitSeq),
+    ).toEqual([4, 5]);
+  });
+
+  test('returns and reports a concurrently advanced horizon', async () => {
+    const t = makeContext();
+    for (let i = 1; i <= 5; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
+    const record = await t.storage.getClientRecord('part-1', 'client-1');
+    if (record === undefined) throw new Error('expected client record');
+    await t.storage.putClientRecord('part-1', {
+      ...record,
+      cursor: 2,
+      updatedAtMs: t.now.ms,
+    });
+
+    const setHorizonSeq = t.storage.setHorizonSeq.bind(t.storage);
+    Object.assign(t.storage, {
+      setHorizonSeq: async (
+        ...args: Parameters<typeof setHorizonSeq>
+      ): Promise<void> => {
+        await setHorizonSeq(args[0], 4);
+        await setHorizonSeq(...args);
+      },
+    });
+    let completed: PruneCompletedEvent | undefined;
+
+    expect(
+      await pruneCommitLog({
+        storage: t.storage,
+        partition: 'part-1',
+        nowMs: t.now.ms,
+        retention: { minRetainedCommits: 1 },
+        events: {
+          emit(event) {
+            if (event.type === 'prune.completed') completed = event;
+          },
+        },
+      }),
+    ).toBe(4);
+    expect(completed).toMatchObject({
+      previousHorizonSeq: 0,
+      horizonSeq: 4,
+      advanced: true,
+      removedCommits: 4,
+    });
+    expect(
+      (
+        await t.storage.readCommitWindow('part-1', {
+          table: 'tasks',
+          scopeFilter: { project_id: ['p1'] },
+          afterSeq: 0,
+          throughSeq: 5,
+          limitChanges: 10,
+        })
+      ).map((commit) => commit.commitSeq),
+    ).toEqual([5]);
+  });
+
   test('inactive cursors do not hold retention; age force applies', async () => {
     const t = makeContext();
     for (let i = 1; i <= 5; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
@@ -109,8 +333,12 @@ describe('pruneCommitLog retention floors (§4.6)', () => {
     await t.storage.putClientRecord('part-1', {
       ...record,
       cursor: 1,
-      updatedAtMs: t.now.ms - 100 * 24 * 60 * 60 * 1000, // long inactive
+      updatedAtMs: t.now.ms,
     });
+    // Full client records preserve the newest activity timestamp, so make
+    // the client inactive by advancing the host clock instead of attempting
+    // to backdate its record.
+    t.now.ms += 100 * 24 * 60 * 60 * 1000;
     const horizon = await pruneCommitLog({
       storage: t.storage,
       partition: 'part-1',

--- a/packages/server/test/realtime.test.ts
+++ b/packages/server/test/realtime.test.ts
@@ -6,15 +6,24 @@ import { describe, expect, test } from 'bun:test';
 import {
   type CommitFrame,
   decodeMessage,
+  encodeMessage,
   parseRealtimeServerEvent,
+  REALTIME_TAG_ROUND,
   type ScopeMap,
   type SubStartFrame,
 } from '@syncular/core';
-import { createRealtimeHub, type RealtimeHub } from '@syncular/server';
+import {
+  type ClientRecord,
+  createRealtimeHub,
+  type RealtimeHub,
+  type ServerStorage,
+  type StoredCommit,
+} from '@syncular/server';
 import {
   makeContext,
   pullHeader,
   pushCommit,
+  requestBytes,
   subFrame,
   sync,
   type TestContext,
@@ -53,6 +62,55 @@ function makeHub(t: TestContext, maxDeltaBytes?: number): RealtimeHub {
   // Wire the hub into the push path.
   Object.assign(t.ctx, { realtime: hub });
   return hub;
+}
+
+function taggedRound(bytes: Uint8Array): Uint8Array {
+  const tagged = new Uint8Array(bytes.length + 1);
+  tagged[0] = REALTIME_TAG_ROUND;
+  tagged.set(bytes, 1);
+  return tagged;
+}
+
+function observeCursorPersistence(
+  storage: ServerStorage,
+  expectedCursor: number,
+): { storage: ServerStorage; persisted: Promise<void> } {
+  let resolve!: () => void;
+  const persisted = new Promise<void>((done) => {
+    resolve = done;
+  });
+  let observed = false;
+  const markObserved = (): void => {
+    if (observed) return;
+    observed = true;
+    resolve();
+  };
+
+  return {
+    storage: new Proxy(storage, {
+      get(target, property) {
+        if (property === 'updateClientCursor') {
+          return async (...args: [string, string, number, number]) => {
+            const update = Reflect.get(target, property, target);
+            if (typeof update !== 'function') {
+              throw new Error('storage does not implement updateClientCursor');
+            }
+            await Reflect.apply(update, target, args);
+            if (args[2] === expectedCursor) markObserved();
+          };
+        }
+        if (property === 'putClientRecord') {
+          return async (partition: string, record: ClientRecord) => {
+            await target.putClientRecord(partition, record);
+            if (record.cursor === expectedCursor) markObserved();
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }),
+    persisted,
+  };
 }
 
 async function waitFor(check: () => Promise<boolean>): Promise<void> {
@@ -125,6 +183,40 @@ describe('handshake (§8.1)', () => {
       }),
     ).rejects.toMatchObject({ code: 'sync.invalid_client_id' });
   });
+
+  test('reserved command IDs touch the registry while exact near misses connect', async () => {
+    const t = makeContext();
+    const hub = makeHub(t);
+
+    await expect(
+      hub.connect({
+        partition: 'reserved-connect',
+        actorId: 'actor-1',
+        clientId: '["remote-command","actor-1","job-1"]',
+        send: () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'sync.invalid_client_id' });
+
+    expect(
+      typeof (await t.storage.listPartitionRegistry()).find(
+        (entry) => entry.partition === 'reserved-connect',
+      )?.logEpoch,
+    ).toBe('string');
+
+    for (const clientId of [
+      '["remote-command"]',
+      '["remote-commandx","actor-1"]',
+    ]) {
+      await expect(
+        hub.connect({
+          partition: 'reserved-connect',
+          actorId: 'actor-1',
+          clientId,
+          send: () => {},
+        }),
+      ).resolves.toBeDefined();
+    }
+  });
 });
 
 describe('delta delivery (§8.2)', () => {
@@ -171,6 +263,184 @@ describe('delta delivery (§8.2)', () => {
     expect(end?.type === 'SUB_END' && end.nextCursor).toBe(
       commit?.commitSeq ?? -1,
     );
+  });
+
+  test('out-of-order commit notifications wake before sending a gap delta', async () => {
+    const t = makeContext();
+    await sync(t, [
+      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+    ]);
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+    expect(session.cursor).toBe(1);
+    expect(session.lastKnownSeq).toBe(1);
+
+    const captured: StoredCommit[] = [];
+    Object.assign(t.ctx, {
+      realtime: {
+        notifyCommit: (_partition: string, commit: StoredCommit) => {
+          captured.push(commit);
+        },
+      },
+    });
+    await sync(
+      t,
+      [pushCommit('c2', [upsert('tasks', 't2', taskRow('t2', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    await sync(
+      t,
+      [pushCommit('c3', [upsert('tasks', 't3', taskRow('t3', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    expect(captured.map((commit) => commit.commitSeq)).toEqual([2, 3]);
+
+    await hub.notifyCommit('part-1', captured[1]!);
+    await hub.notifyCommit('part-1', captured[0]!);
+
+    expect(wire.binaries).toHaveLength(0);
+    const wakes = wire.texts.slice(1).map((text) => {
+      const parsed = parseRealtimeServerEvent(text);
+      if (!parsed.known || parsed.event.event !== 'sync') {
+        throw new Error('expected catch-up wake');
+      }
+      return parsed.event.data;
+    });
+    expect(wakes.map((wake) => wake.reason)).toEqual([
+      'catchup-required',
+      'catchup-required',
+    ]);
+    expect(wakes.map((wake) => wake.cursor)).toEqual([3, 3]);
+    expect(session.cursor).toBe(1);
+    expect(session.lastKnownSeq).toBe(3);
+    expect(session.wakePending).toBe(true);
+  });
+
+  test('a catch-up ack advances the notification base before deltas resume', async () => {
+    const t = makeContext();
+    await sync(t, [
+      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+    ]);
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+
+    const captured: StoredCommit[] = [];
+    Object.assign(t.ctx, {
+      realtime: {
+        notifyCommit: (_partition: string, commit: StoredCommit) => {
+          captured.push(commit);
+        },
+      },
+    });
+    await sync(
+      t,
+      [pushCommit('c2', [upsert('tasks', 't2', taskRow('t2', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    await sync(
+      t,
+      [pushCommit('c3', [upsert('tasks', 't3', taskRow('t3', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    expect(captured.map((commit) => commit.commitSeq)).toEqual([2, 3]);
+
+    // The shared client loop caught up through a pull on another binding.
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 3 }));
+    expect(session.lastKnownSeq).toBe(3);
+    Object.assign(t.ctx, { realtime: hub });
+
+    await sync(
+      t,
+      [pushCommit('c4', [upsert('tasks', 't4', taskRow('t4', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    expect(wire.binaries).toHaveLength(1);
+    expect(session.cursor).toBe(4);
+    expect(session.lastKnownSeq).toBe(4);
+  });
+
+  test('duplicate and regressive notifications wake from an unsuppressed session', async () => {
+    const t = makeContext();
+    await sync(t, [
+      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+    ]);
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+
+    const captured: StoredCommit[] = [];
+    Object.assign(t.ctx, {
+      realtime: {
+        notifyCommit: (_partition: string, commit: StoredCommit) => {
+          captured.push(commit);
+        },
+      },
+    });
+    await sync(
+      t,
+      [pushCommit('c2', [upsert('tasks', 't2', taskRow('t2', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    await sync(
+      t,
+      [pushCommit('c3', [upsert('tasks', 't3', taskRow('t3', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    const second = captured[0]!;
+    const third = captured[1]!;
+
+    await hub.notifyCommit('part-1', second);
+    expect(wire.binaries).toHaveLength(1);
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 2 }));
+    await hub.notifyCommit('part-1', second);
+    expect(wire.binaries).toHaveLength(1);
+    const duplicateWake = parseRealtimeServerEvent(wire.texts[1] ?? '');
+    if (!duplicateWake.known || duplicateWake.event.event !== 'sync') {
+      throw new Error('expected duplicate notification wake');
+    }
+    expect(duplicateWake.event.data.reason).toBe('catchup-required');
+    expect(duplicateWake.event.data.cursor).toBe(2);
+    expect(session.lastKnownSeq).toBe(2);
+    expect(session.cursor).toBe(2);
+
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 2 }));
+    await hub.notifyCommit('part-1', third);
+    expect(wire.binaries).toHaveLength(2);
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 3 }));
+    await hub.notifyCommit('part-1', second);
+    expect(wire.binaries).toHaveLength(2);
+    const regressionWake = parseRealtimeServerEvent(wire.texts[2] ?? '');
+    if (!regressionWake.known || regressionWake.event.event !== 'sync') {
+      throw new Error('expected regressive notification wake');
+    }
+    expect(regressionWake.event.data.reason).toBe('catchup-required');
+    expect(regressionWake.event.data.cursor).toBe(3);
+    expect(session.lastKnownSeq).toBe(3);
+    expect(session.cursor).toBe(3);
+    expect(wire.texts).toHaveLength(3);
   });
 
   test('a commit outside the registered scopes produces nothing', async () => {
@@ -258,6 +528,169 @@ describe('delta delivery (§8.2)', () => {
       const record = await t.storage.getClientRecord('part-1', 'client-1');
       return record?.cursor === latest;
     });
+  });
+
+  test('ACK then v2 socket replacement keeps the ACK cursor and new subscriptions', async () => {
+    const t = makeContext();
+    const initial: ClientRecord = {
+      clientId: 'client-1',
+      actorId: 'actor-1',
+      wireVersion: 1,
+      cursor: 0,
+      updatedAtMs: t.now.ms,
+      subscriptions: [
+        { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+      ],
+    };
+    await t.storage.putClientRecord('part-1', initial);
+    const observed = observeCursorPersistence(t.storage, 10);
+    Object.assign(t.ctx, { storage: observed.storage });
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 10 }));
+    await observed.persisted;
+    await session.handleBinary(
+      taggedRound(
+        requestBytes([
+          pullHeader(),
+          subFrame('new', 'tasks', { project_id: ['p1'] }, -1),
+        ]),
+      ),
+    );
+
+    expect(await t.storage.getClientRecord('part-1', 'client-1')).toMatchObject(
+      {
+        cursor: 10,
+        wireVersion: 2,
+        subscriptions: [
+          { id: 'new', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      },
+    );
+  });
+
+  test('v2 socket replacement then ACK keeps the new subscriptions and advances the cursor', async () => {
+    const t = makeContext();
+    const initial: ClientRecord = {
+      clientId: 'client-1',
+      actorId: 'actor-1',
+      wireVersion: 1,
+      cursor: 0,
+      updatedAtMs: t.now.ms,
+      subscriptions: [
+        { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+      ],
+    };
+    await t.storage.putClientRecord('part-1', initial);
+    const observed = observeCursorPersistence(t.storage, 10);
+    Object.assign(t.ctx, { storage: observed.storage });
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+
+    await session.handleBinary(
+      taggedRound(
+        requestBytes([
+          pullHeader(),
+          subFrame('new', 'tasks', { project_id: ['p1'] }, -1),
+        ]),
+      ),
+    );
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 10 }));
+    await observed.persisted;
+
+    expect(await t.storage.getClientRecord('part-1', 'client-1')).toMatchObject(
+      {
+        cursor: 10,
+        wireVersion: 2,
+        subscriptions: [
+          { id: 'new', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      },
+    );
+  });
+
+  test('a v1 error round keeps its minimal error and later delta on v1', async () => {
+    const t = makeContext();
+    const observed = observeCursorPersistence(t.storage, 0);
+    Object.assign(t.ctx, { storage: observed.storage });
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+    expect(session.wireVersion).toBe(2);
+
+    await t.storage.putClientRecord('part-1', {
+      clientId: 'client-1',
+      actorId: 'actor-1',
+      wireVersion: 2,
+      cursor: 0,
+      updatedAtMs: t.now.ms,
+      subscriptions: [
+        { id: 'later', table: 'tasks', scopes: { project_id: ['p1'] } },
+      ],
+    });
+
+    await session.handleBinary(
+      taggedRound(
+        encodeMessage({
+          wireVersion: 1,
+          msgKind: 'request',
+          frames: [
+            {
+              type: 'REQ_HEADER',
+              clientId: 'different-client',
+              schemaVersion: 1,
+            },
+            pullHeader(),
+          ],
+        }),
+      ),
+    );
+
+    const errorWire = wire.binaries[0];
+    expect(errorWire?.[0]).toBe(REALTIME_TAG_ROUND);
+    const error = decodeMessage(errorWire?.subarray(1) ?? new Uint8Array());
+    expect(error.wireVersion).toBe(1);
+    expect(error.frames[0]).toEqual({ type: 'RESP_HEADER' });
+    expect(error.frames[1]).toMatchObject({
+      type: 'ERROR',
+      code: 'sync.invalid_client_id',
+    });
+
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 0 }));
+    await observed.persisted;
+    await sync(
+      t,
+      [
+        pushCommit('after-v1-error', [
+          upsert('tasks', 'later', taskRow('later', 'p1')),
+        ]),
+      ],
+      { clientId: 'writer' },
+    );
+
+    const deltaWire = wire.binaries[1];
+    expect(deltaWire?.[0]).toBe(0x00);
+    const delta = decodeMessage(deltaWire?.subarray(1) ?? new Uint8Array());
+    expect(delta.wireVersion).toBe(1);
+    expect(delta.frames[0]).toEqual({ type: 'RESP_HEADER' });
   });
 
   test('closed sessions receive nothing', async () => {

--- a/packages/server/test/relational-rows.test.ts
+++ b/packages/server/test/relational-rows.test.ts
@@ -21,16 +21,27 @@ import {
   type RowValue,
 } from '@syncular/core';
 import {
+  commitWindowPageSql,
   compileSchema,
   createTableDdl,
   D1ServerStorage,
   PostgresServerStorage,
   physicalIndexName,
+  postgresScopeValueParam,
+  scanRowPageSql,
   type ServerSchema,
   SqliteServerStorage,
   type StoredRow,
 } from '@syncular/server';
 import { pgliteExecutor } from '@syncular/server/pglite';
+import type { D1Database, D1PreparedStatement } from '../src/d1-storage';
+import type { PgExecutor, PgQueryable } from '../src/pg-executor';
+import type {
+  SqliteDatabase,
+  SqliteRunResult,
+  SqliteStatement,
+  SqliteValue,
+} from '../src/sqlite-driver';
 import { D1DatabaseDouble } from './d1-double';
 
 const PARTITION = 'part-1';
@@ -113,6 +124,23 @@ function nullableAppendSchema(): ServerSchema {
         ],
       },
       ...SCHEMA.tables.slice(1),
+    ],
+  };
+}
+
+function secondNullableAppendSchema(): ServerSchema {
+  const v2 = nullableAppendSchema();
+  return {
+    version: 3,
+    tables: [
+      {
+        ...v2.tables[0]!,
+        columns: [
+          ...v2.tables[0]!.columns,
+          { name: 'reviewer', type: 'string', nullable: true },
+        ],
+      },
+      ...v2.tables.slice(1),
     ],
   };
 }
@@ -449,6 +477,327 @@ describe('server-side schema migration (the subset)', () => {
     expect(projected).toEqual({ assignee: null });
   });
 
+  test('a competing D1 layout cannot rewrite rows beneath another migration target', async () => {
+    const db = new D1DatabaseDouble();
+    const v1 = new D1ServerStorage(db);
+    await v1.ensureSchema(compileSchema(SCHEMA));
+    await upsert(v1, PARTITION, 'tasks', taskRow('t1', 'p1', 'v1 row'));
+
+    let announce!: () => void;
+    const announced = new Promise<void>((resolve) => {
+      announce = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const sqlByStatement = new WeakMap<D1PreparedStatement, string>();
+    let rewriteGated = false;
+    const gated: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        const statement = db.prepare(query);
+        sqlByStatement.set(statement, query);
+        return statement;
+      },
+      async batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+        if (
+          !rewriteGated &&
+          statements.some((statement) =>
+            sqlByStatement.get(statement)?.startsWith('UPDATE "tasks" SET'),
+          )
+        ) {
+          rewriteGated = true;
+          announce();
+          await released;
+        }
+        return db.batch(statements);
+      },
+      exec(query: string): Promise<unknown> {
+        return db.exec(query);
+      },
+    };
+
+    const v2Migration = new D1ServerStorage(gated).ensureSchema(
+      compileSchema(nullableAppendSchema()),
+    );
+    await announced;
+    const v3Outcome = await new D1ServerStorage(db)
+      .ensureSchema(compileSchema(secondNullableAppendSchema()))
+      .then(
+        () => undefined,
+        (error: Error) => error,
+      );
+    release();
+    const v2Outcome = await v2Migration.then(
+      () => undefined,
+      (error: Error) => error,
+    );
+
+    expect(v3Outcome).toBeInstanceOf(Error);
+    expect(v3Outcome?.message).toContain('migration is already in progress');
+    expect(v2Outcome).toBeUndefined();
+
+    const v3 = secondNullableAppendSchema();
+    const current = new D1ServerStorage(db);
+    await current.ensureSchema(compileSchema(v3));
+    const stored = await current.getRow(PARTITION, 'tasks', 't1');
+    expect(decodeRow(v3.tables[0]!.columns, stored!.payload).slice(-2)).toEqual(
+      [null, null],
+    );
+  });
+
+  test('an active D1 migration fences old-instance reads and in-flight writes', async () => {
+    const db = new D1DatabaseDouble();
+    const old = new D1ServerStorage(db);
+    const v1 = compileSchema(SCHEMA);
+    await old.ensureSchema(v1);
+    await upsert(old, PARTITION, 'tasks', taskRow('m1', 'p1', 'existing'));
+    const inFlight = await old.begin(PARTITION);
+    await inFlight.upsertRow(
+      'tasks',
+      taskRow('z-later', 'p1', 'old-layout write'),
+    );
+
+    let announce!: () => void;
+    const announced = new Promise<void>((resolve) => {
+      announce = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const sqlByStatement = new WeakMap<D1PreparedStatement, string>();
+    let rewriteGated = false;
+    const gated: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        const statement = db.prepare(query);
+        sqlByStatement.set(statement, query);
+        return statement;
+      },
+      async batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+        if (
+          !rewriteGated &&
+          statements.some((statement) =>
+            sqlByStatement.get(statement)?.startsWith('UPDATE "tasks" SET'),
+          )
+        ) {
+          rewriteGated = true;
+          announce();
+          await released;
+        }
+        return db.batch(statements);
+      },
+      exec(query: string): Promise<unknown> {
+        return db.exec(query);
+      },
+    };
+
+    const migration = new D1ServerStorage(gated).ensureSchema(
+      compileSchema(nullableAppendSchema()),
+    );
+    await announced;
+    const ensureOutcome = await old.ensureSchema(v1).then(
+      () => undefined,
+      (error: Error) => error,
+    );
+    const readOutcome = await old.getRow(PARTITION, 'tasks', 'm1').then(
+      () => undefined,
+      (error: Error) => error,
+    );
+    const scanOutcome = await old
+      .scanRows(PARTITION, {
+        table: 'tasks',
+        scopeFilter: { project_id: ['p1'] },
+        afterRowId: null,
+        limit: 10,
+      })
+      .then(
+        () => undefined,
+        (error: Error) => error,
+      );
+    const late = await old.begin(PARTITION);
+    const uniqueReadOutcome = await late
+      .upsertRow('tasks', taskRow('z-second', 'p1', 'late unique read'))
+      .then(
+        () => undefined,
+        (error: Error) => error,
+      );
+    const commitOutcome = await inFlight.commit().then(
+      () => undefined,
+      (error: Error) => error,
+    );
+    release();
+    await migration;
+    await inFlight.rollback();
+    await late.rollback();
+
+    for (const outcome of [
+      ensureOutcome,
+      readOutcome,
+      scanOutcome,
+      uniqueReadOutcome,
+      commitOutcome,
+    ]) {
+      expect(outcome).toBeInstanceOf(Error);
+      expect(outcome?.message).toContain('migration is already in progress');
+    }
+    const current = new D1ServerStorage(db);
+    const v2 = nullableAppendSchema();
+    await current.ensureSchema(compileSchema(v2));
+    expect(await current.getRow(PARTITION, 'tasks', 'z-later')).toBeUndefined();
+  });
+
+  test('a stale D1 claimant accepts an equal target published first', async () => {
+    const db = new D1DatabaseDouble();
+    await new D1ServerStorage(db).ensureSchema(compileSchema(SCHEMA));
+    const sqlByStatement = new WeakMap<D1PreparedStatement, string>();
+    let announce!: () => void;
+    const announced = new Promise<void>((resolve) => {
+      announce = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let claimGated = false;
+    const gated: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        const statement = db.prepare(query);
+        sqlByStatement.set(statement, query);
+        return statement;
+      },
+      async batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+        if (
+          !claimGated &&
+          statements.some((statement) =>
+            sqlByStatement
+              .get(statement)
+              ?.includes('INSERT OR IGNORE INTO sync_schema_migration'),
+          )
+        ) {
+          claimGated = true;
+          announce();
+          await released;
+        }
+        return db.batch(statements);
+      },
+      exec(query: string): Promise<unknown> {
+        return db.exec(query);
+      },
+    };
+    const v2 = compileSchema(nullableAppendSchema());
+
+    const stale = new D1ServerStorage(gated).ensureSchema(v2);
+    await announced;
+    await new D1ServerStorage(db).ensureSchema(v2);
+    release();
+
+    await expect(stale).resolves.toBeUndefined();
+  });
+
+  test('concurrent D1 callers can complete the same migration target', async () => {
+    const db = new D1DatabaseDouble();
+    const v1 = new D1ServerStorage(db);
+    await v1.ensureSchema(compileSchema(SCHEMA));
+    await upsert(v1, PARTITION, 'tasks', taskRow('t1', 'p1', 'v1 row'));
+
+    let announce!: () => void;
+    const announced = new Promise<void>((resolve) => {
+      announce = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let ddlGated = false;
+    const gated: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        return db.prepare(query);
+      },
+      batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+        return db.batch(statements);
+      },
+      async exec(query: string): Promise<unknown> {
+        if (
+          !ddlGated &&
+          query.startsWith('ALTER TABLE "tasks" ADD COLUMN "assignee" TEXT')
+        ) {
+          ddlGated = true;
+          announce();
+          await released;
+        }
+        return db.exec(query);
+      },
+    };
+    const v2 = compileSchema(nullableAppendSchema());
+
+    const first = new D1ServerStorage(gated).ensureSchema(v2);
+    await announced;
+    await new D1ServerStorage(db).ensureSchema(v2);
+    release();
+    await first;
+
+    const current = new D1ServerStorage(db);
+    await current.ensureSchema(v2);
+    const stored = await current.getRow(PARTITION, 'tasks', 't1');
+    expect(
+      decodeRow(v2.tables.get('tasks')!.columns, stored!.payload).at(-1),
+    ).toBeNull();
+  });
+
+  test('D1 resumes after a committed rewrite page without rewriting it twice', async () => {
+    const db = new D1DatabaseDouble();
+    const v1 = new D1ServerStorage(db);
+    await v1.ensureSchema(compileSchema(SCHEMA));
+    await upsert(v1, PARTITION, 'tasks', taskRow('t1', 'p1', 'v1 row'));
+
+    const sqlByStatement = new WeakMap<D1PreparedStatement, string>();
+    let interrupted = false;
+    let interruptNextPrepare = false;
+    const crashAfterRewrite: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        if (interruptNextPrepare) {
+          interruptNextPrepare = false;
+          throw new Error('simulated process interruption after D1 commit');
+        }
+        const statement = db.prepare(query);
+        sqlByStatement.set(statement, query);
+        return statement;
+      },
+      async batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+        const result = await db.batch(statements);
+        if (
+          !interrupted &&
+          statements.some((statement) =>
+            sqlByStatement.get(statement)?.startsWith('UPDATE "tasks" SET'),
+          )
+        ) {
+          interrupted = true;
+          interruptNextPrepare = true;
+        }
+        return result;
+      },
+      exec(query: string): Promise<unknown> {
+        return db.exec(query);
+      },
+    };
+    const v2 = nullableAppendSchema();
+
+    await expect(
+      new D1ServerStorage(crashAfterRewrite).ensureSchema(compileSchema(v2)),
+    ).rejects.toThrow('simulated process interruption');
+    await new D1ServerStorage(db).ensureSchema(compileSchema(v2));
+
+    const current = new D1ServerStorage(db);
+    await current.ensureSchema(compileSchema(v2));
+    const stored = await current.getRow(PARTITION, 'tasks', 't1');
+    expect(decodeRow(v2.tables[0]!.columns, stored!.payload).at(-1)).toBeNull();
+    const migration = await db
+      .prepare('SELECT id FROM sync_schema_migration WHERE id=1')
+      .first<{ id: number }>();
+    expect(migration).toBeNull();
+  });
+
   test('a version bump replaces declared indexes on SQLite', async () => {
     const storage = new SqliteServerStorage();
     await storage.ensureSchema(compileSchema(SCHEMA));
@@ -469,7 +818,94 @@ describe('server-side schema migration (the subset)', () => {
       )
       .all()
       .map((column) => column.name);
-    expect(columns).toEqual(['project_id', 'title']);
+    expect(columns).toEqual(['_sync_partition', 'project_id', 'title']);
+  });
+
+  test('same-version startup upgrades legacy declared indexes on SQLite', async () => {
+    const storage = new SqliteServerStorage();
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    storage.db.run('DROP INDEX sync_ix_tasks_by_project_title');
+    storage.db.run(
+      'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks (project_id, title)',
+    );
+    storage.db.run('CREATE INDEX ops_tasks_tuning ON tasks (title)');
+
+    const restarted = new SqliteServerStorage(storage.db);
+    await restarted.ensureSchema(compileSchema(SCHEMA));
+
+    const columns = restarted.db
+      .query<{ name: string }, []>(
+        'PRAGMA index_info("sync_ix_tasks_by_project_title")',
+      )
+      .all()
+      .map((column) => column.name);
+    expect(columns).toEqual(['_sync_partition', 'project_id', 'title']);
+    const indexes = restarted.db
+      .query<{ name: string; unique: number }, []>('PRAGMA index_list("tasks")')
+      .all();
+    expect(indexes).toContainEqual(
+      expect.objectContaining({
+        name: 'sync_ix_tasks_by_project_title',
+        unique: 1,
+      }),
+    );
+    expect(indexes).toContainEqual(
+      expect.objectContaining({ name: 'ops_tasks_tuning' }),
+    );
+  });
+
+  test('an older SQLite repair cannot cross a newer schema bump', async () => {
+    const storage = new SqliteServerStorage();
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    storage.db.run('DROP INDEX sync_ix_tasks_by_project_title');
+    storage.db.run(
+      'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks (project_id, title)',
+    );
+
+    let newer: Promise<void> | undefined;
+    let intercepted = false;
+    const gatedDb: SqliteDatabase = {
+      exec(sql: string): void {
+        if (sql === 'BEGIN IMMEDIATE' && !intercepted) {
+          intercepted = true;
+          newer = new SqliteServerStorage(storage.db).ensureSchema(
+            compileSchema(INDEX_REPLACEMENT_SCHEMA),
+          );
+        }
+        storage.db.exec(sql);
+      },
+      run(sql: string, bindings?: readonly SqliteValue[]): SqliteRunResult {
+        return storage.db.run(sql, bindings);
+      },
+      query<
+        Row = Record<string, SqliteValue>,
+        Params extends readonly SqliteValue[] = SqliteValue[],
+      >(sql: string): SqliteStatement<Row, Params> {
+        return storage.db.query<Row, Params>(sql);
+      },
+      close(): void {
+        storage.db.close();
+      },
+    };
+
+    const older = new SqliteServerStorage(gatedDb).ensureSchema(
+      compileSchema(SCHEMA),
+    );
+    await newer;
+    await expect(older).rejects.toThrow(/newer than the configured schema/);
+
+    const marker = storage.db
+      .query<{ schema_version: number }, []>(
+        'SELECT schema_version FROM sync_schema_meta WHERE id=1',
+      )
+      .get();
+    expect(marker?.schema_version).toBe(2);
+    const names = storage.db
+      .query<{ name: string; origin: string }, []>('PRAGMA index_list("tasks")')
+      .all()
+      .filter((index) => index.origin === 'c')
+      .map((index) => index.name);
+    expect(names).toEqual(['sync_ix_tasks_by_title']);
   });
 
   test('a version bump replaces declared indexes on Postgres', async () => {
@@ -486,7 +922,111 @@ describe('server-side schema migration (the subset)', () => {
     expect(indexes.rows[0]?.indexdef).toContain(
       'UNIQUE INDEX sync_ix_tasks_by_title',
     );
-    expect(indexes.rows[0]?.indexdef).toContain('(project_id, title)');
+    expect(indexes.rows[0]?.indexdef).toContain(
+      '(_sync_partition, project_id, title)',
+    );
+  });
+
+  test('same-version startup upgrades legacy declared indexes on Postgres', async () => {
+    const db = await PGlite.create();
+    await new PostgresServerStorage(pgliteExecutor(db)).ensureSchema(
+      compileSchema(SCHEMA),
+    );
+    await db.query('DROP INDEX sync_ix_tasks_by_project_title');
+    await db.query(
+      'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks (project_id, title)',
+    );
+
+    await new PostgresServerStorage(pgliteExecutor(db)).ensureSchema(
+      compileSchema(SCHEMA),
+    );
+
+    const index = await db.query<{ indexdef: string }>(
+      "SELECT indexdef FROM pg_indexes WHERE schemaname=current_schema() AND indexname='sync_ix_tasks_by_project_title'",
+    );
+    expect(index.rows[0]?.indexdef).toContain(
+      '(_sync_partition, project_id, title)',
+    );
+    expect(index.rows[0]?.indexdef).toContain(
+      'UNIQUE INDEX sync_ix_tasks_by_project_title',
+    );
+    await db.close();
+  });
+
+  test('an older Postgres repair cannot cross a newer schema bump', async () => {
+    const db = await PGlite.create();
+    const base = pgliteExecutor(db);
+    await new PostgresServerStorage(base).ensureSchema(compileSchema(SCHEMA));
+    await db.query('DROP INDEX sync_ix_tasks_by_project_title');
+    await db.query(
+      'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks (project_id, title)',
+    );
+
+    let announce!: () => void;
+    const announced = new Promise<void>((resolve) => {
+      announce = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const gated: PgExecutor = {
+      query<Row>(text: string, params?: readonly unknown[]) {
+        return base.query<Row>(text, params);
+      },
+      async transaction<T>(fn: (client: PgQueryable) => Promise<T>) {
+        announce();
+        await released;
+        return base.transaction(fn);
+      },
+    };
+
+    const older = new PostgresServerStorage(gated).ensureSchema(
+      compileSchema(SCHEMA),
+    );
+    await announced;
+    await new PostgresServerStorage(base).ensureSchema(
+      compileSchema(INDEX_REPLACEMENT_SCHEMA),
+    );
+    release();
+
+    await expect(older).rejects.toThrow(/newer than the configured schema/);
+    const marker = await db.query<{ schema_version: number }>(
+      'SELECT schema_version FROM sync_schema_meta WHERE id=1',
+    );
+    expect(marker.rows[0]?.schema_version).toBe(2);
+    const indexes = await db.query<{ indexname: string }>(
+      "SELECT indexname FROM pg_indexes WHERE schemaname=current_schema() AND tablename='tasks' AND indexname <> 'tasks_pkey' ORDER BY indexname",
+    );
+    expect(indexes.rows.map((index) => index.indexname)).toEqual([
+      'sync_ix_tasks_by_title',
+    ]);
+    await db.close();
+  });
+
+  test('a declared UNIQUE index is unique per partition', async () => {
+    // One physical table holds every partition, so an index over the declared
+    // columns alone would let one tenant reserve a value for every other.
+    const db = await PGlite.create();
+    const storage = new PostgresServerStorage(pgliteExecutor(db));
+    await storage.ensureSchema(compileSchema(INDEX_REPLACEMENT_SCHEMA));
+
+    await upsert(
+      storage,
+      'tenant-a',
+      'tasks',
+      taskRow('t1', 'p1', 'same-title'),
+    );
+    await upsert(
+      storage,
+      'tenant-b',
+      'tasks',
+      taskRow('t2', 'p1', 'same-title'),
+    );
+
+    expect((await storage.getRow('tenant-a', 'tasks', 't1'))?.rowId).toBe('t1');
+    expect((await storage.getRow('tenant-b', 'tasks', 't2'))?.rowId).toBe('t2');
+    await db.close();
   });
 
   test('a version bump replaces declared indexes on D1', async () => {
@@ -505,9 +1045,97 @@ describe('server-side schema migration (the subset)', () => {
       .prepare('PRAGMA index_info("sync_ix_tasks_by_title")')
       .all<{ name: string }>();
     expect(columns.results.map((column) => column.name)).toEqual([
+      '_sync_partition',
       'project_id',
       'title',
     ]);
+  });
+
+  test('same-version startup upgrades legacy declared indexes on D1', async () => {
+    const db = new D1DatabaseDouble();
+    await new D1ServerStorage(db).ensureSchema(compileSchema(SCHEMA));
+    await db.exec('DROP INDEX sync_ix_tasks_by_project_title');
+    await db.exec(
+      'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks (project_id, title)',
+    );
+
+    await new D1ServerStorage(db).ensureSchema(compileSchema(SCHEMA));
+
+    const columns = await db
+      .prepare('PRAGMA index_info("sync_ix_tasks_by_project_title")')
+      .all<{ name: string }>();
+    expect(columns.results.map((column) => column.name)).toEqual([
+      '_sync_partition',
+      'project_id',
+      'title',
+    ]);
+    const indexes = await db
+      .prepare('PRAGMA index_list("tasks")')
+      .all<{ name: string; unique: number }>();
+    expect(indexes.results).toContainEqual(
+      expect.objectContaining({
+        name: 'sync_ix_tasks_by_project_title',
+        unique: 1,
+      }),
+    );
+  });
+
+  test('an older D1 repair cannot cross a newer schema bump', async () => {
+    const db = new D1DatabaseDouble();
+    await new D1ServerStorage(db).ensureSchema(compileSchema(SCHEMA));
+    await db.exec('DROP INDEX sync_ix_tasks_by_project_title');
+    await db.exec(
+      'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks (project_id, title)',
+    );
+
+    let announce!: () => void;
+    const announced = new Promise<void>((resolve) => {
+      announce = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let gatedBatch = false;
+    const gated: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        return db.prepare(query);
+      },
+      async batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
+        if (!gatedBatch) {
+          gatedBatch = true;
+          announce();
+          await released;
+        }
+        return db.batch(statements);
+      },
+      exec(query: string): Promise<unknown> {
+        return db.exec(query);
+      },
+    };
+
+    const older = new D1ServerStorage(gated).ensureSchema(
+      compileSchema(SCHEMA),
+    );
+    await announced;
+    await new D1ServerStorage(db).ensureSchema(
+      compileSchema(INDEX_REPLACEMENT_SCHEMA),
+    );
+    release();
+
+    await expect(older).rejects.toThrow(/newer than the configured schema/);
+    const marker = await db
+      .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+      .first<{ schema_version: number }>();
+    expect(marker?.schema_version).toBe(2);
+    const indexes = await db
+      .prepare('PRAGMA index_list("tasks")')
+      .all<{ name: string; origin: string }>();
+    expect(
+      indexes.results
+        .filter((index) => index.origin === 'c')
+        .map((index) => index.name),
+    ).toEqual(['sync_ix_tasks_by_title']);
   });
 
   test('a version bump preserves operator-added tuning indexes and migrates bare declared names', async () => {
@@ -1041,6 +1669,91 @@ describe('IR→DDL', () => {
     expect(postgres).toContain('"priority" BIGINT');
     expect(postgres).toContain('"score" DOUBLE PRECISION');
     expect(postgres).toContain('"_sync_payload" BYTEA NOT NULL');
+  });
+});
+
+// --- the scope-value bind of the two page queries ----------------------------
+
+describe('scope-value binds', () => {
+  function tasks() {
+    const compiled = compileSchema(SCHEMA).tables.get('tasks');
+    if (compiled === undefined) throw new Error('missing table');
+    return compiled;
+  }
+
+  test('postgres binds one value as a scalar and unnests more', () => {
+    const one = scanRowPageSql(tasks(), 1, 'postgres');
+    const many = scanRowPageSql(tasks(), 3, 'postgres');
+
+    expect(one).toContain('value=$4');
+    expect(one).not.toContain('unnest');
+
+    // The array is expanded into one bounded index range per value rather
+    // than put on `value` as an array qual, which is what keeps the scan off
+    // the ordering column. These fragments pin the exact SQL contract used
+    // by both commit-window and row-page scans.
+    expect(many).toContain('unnest($4::text[]) AS v(value)');
+    expect(many).toContain('CROSS JOIN LATERAL');
+    expect(many).toContain('value=v.value');
+    expect(many).not.toContain('value=ANY');
+
+    // The placeholder numbers do not move with the value count, which is
+    // what takes the 65,535 bind-parameter ceiling off the query.
+    expect(one).toContain('row_id>$5');
+    expect(many).toContain('row_id>$5');
+
+    // Each lateral arm is bounded by the page limit, so the sort above it
+    // sees `values * limit` rows instead of the whole scope extent.
+    expect(many.split('LIMIT $6')).toHaveLength(3);
+
+    expect(commitWindowPageSql(1, 'postgres')).toContain('value=$4');
+    expect(commitWindowPageSql(1, 'postgres')).not.toContain('unnest');
+
+    const windowMany = commitWindowPageSql(9, 'postgres');
+    expect(windowMany).toContain('unnest($4::text[]) AS v(value)');
+    expect(windowMany).toContain('value=v.value');
+    expect(windowMany).not.toContain('value=ANY');
+    expect(windowMany).toContain('commit_seq>$5');
+    expect(windowMany.split('LIMIT $7')).toHaveLength(3);
+
+    expect(postgresScopeValueParam(['l1'])).toEqual(['l1']);
+    expect(postgresScopeValueParam(['l1', 'l2'])).toEqual([['l1', 'l2']]);
+  });
+
+  test('sqlite keeps one placeholder per scope value', () => {
+    // SQLite has no array type and D1 shares this builder. The ceiling there
+    // is a separate, lower one that this shape does not address.
+    expect(scanRowPageSql(tasks(), 3, 'sqlite')).toContain('value IN (?,?,?)');
+    expect(commitWindowPageSql(3, 'sqlite')).toContain('value IN (?,?,?)');
+  });
+
+  test('scope values survive the array bind verbatim', async () => {
+    // A comma, a brace, a double quote, a backslash and a NULL-looking word
+    // are what an array literal has to escape.
+    const awkward = ['a,b', '{c}', 'd"e', 'f\\g', 'NULL'];
+    const db = await PGlite.create();
+    const storage = new PostgresServerStorage(pgliteExecutor(db));
+    await storage.ensureSchema(compileSchema(SCHEMA));
+    for (const [index, project] of awkward.entries()) {
+      await upsert(
+        storage,
+        PARTITION,
+        'tasks',
+        taskRow(`t${index}`, project, 'title'),
+      );
+    }
+
+    const rows = await storage.scanRows(PARTITION, {
+      table: 'tasks',
+      scopeFilter: { project_id: awkward },
+      afterRowId: null,
+      limit: 10,
+    });
+
+    expect(rows.map((row) => row.scopes.project_id).sort()).toEqual(
+      [...awkward].sort(),
+    );
+    await db.close();
   });
 });
 

--- a/packages/server/test/storage-contract.ts
+++ b/packages/server/test/storage-contract.ts
@@ -1071,6 +1071,10 @@ export function runStorageContract(
       expect(await storage.getHorizonSeq(PARTITION)).toBe(0);
       await storage.setHorizonSeq(PARTITION, 2);
       expect(await storage.getHorizonSeq(PARTITION)).toBe(2);
+      // A stale concurrent prune must not move the horizon behind rows a
+      // newer prune may already have deleted.
+      await storage.setHorizonSeq(PARTITION, 1);
+      expect(await storage.getHorizonSeq(PARTITION)).toBe(2);
       const removed = await storage.pruneCommitsThrough(PARTITION, 2);
       expect(removed).toBe(2);
       // Pruned commits vanish from the window; retained ones remain.
@@ -1136,6 +1140,105 @@ export function runStorageContract(
       await storage.putClientRecord(PARTITION, { ...record, cursor: 99 });
       const updated = await storage.getClientRecord(PARTITION, 'c1');
       expect(updated?.cursor).toBe(99);
+    });
+
+    test('cursor-only updates are absent-safe and monotonic', async () => {
+      const storage = await make();
+
+      await storage.updateClientCursor(PARTITION, 'missing', 8, NOW + 8);
+      expect(
+        await storage.getClientRecord(PARTITION, 'missing'),
+      ).toBeUndefined();
+
+      const record: ClientRecord = {
+        clientId: 'cursor-only',
+        actorId: 'actor-old',
+        wireVersion: 1,
+        cursor: 2,
+        updatedAtMs: NOW,
+        subscriptions: [
+          { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      };
+      await storage.putClientRecord(PARTITION, record);
+      await storage.updateClientCursor(PARTITION, record.clientId, 9, NOW + 20);
+      await storage.updateClientCursor(PARTITION, record.clientId, 4, NOW + 10);
+
+      expect(await storage.getClientRecord(PARTITION, record.clientId)).toEqual(
+        {
+          ...record,
+          cursor: 9,
+          updatedAtMs: NOW + 20,
+        },
+      );
+    });
+
+    test('ACK then full replacement preserves the ACK cursor and replaces round fields', async () => {
+      const storage = await make();
+      const old: ClientRecord = {
+        clientId: 'ack-then-round',
+        actorId: 'actor-old',
+        wireVersion: 1,
+        cursor: 2,
+        updatedAtMs: NOW,
+        subscriptions: [
+          { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      };
+      const replacement: ClientRecord = {
+        ...old,
+        actorId: 'actor-new',
+        wireVersion: 2,
+        cursor: 4,
+        updatedAtMs: NOW + 10,
+        subscriptions: [
+          { id: 'new', table: 'tasks', scopes: { project_id: ['p2'] } },
+        ],
+      };
+
+      await storage.putClientRecord(PARTITION, old);
+      await storage.updateClientCursor(PARTITION, old.clientId, 9, NOW + 20);
+      await storage.putClientRecord(PARTITION, replacement);
+
+      expect(await storage.getClientRecord(PARTITION, old.clientId)).toEqual({
+        ...replacement,
+        cursor: 9,
+        updatedAtMs: NOW + 20,
+      });
+    });
+
+    test('full replacement then ACK preserves round fields and advances the cursor', async () => {
+      const storage = await make();
+      const old: ClientRecord = {
+        clientId: 'round-then-ack',
+        actorId: 'actor-old',
+        wireVersion: 1,
+        cursor: 2,
+        updatedAtMs: NOW,
+        subscriptions: [
+          { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      };
+      const replacement: ClientRecord = {
+        ...old,
+        actorId: 'actor-new',
+        wireVersion: 2,
+        cursor: 4,
+        updatedAtMs: NOW + 20,
+        subscriptions: [
+          { id: 'new', table: 'tasks', scopes: { project_id: ['p2'] } },
+        ],
+      };
+
+      await storage.putClientRecord(PARTITION, old);
+      await storage.putClientRecord(PARTITION, replacement);
+      await storage.updateClientCursor(PARTITION, old.clientId, 9, NOW + 30);
+
+      expect(await storage.getClientRecord(PARTITION, old.clientId)).toEqual({
+        ...replacement,
+        cursor: 9,
+        updatedAtMs: NOW + 30,
+      });
     });
 
     // --- Blob reference index (§5.9.4, optional methods) ---

--- a/packages/server/test/storage.test.ts
+++ b/packages/server/test/storage.test.ts
@@ -156,6 +156,38 @@ test('SQLite: a failed COMMIT rolls back and later transactions proceed', async 
   ).toBeDefined();
 });
 
+test('retiring a table purges its blob refs with its row scopes', async () => {
+  // A surviving `sync_blob_refs` row fails in both directions at once: it
+  // keeps answering the reference lookup the §5.9.2 sweep consults, so the
+  // bytes are never reclaimed, and it is skipped by the row lookup §5.9.5
+  // authorizes downloads against, so every download is denied.
+  const db = await PGlite.create();
+  const storage = new PostgresServerStorage(pgliteExecutor(db));
+  await storage.migrate();
+  await storage.ensureSchema(compileSchema(CONTRACT_SCHEMA));
+
+  for (const tbl of ['tasks', 'docs']) {
+    await db.query(
+      'INSERT INTO sync_blob_refs(partition, tbl, row_id, blob_id) VALUES ($1,$2,$3,$4)',
+      ['p1', tbl, 'r1', `sha256:${'a'.repeat(64)}`],
+    );
+  }
+
+  // Retire `docs` by bumping to a schema that no longer declares it.
+  await storage.ensureSchema(
+    compileSchema({
+      ...CONTRACT_SCHEMA,
+      version: 2,
+      tables: CONTRACT_SCHEMA.tables.filter((table) => table.name !== 'docs'),
+    }),
+  );
+
+  const remaining = await db.query<{ tbl: string }>(
+    'SELECT DISTINCT tbl FROM sync_blob_refs ORDER BY tbl',
+  );
+  expect(remaining.rows.map((row) => row.tbl)).toEqual(['tasks']);
+});
+
 test('pglite executor serializes overlapping transaction scopes', async () => {
   const db = await PGlite.create();
   const exec = pgliteExecutor(db);

--- a/packages/web-client/test/helpers.ts
+++ b/packages/web-client/test/helpers.ts
@@ -143,6 +143,8 @@ function wrapStorage(
     scanRows: (p, q) => storage.scanRows(p, q),
     getClientRecord: (p, c) => storage.getClientRecord(p, c),
     putClientRecord: (p, r) => storage.putClientRecord(p, r),
+    updateClientCursor: (p, c, cursor, updatedAtMs) =>
+      storage.updateClientCursor(p, c, cursor, updatedAtMs),
     listClientCursors: (p) => storage.listClientCursors(p),
   };
 }


### PR DESCRIPTION
## Summary

- Make incremental pulls fail with `sync.cursor_expired` if retention advances across a commit read, and make pruning repair incomplete deletions.
- Reject out-of-order realtime deltas, realign notification watermarks on acknowledgements, and persist cursor-only updates atomically.
- Make declared server indexes partition-scoped and reconcile legacy same-version index shapes across SQLite, PostgreSQL, and D1.
- Serialize and fence D1 schema migration with a durable claim and keyset checkpoints so projection traffic cannot cross mixed layouts.
- Improve multi-scope PostgreSQL filtering and purge blob references for retired tables.
- Make the embedded sqlite-wasm D1 adapter preserve batched read results required by the D1 contract.

## Why

Concurrent pruning, post-commit realtime fanout, and schema upgrades could expose incomplete histories, stale client state, cross-partition unique collisions, or mixed-layout D1 payloads. Several races are invisible to the serialized conformance driver, so the change includes deterministic backend-specific regressions.

## Impact

Clients receive contiguous commit history and deltas or an explicit catch-up/reset signal. Existing same-version databases repair Syncular-owned index definitions without replacing operator or constraint-owned indexes. D1 migrations fence old-layout reads and in-flight writes until canonical publication completes.

## Validation

- `bun run check`
- 1,569 main tests passed with 9 environment-gated skips
- 13 isolated multi-tab tests passed
- Node SQLite runtime contracts passed
- Pre-push dependency audits passed with repository-approved warnings
