### PR TITLE
Resume D1 schema upgrades across Worker requests

### DIFF
--- a/apps/demo/src/frontend/server-worker.test.ts
+++ b/apps/demo/src/frontend/server-worker.test.ts
@@ -6,6 +6,7 @@ interface WorkerMessage {
   readonly ok?: boolean;
   readonly status?: number;
   readonly body?: {
+    readonly row?: { readonly exists: boolean; readonly serverVersion: number };
     readonly horizon?: { readonly maxCommitSeq: number };
   };
   readonly error?: { readonly code: string; readonly message: string };
@@ -14,6 +15,7 @@ interface WorkerMessage {
 test('embedded server seeds before serving its admin routes', async () => {
   const worker = new Worker(new URL('./server-worker.ts', import.meta.url));
   try {
+    let horizon: WorkerMessage | undefined;
     const response = await new Promise<WorkerMessage>((resolve, reject) => {
       worker.onerror = (event) => reject(event.error);
       worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
@@ -27,13 +29,24 @@ test('embedded server seeds before serving its admin routes', async () => {
         } else if (message.kind === 'ready') {
           worker.postMessage({ kind: 'admin', id: 1, path: '/horizon' });
         } else if (message.kind === 'result' && message.id === 1) {
+          horizon = message;
+          worker.postMessage({
+            kind: 'admin',
+            id: 2,
+            path: '/rows/todos/seed-1',
+          });
+        } else if (message.kind === 'result' && message.id === 2) {
           resolve(message);
         }
       };
     });
     expect(response.ok).toBe(true);
     expect(response.status).toBe(200);
-    expect(response.body?.horizon?.maxCommitSeq).toBe(1);
+    expect(horizon?.body?.horizon?.maxCommitSeq).toBe(1);
+    expect(response.body?.row).toMatchObject({
+      exists: true,
+      serverVersion: 1,
+    });
   } finally {
     worker.terminate();
   }

--- a/apps/demo/src/frontend/server-worker.ts
+++ b/apps/demo/src/frontend/server-worker.ts
@@ -70,10 +70,9 @@ function d1OverWasm(db: WasmDb): D1Database {
         params.length > 0 ? params : undefined,
       ) as T[],
     }),
-    run: async () => {
-      db.exec({ sql, ...(params.length > 0 ? { bind: params } : {}) });
-      return {};
-    },
+    run: async () => ({
+      results: db.selectObjects(sql, params.length > 0 ? params : undefined),
+    }),
   });
   return {
     prepare: (sql) => statement(sql, []),

--- a/apps/docs/src/changelog.mjs
+++ b/apps/docs/src/changelog.mjs
@@ -17,6 +17,17 @@
 export const changelog = [
   {
     date: '2026-09-05',
+    title: 'D1 schema upgrades resume across requests',
+    body: 'D1ServerStorage.migrateSchema limits statements per invocation and saves row-rewrite progress. Interrupted upgrades resume with the same schema, and competing requests cannot apply the same batch twice. The storage rejects row reads and transaction commits until migration finishes. Run migration requests before admitting sync traffic; ensureSchema reports when another invocation is needed.',
+    links: [
+      {
+        href: '/server-workers/#schema-migration',
+        label: 'D1 migration setup',
+      },
+    ],
+  },
+  {
+    date: '2026-09-05',
     title: 'Concurrent pull recovery and partition-scoped server indexes',
     body: 'Pulls reset before emitting an active section when pruning crosses their commit-window read. Realtime notifications that break sequence trigger catch-up, and acknowledgment persistence preserves concurrent subscription updates. Declared server indexes include the partition column; existing databases require an application schema-version bump to rebuild them. Table retirement removes stale blob references. Includes focused contributions from Chase Pursley in PR #47.',
     links: [

--- a/apps/docs/src/content/server-storage.md
+++ b/apps/docs/src/content/server-storage.md
@@ -35,9 +35,9 @@ and constraint-owned indexes remain outside the rebuild set.
 Removing a table in a schema migration also deletes its blob references. References
 from retained tables continue to protect their blobs from garbage collection.
 
-D1 schema migration still requires a separate redesign for invocation budgets and
-concurrent migration fencing. This change does not introduce the proposed durable
-migration-claim framework from PR #47.
+D1 upgrades save progress between Worker invocations. Run
+`D1ServerStorage.migrateSchema` until it returns `complete: true` before admitting
+traffic. See [D1 schema migration](/server-workers/#schema-migration).
 
 ## Choosing a database
 

--- a/apps/docs/src/content/server-workers.md
+++ b/apps/docs/src/content/server-workers.md
@@ -84,17 +84,55 @@ so the storage executes reads immediately and **buffers** writes, flushing
 them as one atomic batch at commit. A rejected op rolls back by never
 flushing.
 
-It does not apply DDL on construction (a cold request must never race a
-schema apply). Generate the migration SQL from `sqliteDdlStatements()`
-(exported from `@syncular/server`) into a `migrations/` file, then:
+### Schema migration
 
-```sh
-wrangler d1 create syncular
-wrangler d1 migrations apply syncular
+Call `D1ServerStorage.migrateSchema(compileSchema(schema))` from an authenticated
+maintenance handler before admitting sync traffic. It creates the core tables,
+applies application DDL, and rewrites stored rows. Each call saves its progress
+and returns `{ complete, statementsExecuted }`.
+
+```ts
+import { compileSchema, D1ServerStorage } from '@syncular/server';
+import { schema } from './syncular.generated';
+
+// Inside your authenticated maintenance handler:
+const storage = new D1ServerStorage(env.DB);
+const result = await storage.migrateSchema(compileSchema(schema), {
+  maxStatements: 40,
+});
+return Response.json(result, { status: result.complete ? 200 : 202 });
 ```
 
-The generated migration must include `sync_reactions` before configuring a
-`reactionPlanner`. Planned records join the source commit's atomic batch.
+Send another request after a `202` response. Run one migration call per Worker
+invocation; a loop or `waitUntil` in the same invocation shares its query limit.
+`maxStatements` defaults to 50 and accepts integers from 10 through 1000. It
+counts the statements issued by this call, including progress tracking. Leave
+room for other D1 queries in the invocation. Cloudflare allows 50 queries on Free
+and 1000 on Paid; see [D1 limits](https://developers.cloudflare.com/d1/platform/limits/).
+A row batch rewrites at most 32 rows. Each individual DDL statement must still
+finish within D1's time limit; this budget cannot split an index build.
+
+Retry the same schema after an interrupted request. The storage commits each
+batch and its progress together, and competing requests cannot apply the same
+batch twice. An unfinished migration rejects a different target schema with
+`sync.storage.schema_migration_conflict`. Keep the target schema available until
+the migration completes.
+
+The storage rejects application row reads and transaction commits while a
+migration is pending. A storage instance using an older schema remains unusable
+after completion. Each protected read or commit adds one guard statement to its
+D1 batch. Drain Workers running Syncular versions without these checks
+before starting the first upgrade with this API. Direct SQL access must observe
+the same maintenance window.
+
+`ensureSchema` runs one step with the default budget. It throws
+`sync.storage.schema_migration_pending` if more work remains;
+`ensureSyncServerReady` wraps this as `sync.schema_not_ready` with the original
+error in `cause`. Finish the maintenance requests before calling the readiness
+helper to admit traffic.
+
+`migrateSchema` creates `sync_reactions` before completing. Planned records join
+the source commit's atomic batch.
 `ReactionRunner` claims work with one atomic write statement and can be driven
 from a scheduled Worker event or Durable Object alarm. D1 statement and
 invocation limits apply to the source batch and delivery passes; see

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -743,6 +743,27 @@ application-table star projections.
 
 ---
 
+#### D1 schema readiness
+
+A D1 schema upgrade MUST save row-rewrite progress in the same atomic batch as
+those rewrites. A resumed upgrade MUST decode only rows after that checkpoint
+using the previous schema layout. The published schema version advances only
+after all DDL, rewrites, and retired-table cleanup finish.
+
+Each call to `D1ServerStorage.migrateSchema` has a statement budget, including
+metadata reads, DDL, guards, and checkpoint writes. The host MUST run at most one
+migration step per Worker invocation and start another invocation when the result
+has `complete: false`. `ensureSchema` performs one default-budget step and throws
+`sync.storage.schema_migration_pending` when more work remains.
+
+Concurrent migration steps MUST compare their saved progress inside the batch
+that changes rows or DDL. A stale step changes nothing. A different target schema
+cannot take over an unfinished upgrade. Application row reads and transaction
+commits MUST check the migration claim and published schema in the same D1 batch
+as the operation. An unfinished upgrade or a changed schema rejects the operation;
+no mixed-layout payload reaches a client. These are host readiness failures and do
+not add a wire error or change either client's recovery protocol.
+
 ## 3. Scopes and authorization
 
 Scopes are the crown jewels of the design. Scope values are always

--- a/packages/server-workers/README.md
+++ b/packages/server-workers/README.md
@@ -101,21 +101,23 @@ See `wrangler.toml.example` for the binding config.
 
 ## Schema migration (D1)
 
-`D1ServerStorage` does **not** apply its DDL on construction (a cold request
-must never race a schema apply). Apply it once with wrangler. Generate the
-migration SQL from `sqliteDdlStatements()` (exported from `@syncular/server`)
-into a `migrations/` file, then:
+Run `storage.migrateSchema(compileSchema(schema))` from an authenticated
+maintenance handler before admitting sync traffic. The method creates core
+and application tables and rewrites stored rows. It returns
+`{ complete, statementsExecuted }`; call it again in a new Worker invocation
+when `complete` is false.
 
-```sh
-wrangler d1 create syncular
-wrangler d1 migrations apply syncular
-```
+Each call defaults to 50 statements. Set `{ maxStatements: 40 }` to leave
+room for other queries, or choose another integer from 10 through 1000 for
+your D1 plan. Run at most one call per invocation. Progress and row updates
+commit together, so interrupted requests can resume with the same schema.
+The storage rejects row reads and transaction commits during migration.
 
-The schema is plain SQLite DDL (shared with `bun:sqlite` via
-`sqlite-dialect.ts`), so it is portable across the two SQLite-family
-storages. Regenerate and apply a migration when upgrading Syncular adds a core
-table. The durable reaction queue uses `sync_reactions`; a Worker running a
-reaction planner or runner fails closed if that migration is absent.
+`ensureSchema` performs one step and throws
+`sync.storage.schema_migration_pending` when another invocation is needed.
+Drain older Syncular deployments before starting an upgrade: they do not
+check the migration state. See [the migration guide](https://syncular.dev/server-workers/#schema-migration)
+for a maintenance handler and the remaining D1 limits.
 
 ## Storage: D1 (`D1ServerStorage`)
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -110,6 +110,11 @@ Log the cause for operators and stop startup. Do not catch readiness errors in
 authentication or convert them to a 401; request-time schema checks are only a
 defensive fallback.
 
+For D1, finish `storage.migrateSchema(compileSchema(schema))` across separate
+Worker invocations before admitting traffic. Each call returns `complete` and
+`statementsExecuted`; the default budget is 50 statements. See
+[D1 schema migration](https://syncular.dev/server-workers/#schema-migration).
+
 After restoring an authoritative database, keep traffic stopped and call
 `rotatePartitionLogEpoch({ storage, partition })` for every restored
 partition. The rotation clears stale client cursors and requires version 2

--- a/packages/server/src/d1-storage.ts
+++ b/packages/server/src/d1-storage.ts
@@ -49,6 +49,7 @@ import {
 } from './authoritative-query';
 import { syncError } from './errors';
 import {
+  assertAppendOnlyMigration,
   commitWindowPageSql,
   deleteRowSql,
   dropTableDdl,
@@ -205,7 +206,7 @@ type PendingRow =
     };
 
 class D1Transaction implements StorageTransaction {
-  readonly #db: D1Database;
+  readonly #db: Pick<D1Database, 'prepare' | 'batch'>;
   readonly #partition: string;
   readonly #resolveTable: (name: string) => CompiledTable;
   readonly #pushApplySerialized: boolean;
@@ -233,7 +234,7 @@ class D1Transaction implements StorageTransaction {
   readonly #pending = new Map<string, PendingRow>();
 
   constructor(
-    db: D1Database,
+    db: Pick<D1Database, 'prepare' | 'batch'>,
     partition: string,
     resolveTable: (name: string) => CompiledTable,
     pushApplySerialized: boolean,
@@ -737,6 +738,23 @@ export interface D1ServerStorageOptions {
   readonly commitValidationSerialized?: boolean;
 }
 
+interface D1MigrationState {
+  phase: 'core' | 'prepare' | 'ddl' | 'rewrite';
+  offset: number;
+  columns: Record<string, string[]>;
+  indexes: Record<string, string[]>;
+  ddl: string[];
+  rewrites: Array<{ table: string; oldLayout?: readonly StoredColumnLayout[] }>;
+  afterPartition: string;
+  afterRowId: string;
+}
+
+interface D1MigrationClaim {
+  target: string;
+  source_layouts: string;
+  state: string;
+}
+
 export class D1ServerStorage implements ServerStorage {
   readonly #db: D1Database;
   readonly #pushApplySerialized: boolean;
@@ -778,100 +796,480 @@ export class D1ServerStorage implements ServerStorage {
   }
 
   async ensureSchema(schema: CompiledSchema): Promise<void> {
-    // Memoized fast path: same instance, same schema version. D1 storages
-    // are typically constructed per request — a fresh instance pays exactly
-    // one marker read below when the version already matches.
-    if (this.#schemaVersion === schema.version) return;
-    for (const table of schema.tables.values()) {
-      const bindCount = tableColumnNames(table).length;
-      if (bindCount > D1_MAX_BIND_PARAMS) {
-        throw new Error(
-          `table ${JSON.stringify(table.name)} needs ${bindCount} bound parameters per upsert; D1 caps statements at ${D1_MAX_BIND_PARAMS}`,
-        );
+    if (this.#schemaVersion === schema.version) {
+      await this.#schemaDatabase().batch([]);
+      return;
+    }
+    if (!(await this.migrateSchema(schema)).complete) {
+      throw new StorageQueryError('sync.storage.schema_migration_pending');
+    }
+  }
+
+  /** Run once per Worker invocation. Resume an incomplete result in another invocation. */
+  async migrateSchema(
+    schema: CompiledSchema,
+    options: { readonly maxStatements?: number } = {},
+  ): Promise<{
+    readonly complete: boolean;
+    readonly statementsExecuted: number;
+  }> {
+    const maxStatements = options.maxStatements ?? 50;
+    if (
+      !Number.isInteger(maxStatements) ||
+      maxStatements < 10 ||
+      maxStatements > 1000
+    ) {
+      throw new StorageQueryError('sync.storage.invalid_migration_budget');
+    }
+    const tables = [...schema.tables.values()].sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
+    for (const table of tables) {
+      if (tableColumnNames(table).length > D1_MAX_BIND_PARAMS) {
+        throw new Error('D1 caps statements at 100 bound parameters');
       }
     }
-    await this.#db.exec(`${SCHEMA_META_DDL_SQLITE.replace(/\s+/g, ' ')};`);
-    const marker = await this.#db
-      .prepare(
+    const target = JSON.stringify({
+      version: schema.version,
+      tables: tables.map((table) => ({
+        name: table.name,
+        columns: table.columns,
+        primaryKeyIndex: table.primaryKeyIndex,
+        materialize: table.materialize,
+        indexes: table.indexes,
+        scopes: table.scopePatterns,
+      })),
+    });
+    let statementsExecuted = 0;
+    const read = async <T>(
+      statement: D1PreparedStatement,
+    ): Promise<T | null> => {
+      statementsExecuted++;
+      return statement.first<T>();
+    };
+    const batch = async (
+      statements: D1PreparedStatement[],
+    ): Promise<unknown[]> => {
+      statementsExecuted += statements.length;
+      return this.#db.batch(statements);
+    };
+    await batch([
+      this.#db.prepare(SCHEMA_META_DDL_SQLITE),
+      this.#db.prepare(`CREATE TABLE IF NOT EXISTS sync_schema_migration(
+  id INTEGER PRIMARY KEY CHECK(id=1),
+  target TEXT NOT NULL,
+  source_layouts TEXT NOT NULL,
+  state TEXT NOT NULL
+)`),
+    ]);
+    const marker = await read<{ schema_version: number; layouts: string }>(
+      this.#db.prepare(
         'SELECT schema_version, layouts FROM sync_schema_meta WHERE id=1',
-      )
-      .first<{ schema_version: number; layouts: string }>();
-    if (marker !== null && marker.schema_version > schema.version) {
-      throw new Error(
-        `stored schema version ${marker.schema_version} is newer than the configured schema (${schema.version}) — refusing to run an older server against a migrated database`,
-      );
+      ),
+    );
+    let claim = await read<D1MigrationClaim>(
+      this.#db.prepare('SELECT * FROM sync_schema_migration WHERE id=1'),
+    );
+    if (claim === null && marker?.schema_version === schema.version) {
+      this.#tables = schema.tables;
+      this.#schemaVersion = schema.version;
+      return { complete: true, statementsExecuted };
     }
-    if (marker === null || marker.schema_version < schema.version) {
-      await this.migrate();
+    if (marker !== null && marker.schema_version > schema.version) {
+      throw new StorageQueryError('sync.storage.schema_changed');
+    }
+    if (claim === null) {
       const layouts = parseLayouts(marker?.layouts);
-      const retiredTables = retiredTableNames(schema, layouts);
-      const existing = new Map<string, ReadonlySet<string>>();
-      const existingIndexes = new Map<string, ReadonlySet<string>>();
-      for (const table of schema.tables.values()) {
-        const escapedTableName = table.name.replaceAll('"', '""');
-        const { results } = await this.#db
-          .prepare(`PRAGMA table_info("${escapedTableName}")`)
-          .all<{ name: string }>();
-        if (results.length > 0) {
-          existing.set(table.name, new Set(results.map((c) => c.name)));
-          const indexes = await this.#db
-            .prepare(`PRAGMA index_list("${escapedTableName}")`)
-            .all<{ name: string; origin: string }>();
-          existingIndexes.set(
-            table.name,
-            new Set(
-              indexes.results
-                .filter((index) => index.origin === 'c')
-                .map((index) => index.name),
-            ),
-          );
+      for (const table of tables) {
+        const oldLayout = layouts[table.name];
+        if (oldLayout !== undefined) {
+          assertAppendOnlyMigration(table.name, oldLayout, table);
         }
       }
-      for (const statement of schemaDdl(
-        schema,
-        existing,
-        'sqlite',
-        existingIndexes,
-      )) {
-        await this.#db.exec(`${statement.replace(/\s+/g, ' ')};`);
+      const state: D1MigrationState = {
+        phase: 'core',
+        offset: 0,
+        columns: {},
+        indexes: {},
+        rewrites: [],
+        ddl: [],
+        afterPartition: '',
+        afterRowId: '',
+      };
+      // Claim the database before inspecting projection layouts. The marker
+      // comparison prevents a delayed caller from planning against an old schema.
+      try {
+        await batch([
+          this.#db
+            .prepare(`INSERT INTO sync_schema_migration
+          SELECT 2, '', '', '' WHERE EXISTS (SELECT 1 FROM sync_schema_meta
+            WHERE id=1 AND schema_version<>?) OR (?=0 AND EXISTS (SELECT 1 FROM sync_schema_meta WHERE id=1))`)
+            .bind(marker?.schema_version ?? 0, marker === null ? 0 : 1),
+          this.#db
+            .prepare(`INSERT OR IGNORE INTO sync_schema_migration
+          (id, target, source_layouts, state) VALUES (1,?,?,?)`)
+            .bind(target, marker?.layouts ?? '{}', JSON.stringify(state)),
+        ]);
+      } catch (error) {
+        const current = await read<{ schema_version: number }>(
+          this.#db.prepare(
+            'SELECT schema_version FROM sync_schema_meta WHERE id=1',
+          ),
+        );
+        if (current?.schema_version !== marker?.schema_version)
+          return { complete: false, statementsExecuted };
+        throw error;
       }
-      // Migration rewrite: payload re-encode on layout change and/or
-      // projection backfill on flipped-on materialization. D1 has no
-      // interactive transaction — the rewrite runs statement-at-a-time,
-      // which is safe (each rewrite is idempotent and the marker only
-      // advances after all rewrites land; a mid-run crash re-runs them).
-      for (const table of schema.tables.values()) {
-        const oldLayout = layouts[table.name];
-        const plan = rewritePlan(table, oldLayout, existing.get(table.name));
-        if (!plan.migrate && !plan.backfill) continue;
-        await this.#rewriteRows(table, plan.migrate ? oldLayout : undefined);
+      claim = await read<D1MigrationClaim>(
+        this.#db.prepare('SELECT * FROM sync_schema_migration WHERE id=1'),
+      );
+    }
+    if (claim === null || claim.target !== target) {
+      throw new StorageQueryError('sync.storage.schema_migration_conflict');
+    }
+    const sourceLayouts = parseLayouts(claim.source_layouts);
+    let state = JSON.parse(claim.state) as D1MigrationState;
+    // Reserve one statement to distinguish a stale checkpoint from a database
+    // failure. A losing concurrent step returns incomplete without retrying here.
+    const save = async (
+      next: D1MigrationState,
+      statements: D1PreparedStatement[],
+      publish = false,
+    ): Promise<boolean> => {
+      const prior = claim.state;
+      const encoded = JSON.stringify(next);
+      try {
+        await batch([
+          this.#db
+            .prepare(`INSERT INTO sync_schema_migration
+            SELECT 2, '', '', '' WHERE NOT EXISTS (
+              SELECT 1 FROM sync_schema_migration WHERE id=1 AND target=? AND state=?)`)
+            .bind(target, prior),
+          ...statements,
+          publish
+            ? this.#db.prepare('DELETE FROM sync_schema_migration WHERE id=1')
+            : this.#db
+                .prepare('UPDATE sync_schema_migration SET state=? WHERE id=1')
+                .bind(encoded),
+        ]);
+      } catch (error) {
+        const current = await read<D1MigrationClaim>(
+          this.#db.prepare('SELECT * FROM sync_schema_migration WHERE id=1'),
+        );
+        if (
+          current === null ||
+          (current.target === target && current.state !== prior)
+        )
+          return false;
+        throw error;
       }
-      // Retire tables only after the additive DDL and rewrites succeed. D1
-      // cannot wrap the whole bump in an interactive transaction, but this
-      // ordering avoids destructive work before every fallible preparatory
-      // step and the batch keeps table + live-scope cleanup atomic.
-      if (retiredTables.length > 0) {
-        await this.#db.batch(
-          retiredTables.flatMap((tableName) => [
-            this.#db
-              .prepare('DELETE FROM sync_row_scopes WHERE tbl=?')
-              .bind(tableName),
-            this.#db
-              .prepare('DELETE FROM sync_blob_refs WHERE tbl=?')
-              .bind(tableName),
-            this.#db.prepare(dropTableDdl(tableName)),
+      claim.state = encoded;
+      state = next;
+      return true;
+    };
+    while (maxStatements - statementsExecuted >= 4) {
+      const remaining = maxStatements - statementsExecuted - 1;
+      if (state.phase === 'core') {
+        const ddl = sqliteDdlStatements();
+        const count = Math.min(ddl.length - state.offset, remaining - 2);
+        if (count > 0) {
+          const statements = ddl
+            .slice(state.offset, state.offset + count)
+            .map((sql) => this.#db.prepare(sql));
+          if (
+            !(await save(
+              { ...state, offset: state.offset + count },
+              statements,
+            ))
+          )
+            break;
+          continue;
+        }
+        if (remaining < 4) break;
+        statementsExecuted++;
+        const columns = await this.#db
+          .prepare('PRAGMA table_info("sync_clients")')
+          .all<{ name: string }>();
+        const needsWireVersion = !columns.results.some(
+          (column) => column.name === 'wire_version',
+        );
+        if (
+          !(await save(
+            { ...state, phase: 'prepare', offset: 0 },
+            needsWireVersion
+              ? [
+                  this.#db.prepare(
+                    'ALTER TABLE sync_clients ADD COLUMN wire_version INTEGER NOT NULL DEFAULT 1',
+                  ),
+                ]
+              : [],
+          ))
+        )
+          break;
+      } else if (state.phase === 'prepare') {
+        const table = tables[state.offset];
+        if (table !== undefined) {
+          if (remaining < 4) break;
+          statementsExecuted += 2;
+          const columns = await this.#db
+            .prepare(`PRAGMA table_info(${quoteIdent(table.name)})`)
+            .all<{ name: string }>();
+          const indexes = await this.#db
+            .prepare(`PRAGMA index_list(${quoteIdent(table.name)})`)
+            .all<{ name: string; origin: string }>();
+          // Validate the old codec before any application DDL or row rewrite.
+          rewritePlan(
+            table,
+            sourceLayouts[table.name],
+            columns.results.length > 0
+              ? new Set(columns.results.map((column) => column.name))
+              : undefined,
+          );
+          if (
+            !(await save(
+              {
+                ...state,
+                offset: state.offset + 1,
+                columns: {
+                  ...state.columns,
+                  ...(columns.results.length > 0
+                    ? {
+                        [table.name]: columns.results.map(
+                          (column) => column.name,
+                        ),
+                      }
+                    : {}),
+                },
+                indexes: {
+                  ...state.indexes,
+                  [table.name]: indexes.results
+                    .filter((index) => index.origin === 'c')
+                    .map((index) => index.name),
+                },
+              },
+              [],
+            ))
+          )
+            break;
+          continue;
+        }
+        const columns = new Map(
+          Object.entries(state.columns).map(([name, names]) => [
+            name,
+            new Set(names),
           ]),
         );
-      }
-      await this.#db
-        .prepare(
-          'INSERT INTO sync_schema_meta(id, schema_version, layouts) VALUES (1, ?, ?) ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, layouts=excluded.layouts',
+        const indexes = new Map(
+          Object.entries(state.indexes).map(([name, names]) => [
+            name,
+            new Set(names),
+          ]),
+        );
+        const rewrites = tables.flatMap((table) => {
+          const plan = rewritePlan(
+            table,
+            sourceLayouts[table.name],
+            columns.get(table.name),
+          );
+          return plan.migrate || plan.backfill
+            ? [
+                {
+                  table: table.name,
+                  ...(plan.migrate
+                    ? { oldLayout: sourceLayouts[table.name] }
+                    : {}),
+                },
+              ]
+            : [];
+        });
+        const ddl = [
+          ...retiredTableNames(schema, sourceLayouts).flatMap((name) => [
+            `DELETE FROM sync_row_scopes WHERE tbl='${name.replaceAll("'", "''")}'`,
+            `DELETE FROM sync_blob_refs WHERE tbl='${name.replaceAll("'", "''")}'`,
+            dropTableDdl(name),
+          ]),
+          ...schemaDdl(schema, columns, 'sqlite', indexes),
+        ];
+        if (
+          !(await save(
+            {
+              ...state,
+              phase: 'ddl',
+              offset: 0,
+              ddl,
+              rewrites,
+              columns: {},
+              indexes: {},
+            },
+            [],
+          ))
         )
-        .bind(schema.version, layoutsOf(schema))
-        .run();
+          break;
+      } else if (state.phase === 'ddl') {
+        const count = Math.min(state.ddl.length - state.offset, remaining - 2);
+        if (count === 0) {
+          if (
+            !(await save(
+              { ...state, phase: 'rewrite', offset: 0, ddl: [] },
+              [],
+            ))
+          )
+            break;
+        } else if (
+          !(await save(
+            { ...state, offset: state.offset + count },
+            state.ddl
+              .slice(state.offset, state.offset + count)
+              .map((sql) => this.#db.prepare(sql)),
+          ))
+        )
+          break;
+      } else {
+        const plan = state.rewrites[state.offset];
+        if (plan === undefined) {
+          if (
+            !(await save(
+              state,
+              [
+                this.#db
+                  .prepare(`INSERT INTO sync_schema_meta(id, schema_version, layouts) VALUES (1,?,?)
+            ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, layouts=excluded.layouts`)
+                  .bind(schema.version, layoutsOf(schema)),
+              ],
+              true,
+            ))
+          )
+            break;
+          this.#tables = schema.tables;
+          this.#schemaVersion = schema.version;
+          return { complete: true, statementsExecuted };
+        }
+        const table = schema.tables.get(plan.table);
+        if (table === undefined)
+          throw new StorageQueryError('sync.storage.schema_migration_conflict');
+        if (remaining < 4) break;
+        const limit = Math.min(32, remaining - 3);
+        statementsExecuted++;
+        const { results } = await this.#db
+          .prepare(`SELECT * FROM (${selectRowsForRewriteSql(table, 'sqlite')})
+            WHERE EXISTS (SELECT 1 FROM sync_schema_migration WHERE id=1 AND target=? AND state=?)`)
+          .bind(
+            state.afterPartition,
+            state.afterRowId,
+            limit,
+            target,
+            claim.state,
+          )
+          .all<{ partition: string; row_id: string; payload: unknown }>();
+        const statements = results.map((row) => {
+          const bytes = asUint8Array(row.payload);
+          const payload =
+            plan.oldLayout !== undefined
+              ? migratePayload(plan.oldLayout, table, bytes)
+              : bytes;
+          return this.#db
+            .prepare(rewriteRowSql(table, 'sqlite'))
+            .bind(
+              ...rewriteValues(
+                table,
+                row.partition,
+                row.row_id,
+                payload,
+                'sqlite',
+              ),
+            );
+        });
+        const last = results.at(-1);
+        const done = results.length < limit;
+        if (
+          !(await save(
+            {
+              ...state,
+              offset: state.offset + (done ? 1 : 0),
+              afterPartition: done ? '' : last!.partition,
+              afterRowId: done ? '' : last!.row_id,
+            },
+            statements,
+          ))
+        )
+          break;
+      }
     }
-    this.#tables = schema.tables;
-    this.#schemaVersion = schema.version;
+    return { complete: false, statementsExecuted };
+  }
+
+  /** Every protected read or write shares a transaction with its schema check. */
+  #schemaDatabase(): Pick<D1Database, 'prepare' | 'batch'> {
+    if (this.#schemaVersion === undefined)
+      throw new StorageQueryError('sync.storage.schema_changed');
+    const db = this.#db;
+    const version = this.#schemaVersion;
+    const sources = new WeakMap<D1PreparedStatement, D1PreparedStatement>();
+    const execute = async (
+      statements: D1PreparedStatement[],
+    ): Promise<unknown[]> => {
+      try {
+        const results = await db.batch([
+          db
+            .prepare(`INSERT INTO sync_schema_migration SELECT 2, '', '', ''
+            WHERE EXISTS (SELECT 1 FROM sync_schema_migration WHERE id=1)
+              OR NOT EXISTS (SELECT 1 FROM sync_schema_meta WHERE id=1 AND schema_version=?)`)
+            .bind(version),
+          ...statements,
+        ]);
+        return results.slice(1);
+      } catch (error) {
+        const migration = await db
+          .prepare('SELECT id FROM sync_schema_migration WHERE id=1')
+          .first();
+        if (migration !== null)
+          throw new StorageQueryError('sync.storage.schema_migration_pending');
+        const marker = await db
+          .prepare('SELECT schema_version FROM sync_schema_meta WHERE id=1')
+          .first<{ schema_version: number }>();
+        if (marker?.schema_version !== version)
+          throw new StorageQueryError('sync.storage.schema_changed');
+        throw error;
+      }
+    };
+    const prepare = (
+      sql: string,
+      params: unknown[] = [],
+    ): D1PreparedStatement => {
+      const source = db.prepare(sql).bind(...params);
+      const all = async <T>(): Promise<{ results: T[] }> => {
+        const result = (await execute([source]))[0];
+        if (
+          typeof result !== 'object' ||
+          result === null ||
+          !('results' in result) ||
+          !Array.isArray(result.results)
+        ) {
+          throw new Error('D1 query returned an invalid batch result');
+        }
+        return { results: result.results as T[] };
+      };
+      const statement: D1PreparedStatement = {
+        bind: (...values) => prepare(sql, values),
+        all,
+        first: async <T>() => (await all<T>()).results[0] ?? null,
+        run: async () => (await execute([source]))[0],
+      };
+      sources.set(statement, source);
+      return statement;
+    };
+    return {
+      prepare,
+      batch: (statements) =>
+        execute(
+          statements.map((statement) => {
+            const source = sources.get(statement);
+            if (source === undefined)
+              throw new Error('D1 batch contains a foreign statement');
+            return source;
+          }),
+        ),
+    };
   }
 
   async touchPartition(
@@ -963,53 +1361,18 @@ export class D1ServerStorage implements ServerStorage {
     }));
   }
 
-  /** Keyset-paged migration rewrite (see the sqlite storage's counterpart). */
-  async #rewriteRows(
-    table: CompiledTable,
-    oldLayout: readonly StoredColumnLayout[] | undefined,
-  ): Promise<void> {
-    const select = selectRowsForRewriteSql(table, 'sqlite');
-    const update = rewriteRowSql(table, 'sqlite');
-    const BATCH = 500;
-    let afterPartition = '';
-    let afterRowId = '';
-    for (;;) {
-      const { results } = await this.#db
-        .prepare(select)
-        .bind(afterPartition, afterRowId, BATCH)
-        .all<{ partition: string; row_id: string; payload: unknown }>();
-      if (results.length === 0) break;
-      const statements = results.map((row) => {
-        const bytes = asUint8Array(row.payload);
-        const payload =
-          oldLayout !== undefined
-            ? migratePayload(oldLayout, table, bytes)
-            : bytes;
-        return this.#db
-          .prepare(update)
-          .bind(
-            ...rewriteValues(
-              table,
-              row.partition,
-              row.row_id,
-              payload,
-              'sqlite',
-            ),
-          );
-      });
-      await this.#db.batch(statements);
-      const last = results[results.length - 1];
-      if (last === undefined || results.length < BATCH) break;
-      afterPartition = last.partition;
-      afterRowId = last.row_id;
-    }
-  }
-
   async begin(partition: string): Promise<StorageTransaction> {
+    const tables = this.#tables;
+    const db = this.#schemaDatabase();
     return new D1Transaction(
-      this.#db,
+      db,
       partition,
-      (name) => this.table(name),
+      (name) => {
+        const table = tables?.get(name);
+        if (table === undefined)
+          throw new StorageQueryError('sync.storage.schema_changed');
+        return table;
+      },
       this.#pushApplySerialized,
     );
   }
@@ -1026,6 +1389,7 @@ export class D1ServerStorage implements ServerStorage {
     partition: string,
     query: AuthoritativeQueryRequest,
   ): Promise<AuthoritativeQueryResult> {
+    const db = this.#schemaDatabase();
     if (this.#tables === undefined) {
       throw new Error(
         'ensureSchema(schema) must run before registered queries',
@@ -1040,9 +1404,9 @@ export class D1ServerStorage implements ServerStorage {
       ),
       partition,
     );
-    const results = await this.#db.batch([
-      this.#db.prepare(prepared.sql).bind(...prepared.params),
-      this.#db
+    const results = await db.batch([
+      db.prepare(prepared.sql).bind(...prepared.params),
+      db
         .prepare('SELECT max_commit_seq FROM sync_partitions WHERE partition=?')
         .bind(partition),
     ]);
@@ -1188,7 +1552,8 @@ export class D1ServerStorage implements ServerStorage {
     table: string,
     rowId: string,
   ): Promise<StoredRow | undefined> {
-    const record = await this.#db
+    const db = this.#schemaDatabase();
+    const record = await db
       .prepare(selectRowSql(this.table(table), 'sqlite'))
       .bind(partition, rowId)
       .first<SqliteRowRecord>();
@@ -1200,7 +1565,8 @@ export class D1ServerStorage implements ServerStorage {
     clientId: string,
     clientCommitId: string,
   ): Promise<StoredPushResult | undefined> {
-    const record = await this.#db
+    const db = this.#schemaDatabase();
+    const record = await db
       .prepare(
         'SELECT result FROM sync_push_results WHERE partition=? AND client_id=? AND client_commit_id=?',
       )
@@ -1431,6 +1797,7 @@ export class D1ServerStorage implements ServerStorage {
     partition: string,
     query: CommitWindowQuery,
   ): Promise<StoredCommit[]> {
+    const db = this.#schemaDatabase();
     const variables = Object.keys(query.scopeFilter).sort();
     const firstVariable = variables[0];
     if (firstVariable === undefined) return [];
@@ -1446,7 +1813,7 @@ export class D1ServerStorage implements ServerStorage {
     let afterSeq = query.afterSeq;
     const batchSize = Math.max(64, query.limitChanges);
     while (deliveredChanges < query.limitChanges) {
-      const { results: records } = await this.#db
+      const { results: records } = await db
         .prepare(sql)
         .bind(
           partition,
@@ -1476,6 +1843,7 @@ export class D1ServerStorage implements ServerStorage {
   }
 
   async scanRows(partition: string, query: RowScanQuery): Promise<StoredRow[]> {
+    const db = this.#schemaDatabase();
     const firstVariable = assertScopeIndexedScan(query);
     const firstValues = query.scopeFilter[firstVariable] ?? [];
     if (firstValues.length === 0) return [];
@@ -1491,7 +1859,7 @@ export class D1ServerStorage implements ServerStorage {
     let afterRowId = query.afterRowId ?? '';
     const batchSize = Math.max(64, query.limit);
     while (rows.length < query.limit) {
-      const { results: records } = await this.#db
+      const { results: records } = await db
         .prepare(sql)
         .bind(
           partition,
@@ -1523,6 +1891,7 @@ export class D1ServerStorage implements ServerStorage {
     partition: string,
     query: IndexRowScanQuery,
   ): Promise<StoredRow[]> {
+    const db = this.#schemaDatabase();
     const table = this.table(query.table);
     const index = resolveIndexRowScan(table, query);
     const statement = indexRowPageStatement(
@@ -1534,7 +1903,7 @@ export class D1ServerStorage implements ServerStorage {
       query.limit,
       'sqlite',
     );
-    const { results } = await this.#db
+    const { results } = await db
       .prepare(statement.sql)
       .bind(...statement.params)
       .all<SqliteRowRecord>();
@@ -1642,7 +2011,8 @@ export class D1ServerStorage implements ServerStorage {
       readonly scopes: Record<string, string>;
     }[]
   > {
-    const { results: refs } = await this.#db
+    const db = this.#schemaDatabase();
+    const { results: refs } = await db
       .prepare(
         'SELECT tbl, row_id FROM sync_blob_refs WHERE partition=? AND blob_id=?',
       )
@@ -1656,7 +2026,7 @@ export class D1ServerStorage implements ServerStorage {
     for (const ref of refs) {
       const compiled = this.#tables?.get(ref.tbl);
       if (compiled === undefined) continue; // table no longer in the schema
-      const row = await this.#db
+      const row = await db
         .prepare(selectRowScopesSql(compiled, 'sqlite'))
         .bind(partition, ref.row_id)
         .first<{ scopes: string }>();
@@ -1807,7 +2177,8 @@ export class D1ServerStorage implements ServerStorage {
   ): Promise<
     { serverVersion: number; scopes: Record<string, string> } | undefined
   > {
-    const record = await this.#db
+    const db = this.#schemaDatabase();
+    const record = await db
       .prepare(selectRowScopesSql(this.table(table), 'sqlite'))
       .bind(partition, rowId)
       .first<{ server_version: number; scopes: string }>();

--- a/packages/server/src/storage-errors.ts
+++ b/packages/server/src/storage-errors.ts
@@ -15,6 +15,10 @@ export class StorageConstraintError extends Error {
 
 /** Stable, privacy-safe failures for trusted server storage queries. */
 export type StorageQueryErrorCode =
+  | 'sync.storage.schema_migration_pending'
+  | 'sync.storage.schema_migration_conflict'
+  | 'sync.storage.schema_changed'
+  | 'sync.storage.invalid_migration_budget'
   | 'sync.storage.scan_requires_scope'
   | 'sync.storage.index_not_found'
   | 'sync.storage.index_not_materialized'
@@ -26,6 +30,14 @@ export type StorageQueryErrorCode =
 
 const STORAGE_QUERY_MESSAGES: Readonly<Record<StorageQueryErrorCode, string>> =
   {
+    'sync.storage.schema_migration_pending':
+      'schema migration requires another invocation',
+    'sync.storage.schema_migration_conflict':
+      'another schema migration target is already pending',
+    'sync.storage.schema_changed':
+      'storage schema is not ready for this operation',
+    'sync.storage.invalid_migration_budget':
+      'migration statement budget must be an integer from 10 through 1000',
     'sync.storage.prune_epoch_mismatch':
       'partition log epoch changed; recompute retention inputs',
     'sync.storage.partition_unregistered':

--- a/packages/server/test/d1-double.ts
+++ b/packages/server/test/d1-double.ts
@@ -50,9 +50,11 @@ function normalizeRow<T>(row: unknown): T {
 class DoublePreparedStatement implements D1PreparedStatement {
   readonly #db: Database;
   readonly #sql: string;
+  readonly #count: () => void;
   #params: unknown[] = [];
 
-  constructor(db: Database, sql: string) {
+  constructor(db: Database, sql: string, count: () => void) {
+    this.#count = count;
     this.#db = db;
     this.#sql = sql;
   }
@@ -63,38 +65,36 @@ class DoublePreparedStatement implements D1PreparedStatement {
   }
 
   async first<T = Record<string, unknown>>(): Promise<T | null> {
+    this.#count();
     const row = this.#db.query(this.#sql).get(...(this.#params as never[]));
     return row === null || row === undefined ? null : normalizeRow<T>(row);
   }
 
   async all<T = Record<string, unknown>>(): Promise<{ results: T[] }> {
+    this.#count();
     const rows = this.#db.query(this.#sql).all(...(this.#params as never[]));
     return { results: rows.map((row) => normalizeRow<T>(row)) };
   }
 
   async run(): Promise<unknown> {
+    this.#count();
     this.#db.query(this.#sql).run(...(this.#params as never[]));
     return {};
-  }
-
-  /** Internal: apply this statement inside an already-open transaction. */
-  _apply(): void {
-    this.#db.query(this.#sql).run(...(this.#params as never[]));
   }
 
   _batchResult(before?: (sql: string) => void): unknown {
+    this.#count();
     before?.(this.#sql);
-    if (/^\s*(?:SELECT|WITH)\b/i.test(this.#sql)) {
-      const rows = this.#db.query(this.#sql).all(...(this.#params as never[]));
-      return { results: rows.map((row) => normalizeRow(row)) };
-    }
-    this._apply();
-    return {};
+    const rows = this.#db.query(this.#sql).all(...(this.#params as never[]));
+    return { results: rows.map((row) => normalizeRow(row)) };
   }
 }
 
 export class D1DatabaseDouble implements D1Database {
   readonly #db: Database;
+  statementsExecuted = 0;
+  statementLimit = Number.POSITIVE_INFINITY;
+  afterBatch: (() => void) | undefined;
   beforeBatchStatement: ((sql: string) => void) | undefined;
 
   constructor(db: Database = new Database(':memory:')) {
@@ -102,29 +102,38 @@ export class D1DatabaseDouble implements D1Database {
   }
 
   prepare(query: string): D1PreparedStatement {
-    return new DoublePreparedStatement(this.#db, query);
+    return new DoublePreparedStatement(this.#db, query, () => {
+      this.statementsExecuted++;
+      if (this.statementsExecuted > this.statementLimit)
+        throw new Error('D1 invocation query limit exceeded');
+    });
   }
 
   async batch(statements: D1PreparedStatement[]): Promise<unknown[]> {
     // Real D1 wraps a batch in one implicit transaction; reproduce the
     // all-or-nothing semantics with BEGIN … COMMIT/ROLLBACK.
     this.#db.exec('BEGIN IMMEDIATE');
+    let results: unknown[];
     try {
-      const results = statements.map((statement) =>
+      results = statements.map((statement) =>
         (statement as DoublePreparedStatement)._batchResult(
           this.beforeBatchStatement,
         ),
       );
       this.beforeBatchStatement?.('COMMIT');
       this.#db.exec('COMMIT');
-      return results;
     } catch (error) {
       this.#db.exec('ROLLBACK');
       throw error;
     }
+    this.afterBatch?.();
+    return results;
   }
 
   async exec(query: string): Promise<unknown> {
+    this.statementsExecuted++;
+    if (this.statementsExecuted > this.statementLimit)
+      throw new Error('D1 invocation query limit exceeded');
     this.#db.exec(query);
     return {};
   }

--- a/packages/server/test/d1-migration.test.ts
+++ b/packages/server/test/d1-migration.test.ts
@@ -1,0 +1,455 @@
+import { Database } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { decodeRow, encodeRow } from '@syncular/core';
+import {
+  compileSchema,
+  D1ServerStorage,
+  type CompiledSchema,
+  type ServerSchema,
+} from '@syncular/server';
+import { D1DatabaseDouble } from './d1-double';
+
+const schema: ServerSchema = {
+  version: 1,
+  tables: [
+    {
+      name: 'tasks',
+      primaryKey: 'id',
+      scopes: ['row:{id}'],
+      columns: [
+        { name: 'id', type: 'string', nullable: false },
+        { name: 'title', type: 'string', nullable: false },
+      ],
+    },
+  ],
+};
+const next = compileSchema({
+  version: 2,
+  tables: [
+    {
+      ...schema.tables[0]!,
+      columns: [
+        ...schema.tables[0]!.columns,
+        { name: 'completed', type: 'boolean', nullable: true },
+      ],
+    },
+  ],
+});
+
+async function fixture(rows = 70) {
+  const raw = new Database(':memory:');
+  const db = new D1DatabaseDouble(raw);
+  const storage = new D1ServerStorage(db);
+  await storage.ensureSchema(compileSchema(schema));
+  for (let i = 0; i < rows; i++) {
+    const id = `t${String(i).padStart(4, '0')}`;
+    const tx = await storage.begin('p1');
+    await tx.upsertRow('tasks', {
+      rowId: id,
+      serverVersion: 1,
+      scopes: { id },
+      payload: encodeRow(schema.tables[0]!.columns, [id, 'original']),
+    });
+    await tx.commit();
+  }
+  return { raw, db, storage };
+}
+
+// Each iteration represents a new Worker invocation with a fresh storage instance.
+async function finish(
+  db: D1DatabaseDouble,
+  target: CompiledSchema,
+  budget = 50,
+) {
+  for (let invocation = 0; invocation < 1000; invocation++) {
+    db.statementsExecuted = 0;
+    db.statementLimit = budget;
+    const storage = new D1ServerStorage(db);
+    const result = await storage.migrateSchema(target, {
+      maxStatements: budget,
+    });
+    expect(result.statementsExecuted).toBe(db.statementsExecuted);
+    expect(db.statementsExecuted).toBeLessThanOrEqual(budget);
+    db.statementLimit = Infinity;
+    if (result.complete) return storage;
+  }
+  throw new Error('migration made no progress');
+}
+
+describe('D1 migration invocations', () => {
+  test('ensureSchema stops before the Free query limit and reports unfinished work', async () => {
+    const { db, storage, raw } = await fixture();
+    db.statementsExecuted = 0;
+    db.statementLimit = 50;
+    await expect(storage.ensureSchema(next)).rejects.toMatchObject({
+      code: 'sync.storage.schema_migration_pending',
+    });
+    expect(db.statementsExecuted).toBeLessThanOrEqual(50);
+    db.statementLimit = Infinity;
+    const ready = await finish(db, next);
+    const row = await ready.getRow('p1', 'tasks', 't0069');
+    expect(decodeRow(next.tables.get('tasks')!.columns, row!.payload)).toEqual([
+      't0069',
+      'original',
+      null,
+    ]);
+    raw.close();
+  });
+
+  for (const budget of [10, 20, 50, 1000]) {
+    test(`resumes fresh storage instances within a ${budget}-statement budget`, async () => {
+      const { db, raw } = await fixture();
+      await finish(db, next, budget);
+      expect(
+        raw.query('SELECT schema_version FROM sync_schema_meta').get(),
+      ).toEqual({ schema_version: 2 });
+      expect(raw.query('SELECT * FROM sync_schema_migration').all()).toEqual(
+        [],
+      );
+      for (const row of raw
+        .query<{ _sync_payload: Uint8Array }, []>(
+          'SELECT _sync_payload FROM tasks',
+        )
+        .all()) {
+        expect(
+          decodeRow(next.tables.get('tasks')!.columns, row._sync_payload).at(
+            -1,
+          ),
+        ).toBeNull();
+      }
+      raw.close();
+    });
+  }
+
+  test('a large rewrite stops before the Paid query limit', async () => {
+    const { db, raw } = await fixture(1100);
+    db.statementsExecuted = 0;
+    db.statementLimit = 1000;
+    const result = await new D1ServerStorage(db).migrateSchema(next, {
+      maxStatements: 1000,
+    });
+    expect(result.complete).toBe(false);
+    expect(result.statementsExecuted).toBe(db.statementsExecuted);
+    expect(db.statementsExecuted).toBeLessThanOrEqual(1000);
+    const ready = await finish(db, next, 1000);
+    const row = await ready.getRow('p1', 'tasks', 't1099');
+    expect(decodeRow(next.tables.get('tasks')!.columns, row!.payload)).toEqual([
+      't1099',
+      'original',
+      null,
+    ]);
+    raw.close();
+  });
+
+  test('materialization backfill resumes across tables and partitions', async () => {
+    const raw = new Database(':memory:');
+    const db = new D1DatabaseDouble(raw);
+    const source = {
+      version: 1,
+      tables: ['tasks', 'notes'].map((name) => ({
+        ...schema.tables[0]!,
+        name,
+        materialize: false,
+      })),
+    };
+    const initial = await finish(db, compileSchema(source), 10);
+    for (const partition of ['p1', 'p2']) {
+      for (const table of source.tables) {
+        for (const rowId of ['a', 'b', 'c']) {
+          const tx = await initial.begin(partition);
+          await tx.upsertRow(table.name, {
+            rowId,
+            serverVersion: 1,
+            scopes: { id: rowId },
+            payload: encodeRow(table.columns, [rowId, partition]),
+          });
+          await tx.commit();
+        }
+      }
+    }
+    const target = compileSchema({
+      version: 2,
+      tables: source.tables.map((table) => ({ ...table, materialize: true })),
+    });
+    const ready = await finish(db, target, 10);
+    for (const table of source.tables) {
+      expect(
+        raw
+          .query(
+            `SELECT id, title FROM "${table.name}" ORDER BY _sync_partition, id`,
+          )
+          .all(),
+      ).toEqual(
+        ['p1', 'p2'].flatMap((title) =>
+          ['a', 'b', 'c'].map((id) => ({ id, title })),
+        ),
+      );
+      for (const partition of ['p1', 'p2']) {
+        expect(
+          (await ready.getRow(partition, table.name, 'c'))?.payload,
+        ).toEqual(encodeRow(table.columns, ['c', partition]));
+      }
+    }
+    raw.close();
+  });
+
+  test('a failed row batch leaves its checkpoint unchanged and can resume', async () => {
+    const { db, raw } = await fixture();
+    let updates = 0;
+    let checkpoint: string | undefined;
+    db.beforeBatchStatement = (sql) => {
+      if (sql.startsWith('UPDATE "tasks"') && ++updates === 40) {
+        checkpoint = raw
+          .query<{ state: string }, []>(
+            'SELECT state FROM sync_schema_migration',
+          )
+          .get()?.state;
+        throw new Error('injected batch failure');
+      }
+    };
+    await expect(finish(db, next)).rejects.toThrow('injected batch failure');
+    expect(updates).toBe(40);
+    expect(
+      raw.query('SELECT schema_version FROM sync_schema_meta').get(),
+    ).toEqual({ schema_version: 1 });
+    const saved = raw
+      .query<{ state: string }, []>('SELECT state FROM sync_schema_migration')
+      .get();
+    expect(checkpoint).toBeDefined();
+    expect(saved?.state).toBe(checkpoint);
+    db.beforeBatchStatement = undefined;
+    await finish(db, next);
+    for (const row of raw
+      .query<{ _sync_payload: Uint8Array }, []>(
+        'SELECT _sync_payload FROM tasks',
+      )
+      .all()) {
+      expect(
+        decodeRow(next.tables.get('tasks')!.columns, row._sync_payload),
+      ).toHaveLength(3);
+    }
+    raw.close();
+  });
+
+  test('a lost reply after a committed rewrite resumes from its saved position', async () => {
+    const { db, raw } = await fixture();
+    let committedRows = false;
+    let lost = false;
+    db.beforeBatchStatement = (sql) => {
+      if (sql.startsWith('UPDATE "tasks"')) committedRows = true;
+    };
+    db.afterBatch = () => {
+      if (committedRows && !lost) {
+        lost = true;
+        throw new Error('lost reply');
+      }
+    };
+    await finish(db, next);
+    expect(lost).toBe(true);
+    expect(
+      raw.query('SELECT schema_version FROM sync_schema_meta').get(),
+    ).toEqual({ schema_version: 2 });
+    raw.close();
+  });
+
+  test('a migration fences cached readers and transactions opened under the old schema', async () => {
+    const { db, storage, raw } = await fixture(1);
+    const tx = await storage.begin('p1');
+    await tx.upsertRow('tasks', {
+      rowId: 'late',
+      serverVersion: 1,
+      scopes: { id: 'late' },
+      payload: encodeRow(schema.tables[0]!.columns, ['late', 'stale']),
+    });
+    expect(
+      (await new D1ServerStorage(db).migrateSchema(next, { maxStatements: 10 }))
+        .complete,
+    ).toBe(false);
+    await expect(
+      storage.ensureSchema(compileSchema(schema)),
+    ).rejects.toMatchObject({ code: 'sync.storage.schema_migration_pending' });
+    await expect(storage.getRow('p1', 'tasks', 't0000')).rejects.toMatchObject({
+      code: 'sync.storage.schema_migration_pending',
+    });
+    await expect(tx.commit()).rejects.toMatchObject({
+      code: 'sync.storage.schema_migration_pending',
+    });
+    const ready = await finish(db, next);
+    await expect(storage.getRow('p1', 'tasks', 't0000')).rejects.toMatchObject({
+      code: 'sync.storage.schema_changed',
+    });
+    await expect(tx.commit()).rejects.toMatchObject({
+      code: 'sync.storage.schema_changed',
+    });
+    expect(await ready.getRow('p1', 'tasks', 'late')).toBeUndefined();
+    await tx.rollback();
+    raw.close();
+  });
+
+  test('competing migration steps converge without rewriting a page twice', async () => {
+    const { db, raw } = await fixture();
+    raw.exec(`CREATE TABLE rewrites (row_id TEXT);
+      CREATE TRIGGER count_rewrites AFTER UPDATE ON tasks BEGIN
+        INSERT INTO rewrites VALUES (NEW._sync_row_id);
+      END`);
+    let complete = false;
+    for (let i = 0; i < 100 && !complete; i++) {
+      const results = await Promise.all([
+        new D1ServerStorage(db).migrateSchema(next),
+        new D1ServerStorage(db).migrateSchema(next),
+      ]);
+      complete = results.some((result) => result.complete);
+    }
+    expect(complete).toBe(true);
+    expect(
+      raw
+        .query(
+          'SELECT COUNT(*) AS count, COUNT(DISTINCT row_id) AS distinct_count FROM rewrites',
+        )
+        .get(),
+    ).toEqual({ count: 70, distinct_count: 70 });
+    for (const row of raw
+      .query<{ _sync_payload: Uint8Array }, []>(
+        'SELECT _sync_payload FROM tasks',
+      )
+      .all()) {
+      expect(
+        decodeRow(next.tables.get('tasks')!.columns, row._sync_payload),
+      ).toHaveLength(3);
+    }
+    raw.close();
+  });
+
+  test('a delayed claim cannot restart a migration that another request completed', async () => {
+    const { db, raw } = await fixture(0);
+    const captured = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const prepare = db.prepare.bind(db);
+    let held = false;
+    db.prepare = (sql) => {
+      const statement = prepare(sql);
+      if (
+        sql ===
+        'SELECT schema_version, layouts FROM sync_schema_meta WHERE id=1'
+      ) {
+        const first = statement.first.bind(statement);
+        statement.first = async <T>() => {
+          const value = await first<T>();
+          if (!held) {
+            held = true;
+            captured.resolve();
+            await resume.promise;
+          }
+          return value;
+        };
+      }
+      return statement;
+    };
+    const delayed = new D1ServerStorage(db).migrateSchema(next);
+    await captured.promise;
+    await finish(db, next);
+    resume.resolve();
+    expect((await delayed).complete).toBe(false);
+    expect(raw.query('SELECT * FROM sync_schema_migration').all()).toEqual([]);
+    expect((await new D1ServerStorage(db).migrateSchema(next)).complete).toBe(
+      true,
+    );
+    raw.close();
+  });
+
+  test('a delayed row read cannot decode rows another request already migrated', async () => {
+    const { db, raw } = await fixture();
+    await new D1ServerStorage(db).migrateSchema(next);
+    const captured = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const prepare = db.prepare.bind(db);
+    let held = false;
+    db.prepare = (sql) => {
+      const statement = prepare(sql);
+      if (sql.includes('AS partition')) {
+        const all = statement.all.bind(statement);
+        statement.all = async <T>() => {
+          if (!held) {
+            held = true;
+            captured.resolve();
+            await resume.promise;
+          }
+          return all<T>();
+        };
+      }
+      return statement;
+    };
+    const delayed = new D1ServerStorage(db).migrateSchema(next);
+    await captured.promise;
+    await finish(db, next);
+    resume.resolve();
+    expect((await delayed).complete).toBe(false);
+    expect(
+      raw.query('SELECT schema_version FROM sync_schema_meta').get(),
+    ).toEqual({ schema_version: 2 });
+    raw.close();
+  });
+
+  test('a different migration target cannot take over an unfinished rewrite', async () => {
+    const { db, raw } = await fixture(0);
+    await new D1ServerStorage(db).migrateSchema(next, { maxStatements: 10 });
+    const other = compileSchema({ ...schema, version: 3 });
+    await expect(
+      new D1ServerStorage(db).migrateSchema(other),
+    ).rejects.toMatchObject({ code: 'sync.storage.schema_migration_conflict' });
+    await finish(db, next);
+    raw.close();
+  });
+
+  test('setup and retirement of many tables also respect the invocation budget', async () => {
+    const raw = new Database(':memory:');
+    const db = new D1DatabaseDouble(raw);
+    const many = compileSchema({
+      version: 1,
+      tables: Array.from({ length: 20 }, (_, i) => ({
+        ...schema.tables[0]!,
+        name: `table_${i}`,
+        indexes: [{ name: `title_${i}`, columns: ['title'] }],
+      })),
+    });
+    await finish(db, many, 10);
+    await finish(db, next, 10);
+    expect(
+      raw
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'table_%'",
+        )
+        .all(),
+    ).toEqual([]);
+    raw.close();
+  });
+
+  test('an invalid schema fails before claiming the database', async () => {
+    const { db, storage, raw } = await fixture(1);
+    const invalid = compileSchema({
+      version: 2,
+      tables: [
+        { ...schema.tables[0]!, columns: [schema.tables[0]!.columns[0]!] },
+      ],
+    });
+    await expect(
+      new D1ServerStorage(db).migrateSchema(invalid),
+    ).rejects.toThrow('removed columns');
+    expect(raw.query('SELECT * FROM sync_schema_migration').all()).toEqual([]);
+    expect(await storage.getRow('p1', 'tasks', 't0000')).toBeDefined();
+    await finish(db, next);
+    raw.close();
+  });
+
+  test('invalid budgets fail before issuing a query', async () => {
+    const db = new D1DatabaseDouble();
+    for (const maxStatements of [0, 9, 1001, 10.5, Number.NaN, Infinity]) {
+      await expect(
+        new D1ServerStorage(db).migrateSchema(next, { maxStatements }),
+      ).rejects.toMatchObject({
+        code: 'sync.storage.invalid_migration_budget',
+      });
+    }
+    expect(db.statementsExecuted).toBe(0);
+  });
+});

--- a/packages/server/test/relational-rows.test.ts
+++ b/packages/server/test/relational-rows.test.ts
@@ -161,6 +161,13 @@ async function sqliteStorage(): Promise<SqliteServerStorage> {
   return storage;
 }
 
+async function migrateD1(
+  storage: D1ServerStorage,
+  schema: ServerSchema,
+): Promise<void> {
+  while (!(await storage.migrateSchema(compileSchema(schema))).complete) {}
+}
+
 async function upsert(
   storage: SqliteServerStorage | PostgresServerStorage | D1ServerStorage,
   partition: string,
@@ -192,7 +199,8 @@ describe('partition-scoped declared unique indexes', () => {
           storage.db.exec(sql);
         }
       };
-      await storage.ensureSchema(compileSchema(SCHEMA));
+      if (storage instanceof D1ServerStorage) await migrateD1(storage, SCHEMA);
+      else await storage.ensureSchema(compileSchema(SCHEMA));
       await exec('DROP INDEX sync_ix_tasks_by_project_title');
       await exec(
         'CREATE UNIQUE INDEX sync_ix_tasks_by_project_title ON tasks(project_id, title)',
@@ -200,7 +208,9 @@ describe('partition-scoped declared unique indexes', () => {
       await exec('CREATE INDEX operator_title_index ON tasks(title)');
       const row = taskRow('t1', 'p1', 'same-title');
       await upsert(storage, PARTITION, 'tasks', row);
-      await storage.ensureSchema(compileSchema({ ...SCHEMA, version: 2 }));
+      if (storage instanceof D1ServerStorage)
+        await migrateD1(storage, { ...SCHEMA, version: 2 });
+      else await storage.ensureSchema(compileSchema({ ...SCHEMA, version: 2 }));
       await upsert(storage, 'part-2', 'tasks', row);
       expect((await storage.getRow(PARTITION, 'tasks', 't1'))?.payload).toEqual(
         row.payload,
@@ -369,7 +379,7 @@ describe('relational tables (D1)', () => {
   test('a secondary unique collision never replaces the existing server row', async () => {
     const db = new D1DatabaseDouble();
     const storage = new D1ServerStorage(db);
-    await storage.ensureSchema(compileSchema(SCHEMA));
+    await migrateD1(storage, SCHEMA);
     await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'original'));
     await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'updated'));
     await upsert(storage, PARTITION, 'tasks', taskRow('t2', 'p1', 'original'));
@@ -490,11 +500,11 @@ describe('server-side schema migration (the subset)', () => {
   test('D1 preserves existing rows across a nullable column append', async () => {
     const db = new D1DatabaseDouble();
     const storage = new D1ServerStorage(db);
-    await storage.ensureSchema(compileSchema(SCHEMA));
+    await migrateD1(storage, SCHEMA);
     await upsert(storage, PARTITION, 'tasks', taskRow('t1', 'p1', 'v1 row'));
 
     const v2 = nullableAppendSchema();
-    await storage.ensureSchema(compileSchema(v2));
+    await migrateD1(storage, v2);
     const stored = await storage.getRow(PARTITION, 'tasks', 't1');
     expect(decodeRow(v2.tables[0]!.columns, stored!.payload).at(-1)).toBeNull();
     const projected = await db
@@ -548,8 +558,8 @@ describe('server-side schema migration (the subset)', () => {
   test('a version bump replaces declared indexes on D1', async () => {
     const db = new D1DatabaseDouble();
     const storage = new D1ServerStorage(db);
-    await storage.ensureSchema(compileSchema(SCHEMA));
-    await storage.ensureSchema(compileSchema(INDEX_REPLACEMENT_SCHEMA));
+    await migrateD1(storage, SCHEMA);
+    await migrateD1(storage, INDEX_REPLACEMENT_SCHEMA);
 
     const indexes = await db
       .prepare('PRAGMA index_list("tasks")')
@@ -734,7 +744,7 @@ describe('server-side schema migration (the subset)', () => {
   test('D1 retires the relational current-row table idempotently', async () => {
     const db = new D1DatabaseDouble();
     const storage = new D1ServerStorage(db);
-    await storage.ensureSchema(compileSchema(SCHEMA));
+    await migrateD1(storage, SCHEMA);
     const tx = await storage.begin(PARTITION);
     await tx.upsertRow('tasks', taskRow('t1', 'p1', 'retired'));
     await tx.commit();

--- a/packages/server/test/storage.test.ts
+++ b/packages/server/test/storage.test.ts
@@ -41,11 +41,17 @@ runStorageContract('postgres/pglite', async () => {
 // D1 (Cloudflare Workers) against the local bun:sqlite-backed double
 // (test/d1-double.ts documents its fidelity limits). Same contract, so the
 // D1 path is held to the reference behavior key-for-key.
+async function prepareD1(storage: D1ServerStorage): Promise<void> {
+  while (
+    !(await storage.migrateSchema(compileSchema(CONTRACT_SCHEMA))).complete
+  ) {}
+}
+
 runStorageContract('d1/double', async () => {
   const storage = new D1ServerStorage(new D1DatabaseDouble(), {
     pushApplySerialized: true,
   });
-  await storage.migrate();
+  await prepareD1(storage);
   return storage;
 });
 
@@ -112,7 +118,7 @@ test('Postgres migrates legacy client records to wire version 1', async () => {
 
 test('D1 push apply fails closed without external serialization', async () => {
   const storage = new D1ServerStorage(new D1DatabaseDouble());
-  await storage.migrate();
+  await prepareD1(storage);
   const tx = await storage.begin('partition');
   await expect(tx.lockPartitionForPush?.()).rejects.toThrow(
     'requires externally serialized partition writes',
@@ -225,8 +231,7 @@ class ConstraintAtBatchDouble extends D1DatabaseDouble {
 test('D1: a batch-commit constraint attributes the opIndex only when it is unambiguous', async () => {
   const db = new ConstraintAtBatchDouble();
   const storage = new D1ServerStorage(db, { pushApplySerialized: true });
-  await storage.migrate();
-  await storage.ensureSchema(compileSchema(CONTRACT_SCHEMA));
+  await prepareD1(storage);
   const taskRow = (id: string) => ({
     rowId: id,
     serverVersion: 1,
@@ -321,7 +326,9 @@ for (const backend of ['SQLite', 'Postgres', 'D1'] as const) {
       storage = new PostgresServerStorage(executor);
     } else {
       d1.beforeBatchStatement = before;
-      storage = new D1ServerStorage(d1, { pushApplySerialized: true });
+      const adapter = new D1ServerStorage(d1, { pushApplySerialized: true });
+      await prepareD1(adapter);
+      storage = adapter;
     }
     try {
       await storage.ensureSchema(compileSchema(CONTRACT_SCHEMA));


### PR DESCRIPTION
D1 processed every migration batch in one Worker request and saved no progress. A 70-row regression case exceeds the simulated Free-plan query limit. `migrateSchema` now limits statements per invocation and saves progress with each batch so another request can resume. The storage rejects row access during migration and prevents competing requests from applying the same batch twice.

Added 17 migration regression tests and the maintenance setup documentation. The full repository checks, docs/demo builds, and a local workerd/D1 check pass. Deployed D1 quotas have not been tested. Each protected read or commit adds one guard statement; individual DDL statements still need to fit D1's time limit.

Fixes #55.
