### PR TITLE
Fix concurrent sync recovery and partition server indexes

### DIFF
--- a/apps/docs/src/changelog.mjs
+++ b/apps/docs/src/changelog.mjs
@@ -17,6 +17,17 @@
 export const changelog = [
   {
     date: '2026-09-05',
+    title: 'Concurrent pull recovery and partition-scoped server indexes',
+    body: 'Pulls reset before emitting an active section when pruning crosses their commit-window read. Realtime notifications that break sequence trigger catch-up, and acknowledgment persistence preserves concurrent subscription updates. Declared server indexes include the partition column; existing databases require an application schema-version bump to rebuild them. Table retirement removes stale blob references. Includes focused contributions from Chase Pursley in PR #47.',
+    links: [
+      {
+        href: '/server-storage/#concurrent-pulls-and-storage-upgrades',
+        label: 'Storage upgrade instructions',
+      },
+    ],
+  },
+  {
+    date: '2026-09-05',
     title: 'Generated Rust decoder compatibility',
     body: 'Typegen emits byte decoders that pass Rust 1.98 Clippy while retaining strict envelope validation. Regenerate Rust query modules with typegen 0.16.1 to receive the updated helper.',
     links: [{ href: '/tooling-queries/', label: 'Generated queries' }],

--- a/apps/docs/src/content/blog/offline-first-writes.md
+++ b/apps/docs/src/content/blog/offline-first-writes.md
@@ -524,7 +524,7 @@ The web core is TypeScript. The native core is Rust, exposed through thin Swift,
 
 Both implement the written [SSP2 protocol](https://github.com/syncular/syncular/blob/main/docs/SPEC.md). Both consume the same generated schema contract. Both run the same implementation-agnostic [conformance scenarios and golden byte vectors](/guide-conformance/).
 
-The catalog contains 104 scenarios covering convergence, offline replay, lost acknowledgements, conflicts, scopes, revocation, bootstrap interruption, blobs, encryption, CRDTs, schema upgrades, realtime, presence, windowing, validation, and pruning. The repository gate passes more than 1,200 tests across the TypeScript and Rust paths.
+The catalog contains 106 scenarios covering convergence, offline replay, lost acknowledgements, conflicts, scopes, revocation, bootstrap interruption, blobs, encryption, CRDTs, schema upgrades, realtime, presence, windowing, validation, and pruning. The repository gate passes more than 1,200 tests across the TypeScript and Rust paths.
 
 Writing down a protocol is valuable because it removes implementation language as an excuse. If behavior can only be explained by pointing at a TypeScript object, it is not yet a portable protocol.
 

--- a/apps/docs/src/content/server-storage.md
+++ b/apps/docs/src/content/server-storage.md
@@ -6,6 +6,39 @@ for the commit log and rows, `SegmentStore` for bootstrap segments, and
 when to pick which; all backends sharing an interface pass one shared
 contract suite.
 
+## Concurrent pulls and storage upgrades
+
+Incremental pulls read their commit window and recheck the retention horizon
+before starting an active subscription section. Pruning during that read returns
+`sync.cursor_expired` as a subscription reset. Both client cores report the reset
+and `syncUntilIdle` follows it with a fresh bootstrap.
+
+Realtime sessions track commit notification order, including commits outside their
+registered scopes. A sequence gap, duplicate, or regression sends a catch-up wake.
+A catch-up acknowledgment advances the notification watermark before deltas resume.
+
+Custom storage adapters must implement
+`updateClientCursor(partition, clientId, cursor, updatedAtMs)`. Update only the
+existing record's cursor and timestamp with their respective maxima, atomically.
+Keep missing records absent and preserve actor, wire version, and subscriptions.
+`putClientRecord` remains a full replacement: changing subscriptions can lower the
+retention cursor floor.
+
+Declared server indexes now lead with `_sync_partition`. Unique values are enforced
+within each partition. The generated client index columns remain unchanged.
+**When upgrading an existing server database, increment the application schema
+version and regenerate its schema before starting the server.** The existing
+schema migration rebuilds Syncular-owned indexes with the partition column.
+Reopening the same schema version does not rebuild old indexes. Operator indexes
+and constraint-owned indexes remain outside the rebuild set.
+
+Removing a table in a schema migration also deletes its blob references. References
+from retained tables continue to protect their blobs from garbage collection.
+
+D1 schema migration still requires a separate redesign for invocation budgets and
+concurrent migration fencing. This change does not introduce the proposed durable
+migration-claim framework from PR #47.
+
 ## Choosing a database
 
 | Backend | Adapter | Realtime fanout | When to use |

--- a/apps/docs/src/content/what-is.md
+++ b/apps/docs/src/content/what-is.md
@@ -36,7 +36,7 @@ with two independent, conformance-locked implementations:
 - A **Rust core** for everything else: rusqlite on the device filesystem,
   shipped through a five-function C FFI.
 
-Both pass the same golden byte-level vectors and the same 104-scenario
+Both pass the same golden byte-level vectors and the same 106-scenario
 conformance catalog, run against both cores in CI. The platform bindings are
 thin marshaling over the shared Rust core, so protocol behavior is identical
 everywhere:

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -27,7 +27,7 @@ const FEATURES = [
 // test/conformance-count.test.ts; the catalog itself is Bun-only
 // (import.meta.dir plus the full client/server stacks), so the landing
 // page cannot import it during the Astro build.
-const CONFORMANCE_SCENARIOS = 104;
+const CONFORMANCE_SCENARIOS = 106;
 
 const PLATFORM_LINKS = [
   { label: 'WEB', href: '/platform-web/' },

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1124,6 +1124,12 @@ Servers prune the commit log. The contract:
   every row, the change that a fresh scan from any cursor ≥ horizonSeq
   would need to converge.
 
+An incremental pull MUST read its commit window and then recheck the horizon
+before emitting `SUB_START`. If pruning advanced past the request cursor during
+that read, the server MUST use the reset response above. It MUST NOT emit an
+active section followed by a non-retryable cursor-expiry error. Once the window
+is buffered and continuity is verified, later pruning cannot remove its frames.
+
 Pruning MUST capture the partition log epoch before reading retention inputs.
 The storage operation `pruneCommitsThrough(partition, { logEpoch, throughSeq })`
 MUST verify that epoch, advance the horizon to the greater of its current value
@@ -3907,6 +3913,16 @@ per §8.7, or `POST /sync`) before trusting the socket for continuity.
   matching commit with a coalescible `catchup-required` wake-up, until
   an ack reaches the highest `commitSeq` the connection has observed —
   then deltas resume.
+- Post-commit notifications can arrive out of commit order. The server MUST
+  track the highest observed notification sequence and send a catch-up wake
+  when the next notification is non-adjacent. Notifications outside the
+  registered scopes still advance this sequence. A catch-up acknowledgment
+  MUST advance the notification sequence to at least its cursor.
+- Acknowledgment persistence MUST update only the existing client record's
+  cursor and timestamp, monotonically and atomically. It MUST preserve the
+  subscriptions, actor, and wire version written by a concurrent sync round.
+  A full sync round remains authoritative for its subscription cursor floor;
+  replacing subscriptions can lower that floor.
 - The client acknowledges applied deltas:
   `{"type":"ack","cursor":<highest contiguously applied commitSeq>}`.
   The ack is the sole client→server control message and is recognized

--- a/packages/conformance/src/catalog/lifecycle.ts
+++ b/packages/conformance/src/catalog/lifecycle.ts
@@ -19,6 +19,49 @@ const P1 = { project_id: ['p1'] } as const;
 
 export const lifecycleScenarios: readonly Scenario[] = [
   {
+    name: 'lifecycle/pruning-during-pull-resets-and-rebootstraps',
+    specRefs: ['§4.6', '§4.7'],
+    requires: ['concurrent-storage-faults'],
+    async run(ctx) {
+      await seedTasks(ctx, [task('t1', 'p1', 'before')]);
+      const client = await ctx.newClient({
+        actorId: 'reader',
+        clientId: 'reader',
+        allowed: P1,
+      });
+      await client.api.subscribe({ id: 'tasks', table: 'tasks', scopes: P1 });
+      await syncIdle(client);
+      await seedTasks(ctx, [task('t2', 'p1', 'pruned')]);
+      await ctx.server.pruneDuringNextCommitRead!();
+      const reset = await syncOk(client);
+      checkEqual(
+        reset.commitsApplied,
+        0,
+        'an incomplete window applies no commits',
+      );
+      checkEqual(
+        (await client.api.subscriptionState('tasks'))?.cursor,
+        -1,
+        'reset discards the expired cursor',
+      );
+      checkEqual(
+        reset.resets,
+        ['tasks'],
+        'the round reports required bootstrap recovery',
+      );
+      await syncIdle(client);
+      await expectConverged(ctx, 'tasks', [client], {
+        variable: 'project_id',
+        values: ['p1'],
+      });
+      checkEqual(
+        (await client.api.readRows('tasks')).length,
+        2,
+        'bootstrap recovers the pruned row',
+      );
+    },
+  },
+  {
     name: 'subscription/identity-is-immutable-and-idempotent',
     specRefs: ['§4.1', '§7.5'],
     async run(ctx) {

--- a/packages/conformance/src/catalog/realtime.ts
+++ b/packages/conformance/src/catalog/realtime.ts
@@ -26,6 +26,34 @@ async function connectedClient(
 
 export const realtimeScenarios: readonly Scenario[] = [
   {
+    name: 'realtime/reversed-notifications-recover-before-resuming-deltas',
+    specRefs: ['§8.2', '§8.3', '§8.4'],
+    requires: ['concurrent-storage-faults'],
+    async run(ctx) {
+      const client = await connectedClient(ctx, 'reader', 'reader');
+      await client.api.connectRealtime();
+      await ctx.server.reverseNextCommitNotifications!();
+      await seedTasks(ctx, [task('t1', 'p1', 'first')]);
+      await seedTasks(ctx, [task('t2', 'p1', 'second')]);
+      await client.realtime.waitForWakes(2);
+      checkEqual(
+        client.realtime.deltasDelivered,
+        0,
+        'no delta crosses the missing notification',
+      );
+      check(await client.api.syncNeeded(), 'the wake schedules catch-up');
+      await syncIdle(client);
+      await client.realtime.waitForAck(await ctx.server.getMaxCommitSeq());
+      await seedTasks(ctx, [task('t3', 'p1', 'resumed')]);
+      await client.realtime.waitForDeltas(1);
+      await client.realtime.waitForAck(await ctx.server.getMaxCommitSeq());
+      await expectConverged(ctx, 'tasks', [client], {
+        variable: 'project_id',
+        values: ['p1'],
+      });
+    },
+  },
+  {
     name: 'realtime/delta-roundtrip-and-ack',
     specRefs: ['§8.1', '§8.2'],
     async run(ctx) {

--- a/packages/conformance/src/driver.ts
+++ b/packages/conformance/src/driver.ts
@@ -206,6 +206,7 @@ export type RealtimeConnectResult =
 export type ServerCapability =
   | 'backup-restore'
   | 'idempotency-fault'
+  | 'concurrent-storage-faults'
   | 'signed-urls'
   | 'blobs'
   | 'blob-presign'
@@ -398,6 +399,11 @@ export interface ServerInstance {
    * unreadable record (§6.3 `sync.idempotency_cache_miss`).
    */
   failNextIdempotencyLookup?(): Promise<void>;
+
+  /** Prune through the pinned window on its next read, after the round's horizon read. */
+  pruneDuringNextCommitRead?(): Promise<void>;
+  /** Hold two post-commit notifications, then deliver them in reverse sequence. */
+  reverseNextCommitNotifications?(): Promise<void>;
 
   close(): Promise<void>;
 }

--- a/packages/conformance/src/drivers/ts-server.ts
+++ b/packages/conformance/src/drivers/ts-server.ts
@@ -237,6 +237,13 @@ class TsServerInstance implements ServerInstance {
   #resolverFailing = false;
   #resolverOutage = false;
   #failNextIdempotencyLookup = false;
+  #pruneDuringNextCommitRead = false;
+  #reversedNotifications:
+    | Array<{
+        partition: string;
+        commit: import('@syncular/server').StoredCommit;
+      }>
+    | undefined;
   /** §6.7: installed per-table write validators (absent ⇒ feature off). */
   #validators: ValidatorRegistry | undefined;
   /** §6.8: installed transaction-scoped whole-commit validator. */
@@ -375,7 +382,18 @@ class TsServerInstance implements ServerInstance {
         }
         return this.#storage.getPushResult(p, c, id);
       },
-      readCommitWindow: (p, q) => this.#storage.readCommitWindow(p, q),
+      readCommitWindow: async (p, q) => {
+        if (this.#pruneDuringNextCommitRead) {
+          this.#pruneDuringNextCommitRead = false;
+          const logEpoch = await this.#storage.getPartitionLogEpoch(p);
+          if (logEpoch === undefined) throw new Error('missing epoch');
+          await this.#storage.pruneCommitsThrough(p, {
+            logEpoch,
+            throughSeq: q.throughSeq,
+          });
+        }
+        return this.#storage.readCommitWindow(p, q);
+      },
       scanRows: (p, q) => this.#storage.scanRows(p, q),
       getClientRecord: (p, c) => this.#storage.getClientRecord(p, c),
       putClientRecord: (p, r) => this.#storage.putClientRecord(p, r),
@@ -422,7 +440,22 @@ class TsServerInstance implements ServerInstance {
       ...(this.#commitValidator !== undefined
         ? { commitValidator: this.#commitValidator }
         : {}),
-      realtime: this.#hub,
+      realtime: {
+        notifyCommit: async (partition, commit) => {
+          const pending = this.#reversedNotifications;
+          if (pending === undefined)
+            return this.#hub.notifyCommit(partition, commit);
+          pending.push({ partition, commit });
+          if (pending.length < 2) return;
+          this.#reversedNotifications = undefined;
+          for (const notification of pending.reverse()) {
+            await this.#hub.notifyCommit(
+              notification.partition,
+              notification.commit,
+            );
+          }
+        },
+      },
     };
   }
 
@@ -813,6 +846,14 @@ class TsServerInstance implements ServerInstance {
     });
   }
 
+  async pruneDuringNextCommitRead(): Promise<void> {
+    this.#pruneDuringNextCommitRead = true;
+  }
+
+  async reverseNextCommitNotifications(): Promise<void> {
+    this.#reversedNotifications = [];
+  }
+
   async failNextIdempotencyLookup(): Promise<void> {
     this.#failNextIdempotencyLookup = true;
   }
@@ -827,6 +868,7 @@ export const tsServerDriver: ServerDriver = {
   capabilities: [
     'backup-restore',
     'idempotency-fault',
+    'concurrent-storage-faults',
     'signed-urls',
     'blobs',
     'blob-presign',

--- a/packages/conformance/src/drivers/ts-server.ts
+++ b/packages/conformance/src/drivers/ts-server.ts
@@ -379,6 +379,8 @@ class TsServerInstance implements ServerInstance {
       scanRows: (p, q) => this.#storage.scanRows(p, q),
       getClientRecord: (p, c) => this.#storage.getClientRecord(p, c),
       putClientRecord: (p, r) => this.#storage.putClientRecord(p, r),
+      updateClientCursor: (p, c, s, t) =>
+        this.#storage.updateClientCursor(p, c, s, t),
       getActiveClientCursorFloor: (p, cutoff) =>
         this.#storage.getActiveClientCursorFloor(p, cutoff),
       listClientCursors: (p) => this.#storage.listClientCursors(p),

--- a/packages/server/src/d1-storage.ts
+++ b/packages/server/src/d1-storage.ts
@@ -856,6 +856,9 @@ export class D1ServerStorage implements ServerStorage {
             this.#db
               .prepare('DELETE FROM sync_row_scopes WHERE tbl=?')
               .bind(tableName),
+            this.#db
+              .prepare('DELETE FROM sync_blob_refs WHERE tbl=?')
+              .bind(tableName),
             this.#db.prepare(dropTableDdl(tableName)),
           ]),
         );
@@ -1583,6 +1586,22 @@ export class D1ServerStorage implements ServerStorage {
         JSON.stringify(record.subscriptions),
         record.updatedAtMs,
       )
+      .run();
+  }
+
+  async updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void> {
+    await this.#db
+      .prepare(
+        `UPDATE sync_clients
+         SET cursor=MAX(cursor, ?), updated_at_ms=MAX(updated_at_ms, ?)
+         WHERE partition=? AND client_id=?`,
+      )
+      .bind(cursor, updatedAtMs, partition, clientId)
       .run();
   }
 

--- a/packages/server/src/postgres-storage.ts
+++ b/packages/server/src/postgres-storage.ts
@@ -986,6 +986,9 @@ export class PostgresServerStorage implements ServerStorage {
           await client.query('DELETE FROM sync_row_scopes WHERE tbl=$1', [
             tableName,
           ]);
+          await client.query('DELETE FROM sync_blob_refs WHERE tbl=$1', [
+            tableName,
+          ]);
           await client.query(dropTableDdl(tableName));
         }
         for (const statement of schemaDdl(
@@ -1673,6 +1676,20 @@ export class PostgresServerStorage implements ServerStorage {
         JSON.stringify(record.subscriptions),
         record.updatedAtMs,
       ],
+    );
+  }
+
+  async updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void> {
+    await this.#exec.query(
+      `UPDATE sync_clients
+       SET cursor=GREATEST(cursor, $3), updated_at_ms=GREATEST(updated_at_ms, $4)
+       WHERE partition=$1 AND client_id=$2`,
+      [partition, clientId, cursor, updatedAtMs],
     );
   }
 

--- a/packages/server/src/pull.ts
+++ b/packages/server/src/pull.ts
@@ -501,6 +501,28 @@ export async function* subscriptionSection(
 
   const token = parseBootstrapToken(sub.bootstrapState, sub.table);
 
+  let commits: StoredCommit[] = [];
+  if (
+    token === undefined &&
+    sub.cursor >= 0 &&
+    sub.cursor >= horizonSeq &&
+    sub.cursor <= maxSeq
+  ) {
+    commits = await ctx.storage.readCommitWindow(ctx.partition, {
+      table: sub.table,
+      scopeFilter: plan.effective,
+      afterSeq: sub.cursor,
+      throughSeq: maxSeq,
+      limitChanges: limits.limitCommits + 1,
+    });
+    // Validate continuity before committing to an active section. A prune
+    // during a paged read can otherwise make an incomplete window look empty.
+    horizonSeq = Math.max(
+      horizonSeq,
+      await ctx.storage.getHorizonSeq(ctx.partition),
+    );
+  }
+
   // §4.6: a cursor behind the horizon (and not resuming a bootstrap)
   // cannot compute deltas — answer `reset` and echo the cursor.
   if (token === undefined && sub.cursor >= 0 && sub.cursor < horizonSeq) {
@@ -574,13 +596,6 @@ export async function* subscriptionSection(
     effectiveScopes: plan.effective,
     bootstrap: false,
   };
-  const commits = await ctx.storage.readCommitWindow(ctx.partition, {
-    table: sub.table,
-    scopeFilter: plan.effective,
-    afterSeq: sub.cursor,
-    throughSeq: maxSeq,
-    limitChanges: limits.limitCommits + 1,
-  });
   let delivered = 0;
   let deliveredCommits = 0;
   let lastDeliveredSeq = sub.cursor;

--- a/packages/server/src/realtime.ts
+++ b/packages/server/src/realtime.ts
@@ -307,6 +307,10 @@ export class RealtimeSession {
     const cursor = (parsed as { cursor?: unknown }).cursor;
     if (typeof cursor !== 'number' || !Number.isSafeInteger(cursor)) return;
     this.cursor = Math.max(this.cursor, cursor);
+    // The client may have caught up through another binding (§8.4). Its ack
+    // proves those commits no longer need socket notifications, so the next
+    // notification must be adjacent to the acknowledged cursor.
+    this.lastKnownSeq = Math.max(this.lastKnownSeq, this.cursor);
     if (this.cursor >= this.lastKnownSeq) this.wakePending = false;
     // §8.2: acks update the client cursor record without an HTTP pull.
     void this.#persistCursor();
@@ -626,16 +630,12 @@ export class RealtimeSession {
 
   async #persistCursor(): Promise<void> {
     try {
-      const record = await this.#storage.getClientRecord(
+      await this.#storage.updateClientCursor(
         this.partition,
         this.clientId,
+        this.cursor,
+        this.#clock(),
       );
-      if (record === undefined) return;
-      await this.#storage.putClientRecord(this.partition, {
-        ...record,
-        cursor: Math.max(record.cursor, this.cursor),
-        updatedAtMs: this.#clock(),
-      });
     } catch {
       // Cursor persistence is best-effort; the next pull repairs it.
     }
@@ -688,8 +688,9 @@ export class RealtimeSession {
     }
   }
 
-  /** Called by the hub for every applied commit, in commitSeq order. */
+  /** Called by the hub for every applied commit notification. */
   deliverCommit(commit: StoredCommit): void {
+    const contiguous = commit.commitSeq === this.lastKnownSeq + 1;
     this.lastKnownSeq = Math.max(this.lastKnownSeq, commit.commitSeq);
     const sections: Array<{
       registration: Registration;
@@ -715,6 +716,14 @@ export class RealtimeSession {
           }),
         );
       if (changes.length > 0) sections.push({ registration, changes });
+    }
+    if (!contiguous) {
+      // Pushes allocate commitSeq under the partition lock but notify after
+      // commit, so racing notifications may arrive out of order. A gap,
+      // duplicate, or regression cannot be a delta: the client would apply
+      // and acknowledge a cursor that does not prove the intervening log.
+      this.sendWake('catchup-required');
+      return;
     }
     if (sections.length === 0) return;
     if (this.#activeRound !== undefined) {
@@ -771,7 +780,7 @@ export class RealtimeSession {
     tagged[0] = REALTIME_TAG_DELTA;
     tagged.set(bytes, 1);
     this.#sendSafe(tagged);
-    this.cursor = commit.commitSeq;
+    this.cursor = Math.max(this.cursor, commit.commitSeq);
     const events = this.#events;
     if (events !== undefined) {
       emitEvent(events, {

--- a/packages/server/src/relational-rows.ts
+++ b/packages/server/src/relational-rows.ts
@@ -205,7 +205,7 @@ export function physicalIndexName(declaredName: string): string {
 
 /**
  * CREATE INDEX IF NOT EXISTS for the table's user-declared indexes. These use
- * the same declared names and columns the client materializes. Cross-table
+ * the declared columns with a leading server partition column. Cross-table
  * index-name uniqueness is the user's schema concern, as it is client-side.
  * Server-side the physical name carries the {@link SYNC_INDEX_PREFIX}
  * ownership marker.
@@ -215,7 +215,7 @@ export function createIndexDdl(table: CompiledTable): string[] {
   if (!table.materialize) return [];
   return table.indexes.map((index) => {
     const unique = index.unique ? 'UNIQUE ' : '';
-    const columns = index.columns
+    const columns = [SYNC_PARTITION_COLUMN, ...index.columns]
       .map((column) => quoteIdent(column))
       .join(', ');
     return `CREATE ${unique}INDEX IF NOT EXISTS ${quoteIdent(physicalIndexName(index.name))} ON ${quoteIdent(table.name)} (${columns})`;

--- a/packages/server/src/sqlite-storage.ts
+++ b/packages/server/src/sqlite-storage.ts
@@ -485,6 +485,9 @@ export class SqliteServerStorage implements ServerStorage {
           this.db
             .query('DELETE FROM sync_row_scopes WHERE tbl=?')
             .run(tableName);
+          this.db
+            .query('DELETE FROM sync_blob_refs WHERE tbl=?')
+            .run(tableName);
           this.db.exec(dropTableDdl(tableName));
         }
         for (const statement of schemaDdl(
@@ -1270,6 +1273,21 @@ export class SqliteServerStorage implements ServerStorage {
         JSON.stringify(record.subscriptions),
         record.updatedAtMs,
       );
+  }
+
+  async updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void> {
+    this.db
+      .query(
+        `UPDATE sync_clients
+         SET cursor=MAX(cursor, ?), updated_at_ms=MAX(updated_at_ms, ?)
+         WHERE partition=? AND client_id=?`,
+      )
+      .run(cursor, updatedAtMs, partition, clientId);
   }
 
   async getActiveClientCursorFloor(

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -560,6 +560,14 @@ export interface ServerStorage {
     clientId: string,
   ): Promise<ClientRecord | undefined>;
   putClientRecord(partition: string, record: ClientRecord): Promise<void>;
+  /** Advance an existing client's ACK cursor and timestamp atomically,
+   * preserving actor, wire version, and subscriptions. Missing records stay absent. */
+  updateClientCursor(
+    partition: string,
+    clientId: string,
+    cursor: number,
+    updatedAtMs: number,
+  ): Promise<void>;
   /** Minimum cursor with updatedAtMs >= cutoff; null when none are active. */
   getActiveClientCursorFloor(
     partition: string,

--- a/packages/server/test/events.test.ts
+++ b/packages/server/test/events.test.ts
@@ -403,6 +403,7 @@ function wrapStorage(
     scanRows: (p, q) => storage.scanRows(p, q),
     getClientRecord: (p, c) => storage.getClientRecord(p, c),
     putClientRecord: (p, r) => storage.putClientRecord(p, r),
+    updateClientCursor: (p, c, s, t) => storage.updateClientCursor(p, c, s, t),
     getActiveClientCursorFloor: (p, cutoff) =>
       storage.getActiveClientCursorFloor(p, cutoff),
     listClientCursors: (p) => storage.listClientCursors(p),

--- a/packages/server/test/horizon.test.ts
+++ b/packages/server/test/horizon.test.ts
@@ -30,6 +30,39 @@ describe('cursor behind the horizon (§4.6)', () => {
     expect(s.end.nextCursor).toBe(1); // echoed unchanged
   });
 
+  for (const pruneAfterRead of [false, true]) {
+    test(`pruning ${pruneAfterRead ? 'after' : 'before'} the window read resets before an active section`, async () => {
+      const t = makeContext();
+      for (let i = 1; i <= 3; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');
+      const read = t.storage.readCommitWindow.bind(t.storage);
+      t.storage.readCommitWindow = async (partition, query) => {
+        const commits = pruneAfterRead
+          ? await read(partition, query)
+          : undefined;
+        const logEpoch = await t.storage.getPartitionLogEpoch(partition);
+        if (logEpoch === undefined) throw new Error('missing epoch');
+        await t.storage.pruneCommitsThrough(partition, {
+          logEpoch,
+          throughSeq: 3,
+        });
+        return commits ?? read(partition, query);
+      };
+      const message = await sync(t, [
+        pullHeader(),
+        subFrame('s1', 'tasks', { project_id: ['p1'] }, 1),
+      ]);
+      const result = section(message, 's1');
+      expect(result.start.status).toBe('reset');
+      expect(result.start.reasonCode).toBe('sync.cursor_expired');
+      expect(result.body).toHaveLength(0);
+      expect(result.end.nextCursor).toBe(1);
+      expect(
+        message.frames.filter((frame) => frame.type === 'ERROR'),
+      ).toHaveLength(0);
+      t.storage.db.close();
+    });
+  }
+
   test('a cursor exactly at the horizon still pulls incrementally (boundary)', async () => {
     const t = makeContext();
     for (let i = 1; i <= 3; i++) await seedTask(t, `c${i}`, `t${i}`, 'p1');

--- a/packages/server/test/realtime.test.ts
+++ b/packages/server/test/realtime.test.ts
@@ -59,14 +59,6 @@ function makeHub(t: TestContext, maxDeltaBytes?: number): RealtimeHub {
   return hub;
 }
 
-async function waitFor(check: () => Promise<boolean>): Promise<void> {
-  for (let i = 0; i < 200; i++) {
-    if (await check()) return;
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  throw new Error('condition not reached');
-}
-
 describe('handshake (§8.1)', () => {
   test('a client that never pulled gets hello with requiresSync and no deltas', async () => {
     const t = makeContext();
@@ -426,19 +418,37 @@ describe('delta delivery (§8.2)', () => {
     expect(wire.binaries).toHaveLength(1);
   });
 
-  test('acks update the client cursor record without an HTTP pull (§8.2)', async () => {
+  test('an ACK racing a subscription replacement updates only the cursor and timestamp', async () => {
     const t = makeContext();
     const hub = makeHub(t);
-    const { wire, session } = await connectedSession(t, hub);
-    await sync(t, [
-      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
-    ]);
-    expect(wire.binaries).toHaveLength(1);
-    const latest = await t.storage.getMaxCommitSeq('part-1');
-    session.handleMessage(JSON.stringify({ type: 'ack', cursor: latest }));
-    await waitFor(async () => {
-      const record = await t.storage.getClientRecord('part-1', 'client-1');
-      return record?.cursor === latest;
+    const { session } = await connectedSession(t, hub);
+    const original = await t.storage.getClientRecord('part-1', 'client-1');
+    if (original === undefined) throw new Error('missing client');
+    const update = t.storage.updateClientCursor.bind(t.storage);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let persisted!: Promise<void>;
+    t.storage.updateClientCursor = (...args) => {
+      persisted = gate.then(() => update(...args));
+      return persisted;
+    };
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 10 }));
+    const replacement = {
+      ...original,
+      cursor: 4,
+      subscriptions: [
+        { id: 'new', table: 'tasks', scopes: { project_id: ['p2'] } },
+      ],
+    };
+    await t.storage.putClientRecord('part-1', replacement);
+    release();
+    await persisted;
+    expect(await t.storage.getClientRecord('part-1', 'client-1')).toEqual({
+      ...replacement,
+      cursor: 10,
+      updatedAtMs: t.now.ms,
     });
   });
 

--- a/packages/server/test/realtime.test.ts
+++ b/packages/server/test/realtime.test.ts
@@ -10,7 +10,11 @@ import {
   type ScopeMap,
   type SubStartFrame,
 } from '@syncular/core';
-import { createRealtimeHub, type RealtimeHub } from '@syncular/server';
+import {
+  createRealtimeHub,
+  type RealtimeHub,
+  type StoredCommit,
+} from '@syncular/server';
 import {
   makeContext,
   pullHeader,
@@ -171,6 +175,184 @@ describe('delta delivery (§8.2)', () => {
     expect(end?.type === 'SUB_END' && end.nextCursor).toBe(
       commit?.commitSeq ?? -1,
     );
+  });
+
+  test('out-of-order commit notifications wake before sending a gap delta', async () => {
+    const t = makeContext();
+    await sync(t, [
+      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+    ]);
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+    expect(session.cursor).toBe(1);
+    expect(session.lastKnownSeq).toBe(1);
+
+    const captured: StoredCommit[] = [];
+    Object.assign(t.ctx, {
+      realtime: {
+        notifyCommit: (_partition: string, commit: StoredCommit) => {
+          captured.push(commit);
+        },
+      },
+    });
+    await sync(
+      t,
+      [pushCommit('c2', [upsert('tasks', 't2', taskRow('t2', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    await sync(
+      t,
+      [pushCommit('c3', [upsert('tasks', 't3', taskRow('t3', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    expect(captured.map((commit) => commit.commitSeq)).toEqual([2, 3]);
+
+    await hub.notifyCommit('part-1', captured[1]!);
+    await hub.notifyCommit('part-1', captured[0]!);
+
+    expect(wire.binaries).toHaveLength(0);
+    const wakes = wire.texts.slice(1).map((text) => {
+      const parsed = parseRealtimeServerEvent(text);
+      if (!parsed.known || parsed.event.event !== 'sync') {
+        throw new Error('expected catch-up wake');
+      }
+      return parsed.event.data;
+    });
+    expect(wakes.map((wake) => wake.reason)).toEqual([
+      'catchup-required',
+      'catchup-required',
+    ]);
+    expect(wakes.map((wake) => wake.cursor)).toEqual([3, 3]);
+    expect(session.cursor).toBe(1);
+    expect(session.lastKnownSeq).toBe(3);
+    expect(session.wakePending).toBe(true);
+  });
+
+  test('a catch-up ack advances the notification base before deltas resume', async () => {
+    const t = makeContext();
+    await sync(t, [
+      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+    ]);
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+
+    const captured: StoredCommit[] = [];
+    Object.assign(t.ctx, {
+      realtime: {
+        notifyCommit: (_partition: string, commit: StoredCommit) => {
+          captured.push(commit);
+        },
+      },
+    });
+    await sync(
+      t,
+      [pushCommit('c2', [upsert('tasks', 't2', taskRow('t2', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    await sync(
+      t,
+      [pushCommit('c3', [upsert('tasks', 't3', taskRow('t3', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    expect(captured.map((commit) => commit.commitSeq)).toEqual([2, 3]);
+
+    // The shared client loop caught up through a pull on another binding.
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 3 }));
+    expect(session.lastKnownSeq).toBe(3);
+    Object.assign(t.ctx, { realtime: hub });
+
+    await sync(
+      t,
+      [pushCommit('c4', [upsert('tasks', 't4', taskRow('t4', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    expect(wire.binaries).toHaveLength(1);
+    expect(session.cursor).toBe(4);
+    expect(session.lastKnownSeq).toBe(4);
+  });
+
+  test('duplicate and regressive notifications wake from an unsuppressed session', async () => {
+    const t = makeContext();
+    await sync(t, [
+      pushCommit('c1', [upsert('tasks', 't1', taskRow('t1', 'p1'))]),
+      pullHeader(),
+      subFrame('s1', 'tasks', { project_id: ['p1'] }, 0),
+    ]);
+    const hub = makeHub(t);
+    const wire = makeWire();
+    const session = await hub.connect({
+      partition: 'part-1',
+      actorId: 'actor-1',
+      clientId: 'client-1',
+      send: wire.send,
+    });
+
+    const captured: StoredCommit[] = [];
+    Object.assign(t.ctx, {
+      realtime: {
+        notifyCommit: (_partition: string, commit: StoredCommit) => {
+          captured.push(commit);
+        },
+      },
+    });
+    await sync(
+      t,
+      [pushCommit('c2', [upsert('tasks', 't2', taskRow('t2', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    await sync(
+      t,
+      [pushCommit('c3', [upsert('tasks', 't3', taskRow('t3', 'p1'))])],
+      { clientId: 'other-client' },
+    );
+    const second = captured[0]!;
+    const third = captured[1]!;
+
+    await hub.notifyCommit('part-1', second);
+    expect(wire.binaries).toHaveLength(1);
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 2 }));
+    await hub.notifyCommit('part-1', second);
+    expect(wire.binaries).toHaveLength(1);
+    const duplicateWake = parseRealtimeServerEvent(wire.texts[1] ?? '');
+    if (!duplicateWake.known || duplicateWake.event.event !== 'sync') {
+      throw new Error('expected duplicate notification wake');
+    }
+    expect(duplicateWake.event.data.reason).toBe('catchup-required');
+    expect(duplicateWake.event.data.cursor).toBe(2);
+    expect(session.lastKnownSeq).toBe(2);
+    expect(session.cursor).toBe(2);
+
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 2 }));
+    await hub.notifyCommit('part-1', third);
+    expect(wire.binaries).toHaveLength(2);
+    session.handleMessage(JSON.stringify({ type: 'ack', cursor: 3 }));
+    await hub.notifyCommit('part-1', second);
+    expect(wire.binaries).toHaveLength(2);
+    const regressionWake = parseRealtimeServerEvent(wire.texts[2] ?? '');
+    if (!regressionWake.known || regressionWake.event.event !== 'sync') {
+      throw new Error('expected regressive notification wake');
+    }
+    expect(regressionWake.event.data.reason).toBe('catchup-required');
+    expect(regressionWake.event.data.cursor).toBe(3);
+    expect(session.lastKnownSeq).toBe(3);
+    expect(session.cursor).toBe(3);
+    expect(wire.texts).toHaveLength(3);
   });
 
   test('a commit outside the registered scopes produces nothing', async () => {

--- a/packages/server/test/relational-rows.test.ts
+++ b/packages/server/test/relational-rows.test.ts
@@ -172,6 +172,60 @@ async function upsert(
   await tx.commit();
 }
 
+describe('partition-scoped declared unique indexes', () => {
+  for (const backend of ['sqlite', 'postgres', 'd1'] as const) {
+    test(`${backend}: a schema bump repairs legacy indexes without changing row payloads`, async () => {
+      const pg = backend === 'postgres' ? await PGlite.create() : undefined;
+      const d1 = backend === 'd1' ? new D1DatabaseDouble() : undefined;
+      const storage =
+        pg !== undefined
+          ? new PostgresServerStorage(pgliteExecutor(pg))
+          : d1 !== undefined
+            ? new D1ServerStorage(d1)
+            : new SqliteServerStorage();
+      const exec = async (sql: string): Promise<void> => {
+        if (pg !== undefined) {
+          await pg.exec(sql);
+        } else if (d1 !== undefined) {
+          await d1.prepare(sql).run();
+        } else if (storage instanceof SqliteServerStorage) {
+          storage.db.exec(sql);
+        }
+      };
+      await storage.ensureSchema(compileSchema(SCHEMA));
+      await exec('DROP INDEX sync_ix_tasks_by_project_title');
+      await exec(
+        'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks(project_id, title)',
+      );
+      await exec('CREATE INDEX operator_title_index ON tasks(title)');
+      const row = taskRow('t1', 'p1', 'same-title');
+      await upsert(storage, PARTITION, 'tasks', row);
+      await storage.ensureSchema(compileSchema({ ...SCHEMA, version: 2 }));
+      await upsert(storage, 'part-2', 'tasks', row);
+      expect((await storage.getRow(PARTITION, 'tasks', 't1'))?.payload).toEqual(
+        row.payload,
+      );
+      expect((await storage.getRow('part-2', 'tasks', 't1'))?.payload).toEqual(
+        row.payload,
+      );
+      const tx = await storage.begin(PARTITION);
+      try {
+        await tx.upsertRow('tasks', taskRow('t2', 'p1', 'same-title'));
+        // D1 applies buffered writes at commit.
+        await tx.commit();
+        throw new Error('write unexpectedly succeeded');
+      } catch (error) {
+        expect(error).toMatchObject({ name: 'StorageConstraintError' });
+        await tx.rollback();
+      }
+      // Operator indexes survive the same existing migration path.
+      await exec('DROP INDEX operator_title_index');
+      if (pg !== undefined) await pg.close();
+      else if (storage instanceof SqliteServerStorage) storage.db.close();
+    });
+  }
+});
+
 // --- 4. the row-codec round-trip invariant (per column type) ---------------
 
 describe('row-codec round-trip invariant (encode∘decode = id)', () => {
@@ -469,7 +523,7 @@ describe('server-side schema migration (the subset)', () => {
       )
       .all()
       .map((column) => column.name);
-    expect(columns).toEqual(['project_id', 'title']);
+    expect(columns).toEqual(['_sync_partition', 'project_id', 'title']);
   });
 
   test('a version bump replaces declared indexes on Postgres', async () => {
@@ -486,7 +540,9 @@ describe('server-side schema migration (the subset)', () => {
     expect(indexes.rows[0]?.indexdef).toContain(
       'UNIQUE INDEX sync_ix_tasks_by_title',
     );
-    expect(indexes.rows[0]?.indexdef).toContain('(project_id, title)');
+    expect(indexes.rows[0]?.indexdef).toContain(
+      '(_sync_partition, project_id, title)',
+    );
   });
 
   test('a version bump replaces declared indexes on D1', async () => {
@@ -505,6 +561,7 @@ describe('server-side schema migration (the subset)', () => {
       .prepare('PRAGMA index_info("sync_ix_tasks_by_title")')
       .all<{ name: string }>();
     expect(columns.results.map((column) => column.name)).toEqual([
+      '_sync_partition',
       'project_id',
       'title',
     ]);
@@ -614,6 +671,10 @@ describe('server-side schema migration (the subset)', () => {
     await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'retired'));
     await upsert(storage, PARTITION, 'projects', projectRow('p1', 'kept'));
 
+    const refs = await storage.begin(PARTITION);
+    await refs.setBlobRefs!('tasks', 't1', ['retired-blob']);
+    await refs.setBlobRefs!('projects', 'p1', ['kept-blob']);
+    await refs.commit();
     const v2: ServerSchema = {
       version: 2,
       tables: [SCHEMA.tables[1]!],
@@ -633,6 +694,12 @@ describe('server-side schema migration (the subset)', () => {
       .get('tasks');
     expect(staleScopes?.n).toBe(0);
     expect(await storage.getRow(PARTITION, 'projects', 'p1')).toBeDefined();
+    expect(await storage.listReferencedBlobIds(PARTITION)).toEqual([
+      'kept-blob',
+    ]);
+    expect(
+      await storage.listRowsReferencingBlob(PARTITION, 'retired-blob'),
+    ).toEqual([]);
   });
 
   test('postgres retires the relational current-row table atomically', async () => {
@@ -640,6 +707,10 @@ describe('server-side schema migration (the subset)', () => {
     const storage = new PostgresServerStorage(pgliteExecutor(db));
     await storage.ensureSchema(compileSchema(SCHEMA));
     await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'retired'));
+    const refs = await storage.begin(PARTITION);
+    await refs.setBlobRefs!('tasks', 't1', ['retired-blob']);
+    await refs.setBlobRefs!('projects', 'p1', ['kept-blob']);
+    await refs.commit();
     await storage.ensureSchema(
       compileSchema({ version: 2, tables: [SCHEMA.tables[1]!] }),
     );
@@ -652,6 +723,12 @@ describe('server-side schema migration (the subset)', () => {
       "SELECT count(*) AS n FROM sync_row_scopes WHERE tbl='tasks'",
     );
     expect(Number(scopes.rows[0]?.n)).toBe(0);
+    expect(await storage.listReferencedBlobIds(PARTITION)).toEqual([
+      'kept-blob',
+    ]);
+    expect(
+      await storage.listRowsReferencingBlob(PARTITION, 'retired-blob'),
+    ).toEqual([]);
   });
 
   test('D1 retires the relational current-row table idempotently', async () => {
@@ -661,6 +738,10 @@ describe('server-side schema migration (the subset)', () => {
     const tx = await storage.begin(PARTITION);
     await tx.upsertRow('tasks', taskRow('t1', 'p1', 'retired'));
     await tx.commit();
+    const refs = await storage.begin(PARTITION);
+    await refs.setBlobRefs!('tasks', 't1', ['retired-blob']);
+    await refs.setBlobRefs!('projects', 'p1', ['kept-blob']);
+    await refs.commit();
     await storage.ensureSchema(
       compileSchema({ version: 2, tables: [SCHEMA.tables[1]!] }),
     );
@@ -676,6 +757,12 @@ describe('server-side schema migration (the subset)', () => {
       .bind('tasks')
       .first<{ n: number }>();
     expect(scopes?.n).toBe(0);
+    expect(await storage.listReferencedBlobIds(PARTITION)).toEqual([
+      'kept-blob',
+    ]);
+    expect(
+      await storage.listRowsReferencingBlob(PARTITION, 'retired-blob'),
+    ).toEqual([]);
   });
 
   test('an older server refuses a newer database', async () => {

--- a/packages/server/test/storage-contract.ts
+++ b/packages/server/test/storage-contract.ts
@@ -1293,6 +1293,39 @@ export function runStorageContract(
       );
     });
 
+    test('full subscription replacement can lower the retention floor after an ACK', async () => {
+      const storage = await make();
+      const original: ClientRecord = {
+        clientId: 'changed-subscriptions',
+        actorId: 'actor-1',
+        wireVersion: 2,
+        cursor: 10,
+        updatedAtMs: NOW,
+        subscriptions: [
+          { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      };
+      await storage.putClientRecord(PARTITION, original);
+      await storage.updateClientCursor(
+        PARTITION,
+        original.clientId,
+        20,
+        NOW + 1,
+      );
+      const replacement: ClientRecord = {
+        ...original,
+        cursor: 2,
+        updatedAtMs: NOW + 2,
+        subscriptions: [
+          { id: 'new', table: 'tasks', scopes: { project_id: ['p2'] } },
+        ],
+      };
+      await storage.putClientRecord(PARTITION, replacement);
+      expect(
+        await storage.getClientRecord(PARTITION, original.clientId),
+      ).toEqual(replacement);
+    });
+
     // --- Blob reference index (§5.9.4, optional methods) ---
 
     test('setBlobRefs / listRowsReferencingBlob / listReferencedBlobIds round-trip', async () => {

--- a/packages/server/test/storage-contract.ts
+++ b/packages/server/test/storage-contract.ts
@@ -1262,6 +1262,37 @@ export function runStorageContract(
       expect(updated?.cursor).toBe(99);
     });
 
+    test('cursor-only updates are absent-safe and monotonic', async () => {
+      const storage = await make();
+
+      await storage.updateClientCursor(PARTITION, 'missing', 8, NOW + 8);
+      expect(
+        await storage.getClientRecord(PARTITION, 'missing'),
+      ).toBeUndefined();
+
+      const record: ClientRecord = {
+        clientId: 'cursor-only',
+        actorId: 'actor-old',
+        wireVersion: 1,
+        cursor: 2,
+        updatedAtMs: NOW,
+        subscriptions: [
+          { id: 'old', table: 'tasks', scopes: { project_id: ['p1'] } },
+        ],
+      };
+      await storage.putClientRecord(PARTITION, record);
+      await storage.updateClientCursor(PARTITION, record.clientId, 9, NOW + 20);
+      await storage.updateClientCursor(PARTITION, record.clientId, 4, NOW + 10);
+
+      expect(await storage.getClientRecord(PARTITION, record.clientId)).toEqual(
+        {
+          ...record,
+          cursor: 9,
+          updatedAtMs: NOW + 20,
+        },
+      );
+    });
+
     // --- Blob reference index (§5.9.4, optional methods) ---
 
     test('setBlobRefs / listRowsReferencingBlob / listReferencedBlobIds round-trip', async () => {

--- a/packages/web-client/test/helpers.ts
+++ b/packages/web-client/test/helpers.ts
@@ -144,6 +144,7 @@ function wrapStorage(
     scanRows: (p, q) => storage.scanRows(p, q),
     getClientRecord: (p, c) => storage.getClientRecord(p, c),
     putClientRecord: (p, r) => storage.putClientRecord(p, r),
+    updateClientCursor: (p, c, s, t) => storage.updateClientCursor(p, c, s, t),
     getActiveClientCursorFloor: (p, cutoff) =>
       storage.getActiveClientCursorFloor(p, cutoff),
     listClientCursors: (p) => storage.listClientCursors(p),


### PR DESCRIPTION
Pruning during an incremental read could advance a client over missing history, and post-commit notifications could send realtime deltas out of sequence. This integrates focused fixes from Chase Pursley's #47 against current main.

- Retain Chase's realtime ordering checks, acknowledgment watermark alignment, atomic cursor-only storage updates, and retired-table blob-reference cleanup. His retained contribution has its own authored commit.
- Read and verify incremental history before starting an active section. An expired cursor follows the specified subscription reset and bootstrap path.
- Prefix declared server indexes with the partition column. Existing deployments must increment their application schema version and regenerate the schema to rebuild old indexes through the existing migration path. Preserve operator and constraint-owned indexes.
- Preserve authoritative full-record cursor replacement when subscriptions change. The blanket monotonic full-record update proposed in #47 would prevent lowering the retention floor for a changed subscription set.
- Extend the shared catalog to 106 scenarios, including pruning during a pull and reversed realtime notifications; run it with both TypeScript and Rust clients. Replace the ACK test's timer polling with deterministic completion.

The pruning writer changes are already covered by 0.16.1. This PR excludes the proposed D1 migration-claim framework, same-version index reconciliation, PostgreSQL query rewrite, and the demo adapter change needed by that migration framework. D1 needs a separately reviewed invocation budget, checkpoint protocol, and migration traffic fence, tracked in #55. The PostgreSQL rewrite needs reproducible plans and measurements before adoption.

Validation: root `bun run check` (typecheck, lint/format, unused-code checks, main and isolated tests, Node runtime contracts), both client conformance pairings, and docs/demo builds. Storage regressions run on SQLite, PGlite, and the D1 double; no deployed D1 migration was exercised.
